### PR TITLE
[Feature] Add a canonical side-effect-free config diff and dry-run Router API

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,7 +75,7 @@ repos:
         entry: .venv-agent/bin/yamllint --config-file=tools/linter/yaml/.yamllint
         language: system
         files: \.(yaml|yml)$
-        exclude: ^(node_modules/)
+        exclude: ^(node_modules/|src/semantic-router/pkg/config/testdata/dryrun/parse-error\.yaml$)
 
   # JavaScript and TypeScript specific hooks
   - repo: local

--- a/e2e/pkg/testmatrix/testcases.go
+++ b/e2e/pkg/testmatrix/testcases.go
@@ -14,6 +14,7 @@ var BaselineRouterContract = []string{
 	"anthropic-messages-streaming",
 	"apiserver-runtime-config-endpoints",
 	"apiserver-classification-endpoints",
+	"apiserver-config-validate",
 	"llm-classifier-distribution-routing",
 	"sequence-classifier-routing",
 	"chat-completions-stress-request",

--- a/e2e/testcases/apiserver_config_validate.go
+++ b/e2e/testcases/apiserver_config_validate.go
@@ -16,7 +16,7 @@ import (
 
 func init() {
 	pkgtestcases.Register("apiserver-config-validate", pkgtestcases.TestCase{
-		Description: "Verify POST /config/router/validate returns the v1 diagnostic contract without mutating the live config (issue #3477)",
+		Description: "Verify POST /api/v1/config/validate returns the v1 diagnostic contract without mutating the live config (issue #3477)",
 		Tags:        []string{"apiserver", "config", "api", "validate"},
 		Fn:          testAPIServerConfigValidate,
 	})
@@ -44,12 +44,12 @@ func testAPIServerConfigValidate(
 	defer session.Close()
 
 	httpClient := session.HTTPClient(30 * time.Second)
-	hashBefore, err := fetchConfigHash(ctx, httpClient, session.URL("/config/hash"))
+	hashBefore, err := fetchConfigHash(ctx, httpClient, session.URL("/api/v1/config/hash"))
 	if err != nil {
 		return err
 	}
 
-	validURL := session.URL("/config/router/validate")
+	validURL := session.URL("/api/v1/config/validate")
 	validBody, err := postRouterConfigValidate(ctx, httpClient, validURL, map[string]any{
 		"yaml": validateE2EValidYAML,
 	})
@@ -70,7 +70,7 @@ func testAPIServerConfigValidate(
 		return err
 	}
 
-	hashAfter, err := fetchConfigHash(ctx, httpClient, session.URL("/config/hash"))
+	hashAfter, err := fetchConfigHash(ctx, httpClient, session.URL("/api/v1/config/hash"))
 	if err != nil {
 		return err
 	}
@@ -133,7 +133,7 @@ func postRouterConfigValidate(
 		return nil, fmt.Errorf("read validate response: %w", err)
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("expected /config/router/validate status 200, got %d: %s", resp.StatusCode, string(body))
+		return nil, fmt.Errorf("expected /api/v1/config/validate status 200, got %d: %s", resp.StatusCode, string(body))
 	}
 	var decoded routerConfigValidateResponse
 	if err := json.Unmarshal(body, &decoded); err != nil {
@@ -148,16 +148,16 @@ func fetchConfigHash(ctx context.Context, httpClient *http.Client, url string) (
 		return "", err
 	}
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("expected /config/hash status 200, got %d: %s", resp.StatusCode, string(resp.Body))
+		return "", fmt.Errorf("expected /api/v1/config/hash status 200, got %d: %s", resp.StatusCode, string(resp.Body))
 	}
 	var decoded struct {
-		Hash string `json:"hash"`
+		Hash string `json:"source_config_hash"`
 	}
 	if err := json.Unmarshal(resp.Body, &decoded); err != nil {
-		return "", fmt.Errorf("decode /config/hash: %w", err)
+		return "", fmt.Errorf("decode /api/v1/config/hash: %w", err)
 	}
 	if decoded.Hash == "" {
-		return "", fmt.Errorf("expected /config/hash to include a source hash")
+		return "", fmt.Errorf("expected /api/v1/config/hash to include a source hash")
 	}
 	return decoded.Hash, nil
 }
@@ -166,11 +166,12 @@ const validateE2EValidYAML = `version: v0.3
 listeners: []
 providers:
   defaults:
-    default_model: m1
+    model: m1
   models:
     - name: m1
       backend_refs:
         - endpoint: 127.0.0.1:8000
+          provider: vllm
 routing:
   modelCards:
     - name: m1
@@ -187,11 +188,12 @@ const validateE2EInvalidYAML = `version: v0.3
 listeners: []
 providers:
   defaults:
-    default_model: m1
+    model: m1
   models:
     - name: m1
       backend_refs:
         - endpoint: 127.0.0.1:8000
+          provider: vllm
 routing:
   modelCards:
     - name: m1

--- a/e2e/testcases/apiserver_config_validate.go
+++ b/e2e/testcases/apiserver_config_validate.go
@@ -9,9 +9,10 @@ import (
 	"net/http"
 	"time"
 
+	"k8s.io/client-go/kubernetes"
+
 	"github.com/vllm-project/semantic-router/e2e/pkg/fixtures"
 	pkgtestcases "github.com/vllm-project/semantic-router/e2e/pkg/testcases"
-	"k8s.io/client-go/kubernetes"
 )
 
 func init() {
@@ -56,7 +57,8 @@ func testAPIServerConfigValidate(
 	if err != nil {
 		return err
 	}
-	if err := assertValidValidateContract(validBody); err != nil {
+	err = assertValidValidateContract(validBody)
+	if err != nil {
 		return err
 	}
 
@@ -66,7 +68,8 @@ func testAPIServerConfigValidate(
 	if err != nil {
 		return err
 	}
-	if err := assertInvalidValidateContract(invalidBody); err != nil {
+	err = assertInvalidValidateContract(invalidBody)
+	if err != nil {
 		return err
 	}
 

--- a/e2e/testcases/apiserver_config_validate.go
+++ b/e2e/testcases/apiserver_config_validate.go
@@ -1,0 +1,214 @@
+package testcases
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/vllm-project/semantic-router/e2e/pkg/fixtures"
+	pkgtestcases "github.com/vllm-project/semantic-router/e2e/pkg/testcases"
+	"k8s.io/client-go/kubernetes"
+)
+
+func init() {
+	pkgtestcases.Register("apiserver-config-validate", pkgtestcases.TestCase{
+		Description: "Verify POST /config/router/validate returns the v1 diagnostic contract without mutating the live config (issue #3477)",
+		Tags:        []string{"apiserver", "config", "api", "validate"},
+		Fn:          testAPIServerConfigValidate,
+	})
+}
+
+type routerConfigValidateResponse struct {
+	Valid           bool   `json:"valid"`
+	ContractVersion string `json:"contract_version"`
+	NormalizedYAML  string `json:"normalized_yaml"`
+	Errors          []struct {
+		Code  string `json:"code"`
+		Field string `json:"field"`
+	} `json:"errors"`
+}
+
+func testAPIServerConfigValidate(
+	ctx context.Context,
+	client *kubernetes.Clientset,
+	opts pkgtestcases.TestCaseOptions,
+) error {
+	session, err := fixtures.OpenRouterAPISession(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+	defer session.Close()
+
+	httpClient := session.HTTPClient(30 * time.Second)
+	hashBefore, err := fetchConfigHash(ctx, httpClient, session.URL("/config/hash"))
+	if err != nil {
+		return err
+	}
+
+	validURL := session.URL("/config/router/validate")
+	validBody, err := postRouterConfigValidate(ctx, httpClient, validURL, map[string]any{
+		"yaml": validateE2EValidYAML,
+	})
+	if err != nil {
+		return err
+	}
+	if err := assertValidValidateContract(validBody); err != nil {
+		return err
+	}
+
+	invalidBody, err := postRouterConfigValidate(ctx, httpClient, validURL, map[string]any{
+		"yaml": validateE2EInvalidYAML,
+	})
+	if err != nil {
+		return err
+	}
+	if err := assertInvalidValidateContract(invalidBody); err != nil {
+		return err
+	}
+
+	hashAfter, err := fetchConfigHash(ctx, httpClient, session.URL("/config/hash"))
+	if err != nil {
+		return err
+	}
+	if hashBefore != hashAfter {
+		return fmt.Errorf("validate mutated live config hash: before=%s after=%s", hashBefore, hashAfter)
+	}
+
+	if opts.SetDetails != nil {
+		opts.SetDetails(map[string]interface{}{
+			"contract_version": validBody.ContractVersion,
+			"invalid_code":     invalidBody.Errors[0].Code,
+			"invalid_field":    invalidBody.Errors[0].Field,
+			"config_hash":      hashAfter,
+		})
+	}
+	return nil
+}
+
+func assertValidValidateContract(body *routerConfigValidateResponse) error {
+	if body.Valid && body.ContractVersion == "v1" {
+		return nil
+	}
+	return fmt.Errorf("expected valid=true contract_version=v1, got valid=%v version=%q", body.Valid, body.ContractVersion)
+}
+
+func assertInvalidValidateContract(body *routerConfigValidateResponse) error {
+	if body.Valid {
+		return fmt.Errorf("expected valid=false for an undeclared signal reference")
+	}
+	if len(body.Errors) == 0 || body.Errors[0].Code == "" || body.Errors[0].Field == "" {
+		return fmt.Errorf("expected a field-addressable error, got %+v", body.Errors)
+	}
+	return nil
+}
+
+func postRouterConfigValidate(
+	ctx context.Context,
+	httpClient *http.Client,
+	url string,
+	payload map[string]any,
+) (*routerConfigValidateResponse, error) {
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal validate request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(encoded))
+	if err != nil {
+		return nil, fmt.Errorf("create validate request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("send validate request: %w", err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read validate response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("expected /config/router/validate status 200, got %d: %s", resp.StatusCode, string(body))
+	}
+	var decoded routerConfigValidateResponse
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		return nil, fmt.Errorf("decode validate response: %w", err)
+	}
+	return &decoded, nil
+}
+
+func fetchConfigHash(ctx context.Context, httpClient *http.Client, url string) (string, error) {
+	resp, err := getJSON(ctx, httpClient, url)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("expected /config/hash status 200, got %d: %s", resp.StatusCode, string(resp.Body))
+	}
+	var decoded struct {
+		Hash string `json:"hash"`
+	}
+	if err := json.Unmarshal(resp.Body, &decoded); err != nil {
+		return "", fmt.Errorf("decode /config/hash: %w", err)
+	}
+	if decoded.Hash == "" {
+		return "", fmt.Errorf("expected /config/hash to include a source hash")
+	}
+	return decoded.Hash, nil
+}
+
+const validateE2EValidYAML = `version: v0.3
+listeners: []
+providers:
+  defaults:
+    default_model: m1
+  models:
+    - name: m1
+      backend_refs:
+        - endpoint: 127.0.0.1:8000
+routing:
+  modelCards:
+    - name: m1
+  decisions:
+    - name: d1
+      priority: 1
+      rules: {operator: AND, conditions: []}
+      modelRefs:
+        - model: m1
+          use_reasoning: false
+`
+
+const validateE2EInvalidYAML = `version: v0.3
+listeners: []
+providers:
+  defaults:
+    default_model: m1
+  models:
+    - name: m1
+      backend_refs:
+        - endpoint: 127.0.0.1:8000
+routing:
+  modelCards:
+    - name: m1
+  signals:
+    keywords:
+      - name: hello
+        operator: OR
+        keywords: ["hi"]
+  decisions:
+    - name: triage
+      priority: 1
+      rules:
+        operator: OR
+        conditions:
+          - type: keyword
+            name: nope
+      modelRefs:
+        - model: m1
+          use_reasoning: false
+`

--- a/src/semantic-router/pkg/apiserver/config_redact.go
+++ b/src/semantic-router/pkg/apiserver/config_redact.go
@@ -6,7 +6,8 @@ import (
 	"context"
 	"net/http"
 	"regexp"
-	"strings"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 )
 
 const redactedConfigValue = "[REDACTED]"
@@ -15,10 +16,6 @@ const redactedConfigValue = "[REDACTED]"
 // sometimes appear inside parse/validation error strings.
 var sensitiveAssignmentPattern = regexp.MustCompile(
 	`(?i)((?:["']?(?:api[_-]?key|x[_-]?api[_-]?key|access[_-]?(?:key|token)|auth[_-]?(?:password|token)|refresh[_-]?token|client[_-]?secret|private[_-]?key|proxy[_-]?authorization|authorization|password|credential|secret|token)["']?)\s*[:=]\s*)(?:"[^"]*"|'[^']*'|(?:Bearer|Basic)\s+[^\s,}\]]+|[^\s,}\]]+)`,
-)
-
-var environmentReferencePattern = regexp.MustCompile(
-	`^\$(?:\{[A-Za-z_][A-Za-z0-9_]*\}|[A-Za-z_][A-Za-z0-9_]*)$`,
 )
 
 // scrubSecretsInErrorMessage removes plaintext credential assignments from
@@ -62,63 +59,5 @@ func (s *ClassificationAPIServer) maybeRedactConfigView(r *http.Request, value i
 }
 
 func redactSensitiveConfigValue(value interface{}) interface{} {
-	switch typed := value.(type) {
-	case map[string]interface{}:
-		out := make(map[string]interface{}, len(typed))
-		for key, nested := range typed {
-			if isSensitiveConfigKey(key) {
-				if isPureEnvironmentReference(nested) {
-					out[key] = nested
-				} else {
-					out[key] = redactedConfigValue
-				}
-				continue
-			}
-			out[key] = redactSensitiveConfigValue(nested)
-		}
-		return out
-	case []interface{}:
-		out := make([]interface{}, len(typed))
-		for i, nested := range typed {
-			out[i] = redactSensitiveConfigValue(nested)
-		}
-		return out
-	default:
-		return value
-	}
-}
-
-func isPureEnvironmentReference(value interface{}) bool {
-	text, ok := value.(string)
-	return ok && environmentReferencePattern.MatchString(strings.TrimSpace(text))
-}
-
-func isSensitiveConfigKey(key string) bool {
-	normalized := strings.ToLower(strings.TrimSpace(key))
-	compact := strings.NewReplacer("_", "", "-", "", " ", "").Replace(normalized)
-	// Env var names (api_key_env) and presence flags stay visible.
-	if strings.HasSuffix(compact, "env") || strings.HasSuffix(compact, "envset") {
-		return false
-	}
-	switch compact {
-	case "apikey", "xapikey", "accesskey", "password", "authpassword",
-		"clientsecret", "privatekey", "authorization", "proxyauthorization",
-		"credential", "secret", "token":
-		return true
-	}
-	for _, suffix := range []string{
-		"apikey",
-		"accesskey",
-		"password",
-		"clientsecret",
-		"privatekey",
-		"authorization",
-		"credential",
-		"token",
-	} {
-		if strings.HasSuffix(compact, suffix) {
-			return true
-		}
-	}
-	return false
+	return config.RedactSensitiveConfigValue(value)
 }

--- a/src/semantic-router/pkg/apiserver/config_redact_test.go
+++ b/src/semantic-router/pkg/apiserver/config_redact_test.go
@@ -3,6 +3,7 @@
 package apiserver
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -264,6 +265,65 @@ func TestClassifierInfoRedactsSecretsWithoutSecretView(t *testing.T) {
 	}
 	if !strings.Contains(rr.Body.String(), redactedConfigValue) {
 		t.Fatalf("expected redacted placeholder for password field, got %s", rr.Body.String())
+	}
+}
+
+func TestClassifierInfoOmitsParsedSourceDocument(t *testing.T) {
+	const canary = "redact-me-canary-value-0001"
+	cfg, err := config.ParseYAMLBytesWithoutEnvExpansion([]byte(validateTestYAML("source-doc-card", canary)))
+	if err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	if len(cfg.SourceDocument) == 0 {
+		t.Fatal("parsed config must retain SourceDocument for this regression")
+	}
+	encodedSource := base64.StdEncoding.EncodeToString(cfg.SourceDocument)
+
+	cfg.ManagementAPI = config.ManagementAPIConfig{
+		Auth: config.ManagementAPIAuthConfig{
+			Mode: config.ManagementAuthModeBearer,
+			Tokens: []config.ManagementAPITokenRef{
+				{Env: "VSR_MGMT_TOKEN", Role: "viewer"},
+			},
+			Roles: config.DefaultManagementAPIRoles(),
+		},
+	}
+	t.Setenv("VSR_MGMT_TOKEN", "viewer-token")
+
+	server := &ClassificationAPIServer{
+		classificationSvc: services.NewPlaceholderClassificationService(),
+		config:            cfg,
+	}
+	mux := server.setupRoutes()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/inventory/classifier", nil)
+	req.Header.Set("Authorization", "Bearer viewer-token")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rr.Code, rr.Body.String())
+	}
+
+	body := rr.Body.String()
+	if strings.Contains(body, canary) {
+		t.Fatalf("/api/v1/inventory/classifier leaked parsed source secret: %s", body)
+	}
+	if strings.Contains(body, encodedSource) {
+		t.Fatalf("/api/v1/inventory/classifier leaked encoded SourceDocument: %s", body)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &parsed); err != nil {
+		t.Fatalf("inventory body must remain valid JSON: %v", err)
+	}
+	configView, _ := parsed["config"].(map[string]interface{})
+	if configView == nil {
+		t.Fatalf("expected config object, got %s", body)
+	}
+	for _, key := range []string{"SourceDocument", "sourceDocument", "DocumentHash", "documentHash", "ConfigBaseDir", "configBaseDir"} {
+		if _, ok := configView[key]; ok {
+			t.Fatalf("inventory config included runtime-only field %q: %s", key, body)
+		}
 	}
 }
 

--- a/src/semantic-router/pkg/apiserver/route_router_config_validate.go
+++ b/src/semantic-router/pkg/apiserver/route_router_config_validate.go
@@ -55,15 +55,37 @@ func (s *ClassificationAPIServer) handleConfigValidate(
 }
 
 func (s *ClassificationAPIServer) activeConfigSnapshotYAML() []byte {
-	if s == nil || s.configPath == "" {
+	if s == nil {
+		return nil
+	}
+	if snapshot := sourceDocumentFromConfig(s.verifiedActiveConfig()); len(snapshot) > 0 {
+		return snapshot
+	}
+	if s.configPath == "" {
 		return nil
 	}
 	paths := resolveConfigPersistencePaths(s.configPath)
-	data, err := os.ReadFile(paths.sourcePath)
+	data, err := os.ReadFile(paths.runtimePath)
 	if err != nil {
 		return nil
 	}
 	return data
+}
+
+func (s *ClassificationAPIServer) verifiedActiveConfig() *config.RouterConfig {
+	if s.runtimeRegistry != nil {
+		if cfg := s.runtimeRegistry.CurrentConfig(); cfg != nil {
+			return cfg
+		}
+	}
+	return s.currentConfig()
+}
+
+func sourceDocumentFromConfig(cfg *config.RouterConfig) []byte {
+	if cfg == nil || len(cfg.SourceDocument) == 0 {
+		return nil
+	}
+	return append([]byte(nil), cfg.SourceDocument...)
 }
 
 func scrubValidateDiagnostics(diagnostics []config.Diagnostic) []config.Diagnostic {

--- a/src/semantic-router/pkg/apiserver/route_router_config_validate.go
+++ b/src/semantic-router/pkg/apiserver/route_router_config_validate.go
@@ -3,23 +3,33 @@
 package apiserver
 
 import (
-	"fmt"
 	"net/http"
+	"os"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 )
 
+// RouterConfigValidateRequest is the JSON body for POST /api/v1/config/validate.
+type RouterConfigValidateRequest struct {
+	YAML            string `json:"yaml"`
+	CompareToActive bool   `json:"compare_to_active,omitempty"`
+}
+
 type RouterConfigValidateResponse struct {
-	Valid          bool   `json:"valid"`
-	NormalizedYAML string `json:"normalized_yaml"`
+	Valid           bool                `json:"valid"`
+	ContractVersion string              `json:"contract_version"`
+	NormalizedYAML  string              `json:"normalized_yaml"`
+	Errors          []config.Diagnostic `json:"errors"`
+	Warnings        []config.Diagnostic `json:"warnings"`
+	Diff            *config.ConfigDiff  `json:"diff,omitempty"`
 }
 
 func (s *ClassificationAPIServer) handleConfigValidate(
 	w http.ResponseWriter,
 	r *http.Request,
 ) {
-	var req RouterConfigUpdateRequest
+	var req RouterConfigValidateRequest
 	if err := s.parseStrictJSONRequest(r, &req); err != nil {
 		s.writeJSONRequestError(w, err)
 		return
@@ -28,56 +38,42 @@ func (s *ClassificationAPIServer) handleConfigValidate(
 		s.writeErrorResponse(w, http.StatusBadRequest, "INVALID_INPUT", "YAML content is required")
 		return
 	}
-	doc, err := decodeYAMLDocument([]byte(req.YAML))
-	if err != nil {
-		s.writeErrorResponse(
-			w,
-			http.StatusBadRequest,
-			"YAML_PARSE_ERROR",
-			scrubSecretsInErrorMessage(err.Error()),
-		)
-		return
+
+	opts := config.EvaluateOptions{CompareToActive: req.CompareToActive}
+	if req.CompareToActive {
+		opts.ActiveYAML = s.activeConfigSnapshotYAML()
 	}
-	normalized, err := normalizeRouterConfigDocumentWithoutEnv(doc)
-	if err != nil {
-		s.writeErrorResponse(
-			w,
-			http.StatusUnprocessableEntity,
-			"CONFIG_VALIDATION_ERROR",
-			scrubSecretsInErrorMessage(err.Error()),
-		)
-		return
-	}
-	normalized, err = redactNormalizedConfigYAML(normalized)
-	if err != nil {
-		s.writeErrorResponse(
-			w,
-			http.StatusInternalServerError,
-			"REDACTION_ERROR",
-			err.Error(),
-		)
-		return
-	}
+	result := config.Evaluate([]byte(req.YAML), opts)
 	s.writeJSONResponse(w, http.StatusOK, RouterConfigValidateResponse{
-		Valid:          true,
-		NormalizedYAML: string(normalized),
+		Valid:           result.Valid,
+		ContractVersion: result.ContractVersion,
+		NormalizedYAML:  result.NormalizedYAML,
+		Errors:          scrubValidateDiagnostics(result.Errors),
+		Warnings:        scrubValidateDiagnostics(result.Warnings),
+		Diff:            result.Diff,
 	})
 }
 
-func redactNormalizedConfigYAML(
-	normalized []byte,
-) ([]byte, error) {
-	var value interface{}
-	if err := yaml.Unmarshal(normalized, &value); err != nil {
-		return nil, fmt.Errorf("failed to decode normalized config: %w", err)
+func (s *ClassificationAPIServer) activeConfigSnapshotYAML() []byte {
+	if s == nil || s.configPath == "" {
+		return nil
 	}
-	// Validation accepts caller-controlled api_key_env names. Never return
-	// resolved process credentials, even to principals that can view the active
-	// config's secrets.
-	redacted := redactSensitiveConfigValue(value)
-	result, err := yaml.Marshal(redacted)
+	paths := resolveConfigPersistencePaths(s.configPath)
+	data, err := os.ReadFile(paths.sourcePath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to encode redacted config: %w", err)
+		return nil
 	}
-	return result, nil
+	return data
+}
+
+func scrubValidateDiagnostics(diagnostics []config.Diagnostic) []config.Diagnostic {
+	if diagnostics == nil {
+		return []config.Diagnostic{}
+	}
+	out := make([]config.Diagnostic, len(diagnostics))
+	for i, diagnostic := range diagnostics {
+		diagnostic.Message = scrubSecretsInErrorMessage(diagnostic.Message)
+		out[i] = diagnostic
+	}
+	return out
 }

--- a/src/semantic-router/pkg/apiserver/route_router_config_validate_test.go
+++ b/src/semantic-router/pkg/apiserver/route_router_config_validate_test.go
@@ -5,13 +5,19 @@ package apiserver
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/routerruntime"
 )
 
 func TestHandleConfigValidate(t *testing.T) {
-	body := `{"yaml":"version: v0.3\nproviders:\n  defaults:\n    model: m1\n  models:\n    - name: m1\n      backend_refs:\n        - endpoint: 127.0.0.1:8000\nrouting:\n  modelCards:\n    - name: m1\n"}`
+	body := `{"yaml":"version: v0.3\nproviders:\n  defaults:\n    model: m1\n  models:\n    - name: m1\n      backend_refs:\n        - endpoint: 127.0.0.1:8000\n          provider: vllm\nrouting:\n  modelCards:\n    - name: m1\n"}`
 	request := httptest.NewRequest("POST", "/api/v1/config/validate", strings.NewReader(body))
 	response := httptest.NewRecorder()
 
@@ -20,8 +26,9 @@ func TestHandleConfigValidate(t *testing.T) {
 	if response.Code != 200 {
 		t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
 	}
-	if !strings.Contains(response.Body.String(), `"valid":true`) {
-		t.Fatalf("body = %s", response.Body.String())
+	decoded := decodeValidateResponse(t, response.Body.Bytes())
+	if !decoded.Valid || decoded.ContractVersion != config.DiagnosticContractVersion {
+		t.Fatalf("response = %+v", decoded)
 	}
 }
 
@@ -44,8 +51,18 @@ func TestHandleConfigValidateRejectsUnknownYAMLFields(t *testing.T) {
 
 	(&ClassificationAPIServer{}).handleConfigValidate(response, request)
 
-	if response.Code != 422 || !strings.Contains(response.Body.String(), `unknown field \"descriptin\"`) {
+	if response.Code != http.StatusOK {
 		t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+	}
+	decoded := decodeValidateResponse(t, response.Body.Bytes())
+	if decoded.Valid {
+		t.Fatal("expected valid=false for an unknown YAML field")
+	}
+	if len(decoded.Errors) == 0 || decoded.Errors[0].Code != config.DiagnosticUnknownField {
+		t.Fatalf("errors = %+v", decoded.Errors)
+	}
+	if !strings.Contains(decoded.Errors[0].Field, "descriptin") {
+		t.Fatalf("field = %q, want descriptin", decoded.Errors[0].Field)
 	}
 }
 
@@ -80,7 +97,7 @@ routing:
     - name: m1
       description: ${VALIDATE_SECRET_CANARY}
 `
-	body, err := json.Marshal(RouterConfigUpdateRequest{YAML: yamlInput})
+	body, err := json.Marshal(RouterConfigValidateRequest{YAML: yamlInput})
 	if err != nil {
 		t.Fatalf("marshal request: %v", err)
 	}
@@ -131,7 +148,7 @@ routing:
   modelCards:
     - name: m1
 `
-	body, err := json.Marshal(RouterConfigUpdateRequest{YAML: yamlInput})
+	body, err := json.Marshal(RouterConfigValidateRequest{YAML: yamlInput})
 	if err != nil {
 		t.Fatalf("marshal request: %v", err)
 	}
@@ -149,6 +166,143 @@ routing:
 	}
 	if !strings.Contains(response.Body.String(), "api_key: ${MODEL_API_KEY}") {
 		t.Fatalf("validation response did not preserve credential reference: %s", response.Body.String())
+	}
+}
+
+func TestHandleConfigValidateReturnsStructuredInvalidResult(t *testing.T) {
+	body, err := json.Marshal(RouterConfigValidateRequest{
+		YAML: "version: v0.3\nproviders: [",
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	response := httptest.NewRecorder()
+	(&ClassificationAPIServer{}).handleConfigValidate(
+		response,
+		httptest.NewRequest(http.MethodPost, "/api/v1/config/validate", strings.NewReader(string(body))),
+	)
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+	}
+	decoded := decodeValidateResponse(t, response.Body.Bytes())
+	if decoded.Valid {
+		t.Fatal("expected valid=false")
+	}
+	if len(decoded.Errors) == 0 || decoded.Errors[0].Code != config.DiagnosticYAMLParseError {
+		t.Fatalf("errors = %+v", decoded.Errors)
+	}
+}
+
+func TestHandleConfigValidateCompareToActive(t *testing.T) {
+	configPath := writeValidateTestConfig(t, validateTestYAML("active-card", "active-secret"))
+	body, err := json.Marshal(RouterConfigValidateRequest{
+		YAML:            validateTestYAML("candidate-card", "candidate-secret"),
+		CompareToActive: true,
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	response := httptest.NewRecorder()
+	(&ClassificationAPIServer{configPath: configPath}).handleConfigValidate(
+		response,
+		httptest.NewRequest(http.MethodPost, "/api/v1/config/validate", strings.NewReader(string(body))),
+	)
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+	}
+	decoded := decodeValidateResponse(t, response.Body.Bytes())
+	if !decoded.Valid {
+		t.Fatalf("expected valid candidate, errors=%+v", decoded.Errors)
+	}
+	if decoded.Diff == nil {
+		t.Fatal("expected diff")
+	}
+	if decoded.Diff.Truncated {
+		t.Fatal("expected an untruncated small diff")
+	}
+	foundChange := false
+	for _, entry := range decoded.Diff.Changed {
+		if strings.Contains(entry.Field, "description") {
+			foundChange = true
+			break
+		}
+	}
+	if !foundChange {
+		t.Fatalf("expected a model-card description change, got %+v", decoded.Diff)
+	}
+	if strings.Contains(response.Body.String(), "candidate-secret") || strings.Contains(response.Body.String(), "active-secret") {
+		t.Fatalf("diff leaked a secret: %s", response.Body.String())
+	}
+	if !strings.Contains(response.Body.String(), "[REDACTED]") {
+		t.Fatal("expected redacted secret values in the validate response")
+	}
+}
+
+func TestHandleConfigValidateIsSideEffectFree(t *testing.T) {
+	configPath := writeValidateTestConfig(t, validateTestYAML("active-card", "active-secret"))
+	backupDir := filepath.Join(filepath.Dir(configPath), ".vllm-sr", "config-backups")
+	if err := os.MkdirAll(backupDir, 0o755); err != nil {
+		t.Fatalf("mkdir backups: %v", err)
+	}
+	backupFile := filepath.Join(backupDir, "config.20240101-000000.yaml")
+	if err := os.WriteFile(backupFile, []byte("seed"), 0o644); err != nil {
+		t.Fatalf("write backup: %v", err)
+	}
+	activeCfg, err := config.ParseYAMLBytesWithoutEnvExpansion([]byte(validateTestYAML("active-card", "active-secret")))
+	if err != nil {
+		t.Fatalf("parse active: %v", err)
+	}
+	registry := routerruntime.NewRegistry(activeCfg)
+	beforeSource := mustReadFile(t, configPath)
+	beforeBackup := mustReadDirNames(t, backupDir)
+	beforeHash := registry.CurrentConfig().DocumentHash
+
+	server := &ClassificationAPIServer{configPath: configPath, runtimeRegistry: registry}
+	payloads := []RouterConfigValidateRequest{
+		{YAML: validateTestYAML("candidate-card", "candidate-secret")},
+		{YAML: "version: v0.3\nproviders: ["},
+		{YAML: validateTestYAML("candidate-card", "candidate-secret"), CompareToActive: true},
+	}
+	for _, payload := range payloads {
+		body, err := json.Marshal(payload)
+		if err != nil {
+			t.Fatalf("marshal request: %v", err)
+		}
+		response := httptest.NewRecorder()
+		server.handleConfigValidate(
+			response,
+			httptest.NewRequest(http.MethodPost, "/api/v1/config/validate", strings.NewReader(string(body))),
+		)
+		if response.Code != http.StatusOK {
+			t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+		}
+	}
+
+	afterSource := mustReadFile(t, configPath)
+	if string(afterSource) != string(beforeSource) {
+		t.Fatal("validate mutated the source config")
+	}
+	afterBackup := mustReadDirNames(t, backupDir)
+	if strings.Join(afterBackup, ",") != strings.Join(beforeBackup, ",") {
+		t.Fatalf("validate mutated backups: before=%v after=%v", beforeBackup, afterBackup)
+	}
+	if registry.CurrentConfig().DocumentHash != beforeHash {
+		t.Fatal("validate mutated the runtime snapshot")
+	}
+}
+
+func TestHandleConfigValidateRejectsEmptyYAML(t *testing.T) {
+	body, err := json.Marshal(RouterConfigValidateRequest{YAML: "   "})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	response := httptest.NewRecorder()
+	(&ClassificationAPIServer{}).handleConfigValidate(
+		response,
+		httptest.NewRequest(http.MethodPost, "/api/v1/config/validate", strings.NewReader(string(body))),
+	)
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", response.Code)
 	}
 }
 
@@ -183,4 +337,62 @@ routing:
         labels: [SAFE, RISKY]
   decisions: []
 `
+}
+
+func decodeValidateResponse(t *testing.T, body []byte) RouterConfigValidateResponse {
+	t.Helper()
+	var decoded RouterConfigValidateResponse
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatalf("decode response: %v body=%s", err, body)
+	}
+	return decoded
+}
+
+func writeValidateTestConfig(t *testing.T, yamlInput string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte(yamlInput), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}
+
+func validateTestYAML(description, apiKey string) string {
+	return `
+version: v0.3
+listeners: []
+providers:
+  defaults:
+    model: m1
+  models:
+    - name: m1
+      backend_refs:
+        - endpoint: 127.0.0.1:8000
+          provider: vllm
+          api_key: ` + apiKey + `
+routing:
+  modelCards:
+    - name: m1
+      description: ` + description + `
+  decisions:
+    - name: d1
+      priority: 1
+      rules: {operator: AND, conditions: []}
+      modelRefs:
+        - model: m1
+          use_reasoning: false
+`
+}
+
+func mustReadDirNames(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir %s: %v", dir, err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	return names
 }

--- a/src/semantic-router/pkg/apiserver/route_router_config_validate_test.go
+++ b/src/semantic-router/pkg/apiserver/route_router_config_validate_test.go
@@ -5,6 +5,7 @@ package apiserver
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -288,6 +289,93 @@ func TestHandleConfigValidateIsSideEffectFree(t *testing.T) {
 	}
 	if registry.CurrentConfig().DocumentHash != beforeHash {
 		t.Fatal("validate mutated the runtime snapshot")
+	}
+}
+
+func TestHandleConfigValidateCompareToActiveUsesInMemorySnapshot(t *testing.T) {
+	desiredPath := writeValidateTestConfig(t, validateTestYAML("desired-card", "desired-secret"))
+	activeCfg, err := config.ParseYAMLBytesWithoutEnvExpansion([]byte(validateTestYAML("active-card", "active-secret")))
+	if err != nil {
+		t.Fatalf("parse active: %v", err)
+	}
+	body, err := json.Marshal(RouterConfigValidateRequest{
+		YAML:            validateTestYAML("desired-card", "desired-secret"),
+		CompareToActive: true,
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	response := httptest.NewRecorder()
+	(&ClassificationAPIServer{
+		configPath:      desiredPath,
+		runtimeRegistry: routerruntime.NewRegistry(activeCfg),
+	}).handleConfigValidate(
+		response,
+		httptest.NewRequest(http.MethodPost, "/api/v1/config/validate", strings.NewReader(string(body))),
+	)
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+	}
+	decoded := decodeValidateResponse(t, response.Body.Bytes())
+	if decoded.Diff == nil {
+		t.Fatal("expected a diff against the in-memory active snapshot")
+	}
+	foundActive := false
+	for _, entry := range decoded.Diff.Changed {
+		if strings.Contains(entry.Field, "description") && fmt.Sprint(entry.Old) == "active-card" {
+			foundActive = true
+			break
+		}
+	}
+	if !foundActive {
+		t.Fatalf("compare_to_active used desired source instead of in-memory active state: %+v", decoded.Diff)
+	}
+	if strings.Contains(response.Body.String(), "active-secret") || strings.Contains(response.Body.String(), "desired-secret") {
+		t.Fatalf("diff leaked a secret: %s", response.Body.String())
+	}
+}
+
+func TestHandleConfigValidateCompareToActiveUsesGeneratedRuntime(t *testing.T) {
+	tempDir := t.TempDir()
+	sourcePath := filepath.Join(tempDir, "config.yaml")
+	runtimePath := filepath.Join(tempDir, ".vllm-sr", "runtime-config.yaml")
+	if err := os.MkdirAll(filepath.Dir(runtimePath), 0o755); err != nil {
+		t.Fatalf("mkdir runtime dir: %v", err)
+	}
+	if err := os.WriteFile(sourcePath, []byte(validateTestYAML("source-card", "source-secret")), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	if err := os.WriteFile(runtimePath, []byte(validateTestYAML("runtime-card", "runtime-secret")), 0o644); err != nil {
+		t.Fatalf("write runtime: %v", err)
+	}
+	body, err := json.Marshal(RouterConfigValidateRequest{
+		YAML:            validateTestYAML("candidate-card", "candidate-secret"),
+		CompareToActive: true,
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	response := httptest.NewRecorder()
+	(&ClassificationAPIServer{configPath: runtimePath}).handleConfigValidate(
+		response,
+		httptest.NewRequest(http.MethodPost, "/api/v1/config/validate", strings.NewReader(string(body))),
+	)
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+	}
+	decoded := decodeValidateResponse(t, response.Body.Bytes())
+	if decoded.Diff == nil {
+		t.Fatal("expected a diff against generated runtime state")
+	}
+	foundRuntime := false
+	for _, entry := range decoded.Diff.Changed {
+		if strings.Contains(entry.Field, "description") && fmt.Sprint(entry.Old) == "runtime-card" {
+			foundRuntime = true
+			break
+		}
+	}
+	if !foundRuntime {
+		t.Fatalf("compare_to_active used desired source instead of generated runtime: %+v", decoded.Diff)
 	}
 }
 

--- a/src/semantic-router/pkg/apiserver/routes_catalog.go
+++ b/src/semantic-router/pkg/apiserver/routes_catalog.go
@@ -355,10 +355,10 @@ func apiNonRecipeConfigRoutes() []apiRoute {
 			(*ClassificationAPIServer).handleConfigGet,
 		),
 		managedRoute(
-			EndpointMetadata{Path: apiConfigValidatePath, Method: "POST", Description: "Validate and normalize a router config without writing it"},
+			EndpointMetadata{Path: apiConfigValidatePath, Method: "POST", Description: "Validate and normalize a router config, returning v1 diagnostics and an optional redacted diff without writing it"},
 			routePolicy{Permission: PermConfigRead, Sensitivity: SensitivityConfig},
 			(*ClassificationAPIServer).handleConfigValidate,
-			strictJSONBodyFor[RouterConfigUpdateRequest](),
+			strictJSONBodyFor[RouterConfigValidateRequest](),
 		),
 		managedRoute(
 			EndpointMetadata{Path: apiConfigPlanPath, Method: "POST", Description: "Plan an exact merge or replace mutation, including hot-reload compatibility, without writing it"},

--- a/src/semantic-router/pkg/config/config.go
+++ b/src/semantic-router/pkg/config/config.go
@@ -146,6 +146,10 @@ type RouterConfig struct {
 	// runtime snapshot was parsed. Management APIs use it to distinguish a
 	// persisted config from the config that has completed hot reload.
 	DocumentHash string `yaml:"-"`
+	// SourceDocument is the exact YAML bytes that produced this snapshot.
+	// Compare-to-active binds to this verified in-memory document instead of a
+	// later desired-source write.
+	SourceDocument []byte `yaml:"-"`
 	// EffectiveModelRegistry is the immutable catalog/config join used to
 	// materialize this runtime snapshot.
 	EffectiveModelRegistry *modelcatalog.EffectiveRegistry `yaml:"-" json:"-"`

--- a/src/semantic-router/pkg/config/config.go
+++ b/src/semantic-router/pkg/config/config.go
@@ -141,15 +141,16 @@ type RouterConfig struct {
 
 	// Runtime-only knowledge bases loaded from global.model_catalog.
 	KnowledgeBases []KnowledgeBaseConfig `yaml:"knowledge_bases,omitempty"`
-	ConfigBaseDir  string                `yaml:"-"`
+	ConfigBaseDir  string                `yaml:"-" json:"-"`
 	// DocumentHash identifies the exact YAML document from which this immutable
 	// runtime snapshot was parsed. Management APIs use it to distinguish a
 	// persisted config from the config that has completed hot reload.
-	DocumentHash string `yaml:"-"`
+	DocumentHash string `yaml:"-" json:"-"`
 	// SourceDocument is the exact YAML bytes that produced this snapshot.
 	// Compare-to-active binds to this verified in-memory document instead of a
-	// later desired-source write.
-	SourceDocument []byte `yaml:"-"`
+	// later desired-source write. It stays out of config JSON so inventory
+	// dumps cannot expose the original document, including plaintext secrets.
+	SourceDocument []byte `yaml:"-" json:"-"`
 	// EffectiveModelRegistry is the immutable catalog/config join used to
 	// materialize this runtime snapshot.
 	EffectiveModelRegistry *modelcatalog.EffectiveRegistry `yaml:"-" json:"-"`

--- a/src/semantic-router/pkg/config/diagnostics.go
+++ b/src/semantic-router/pkg/config/diagnostics.go
@@ -1,0 +1,75 @@
+package config
+
+// DiagnosticContractVersion is the versioned validate/diff response contract.
+const DiagnosticContractVersion = "v1"
+
+// DiffEntryLimit bounds added + removed + changed entries in one evaluate call.
+const DiffEntryLimit = 500
+
+const (
+	DiagnosticYAMLParseError   = "YAML_PARSE_ERROR"
+	DiagnosticUnknownField     = "CONFIG_UNKNOWN_FIELD"
+	DiagnosticValidationError  = "CONFIG_VALIDATION_ERROR"
+	DiagnosticReferenceError   = "CONFIG_REFERENCE_ERROR"
+	DiagnosticCycleError       = "CONFIG_CYCLE_ERROR"
+	DiagnosticConflict         = "CONFIG_CONFLICT"
+	DiagnosticQuorumError      = "CONFIG_QUORUM_ERROR"
+	DiagnosticBudgetError      = "CONFIG_BUDGET_ERROR"
+	DiagnosticCapabilityError  = "CONFIG_CAPABILITY_ERROR"
+	DiagnosticFallbackError    = "CONFIG_FALLBACK_ERROR"
+	DiagnosticNoActiveSnapshot = "CONFIG_NO_ACTIVE_SNAPSHOT"
+)
+
+const (
+	SeverityError   = "error"
+	SeverityWarning = "warning"
+)
+
+const (
+	StageParse     = "parse"
+	StageNormalize = "normalize"
+	StageResolve   = "resolve"
+	StageValidate  = "validate"
+)
+
+// Diagnostic is one field-addressable validate/diff finding.
+type Diagnostic struct {
+	Code     string `json:"code"`
+	Severity string `json:"severity"`
+	Resource string `json:"resource,omitempty"`
+	Recipe   string `json:"recipe,omitempty"`
+	Stage    string `json:"stage"`
+	Field    string `json:"field,omitempty"`
+	Message  string `json:"message"`
+}
+
+// DiffEntry is one schema-aware added, removed, or changed field.
+type DiffEntry struct {
+	Field string `json:"field"`
+	Old   any    `json:"old,omitempty"`
+	New   any    `json:"new,omitempty"`
+}
+
+// ConfigDiff is a bounded active-versus-candidate structured diff.
+type ConfigDiff struct {
+	Added     []DiffEntry `json:"added"`
+	Removed   []DiffEntry `json:"removed"`
+	Changed   []DiffEntry `json:"changed"`
+	Truncated bool        `json:"truncated"`
+}
+
+// EvaluateOptions controls optional active-snapshot comparison.
+type EvaluateOptions struct {
+	CompareToActive bool
+	ActiveYAML      []byte
+}
+
+// EvaluateResult is the canonical side-effect-free validate/diff output.
+type EvaluateResult struct {
+	Valid           bool
+	ContractVersion string
+	NormalizedYAML  string
+	Errors          []Diagnostic
+	Warnings        []Diagnostic
+	Diff            *ConfigDiff
+}

--- a/src/semantic-router/pkg/config/diagnostics_classify.go
+++ b/src/semantic-router/pkg/config/diagnostics_classify.go
@@ -1,0 +1,178 @@
+package config
+
+import (
+	"regexp"
+	"strings"
+)
+
+var (
+	recipePrefixPattern = regexp.MustCompile(`^routing recipe "([^"]+)":\s*`)
+	decisionNamePattern = regexp.MustCompile(`(?i)decision ['"]([^'"]+)['"]`)
+	fieldPathPattern    = regexp.MustCompile(
+		`(?i)((?:[A-Za-z_][A-Za-z0-9_]*)(?:\[[0-9]+\]|\["[^"]+"\])?(?:\.(?:[A-Za-z_][A-Za-z0-9_]*)(?:\[[0-9]+\]|\["[^"]+"\])?)*)`,
+	)
+)
+
+func classifyEvaluationError(err error) Diagnostic {
+	if err == nil {
+		return Diagnostic{}
+	}
+	message := err.Error()
+	diagnostic := Diagnostic{
+		Code:     DiagnosticValidationError,
+		Severity: SeverityError,
+		Stage:    StageValidate,
+		Message:  message,
+	}
+
+	remainder := message
+	if match := recipePrefixPattern.FindStringSubmatch(message); len(match) == 2 {
+		diagnostic.Recipe = match[1]
+		remainder = strings.TrimSpace(strings.TrimPrefix(message, match[0]))
+	}
+
+	applyDiagnosticClassification(&diagnostic, remainder)
+	if diagnostic.Field == "" {
+		diagnostic.Field = extractFieldPath(remainder)
+	}
+	if diagnostic.Resource == "" {
+		diagnostic.Resource = resourceFromField(diagnostic.Field)
+	}
+	if diagnostic.Recipe == "" {
+		diagnostic.Recipe = recipeFromMessage(remainder, diagnostic.Field)
+	}
+	return diagnostic
+}
+
+type classificationRule struct {
+	code  string
+	stage string
+	terms []string
+}
+
+var diagnosticClassificationRules = []classificationRule{
+	{code: DiagnosticYAMLParseError, stage: StageParse, terms: []string{"failed to parse", "yaml:"}},
+	{stage: StageNormalize, terms: []string{"deprecated config fields", "removed config fields", "must use canonical"}},
+	{code: DiagnosticCycleError, stage: StageResolve, terms: []string{"dependency cycle"}},
+	{code: DiagnosticCapabilityError, stage: StageResolve, terms: []string{"outside decision modelrefs", "capability"}},
+	{code: DiagnosticReferenceError, stage: StageResolve, terms: []string{
+		"references unknown", "not declared", "undefined score", "references model", "references undefined",
+	}},
+	{code: DiagnosticQuorumError, terms: []string{
+		"exceeds the configured panel", "exceeds the configured worker", "exceeds roles[", "exceeds max_parallel", "quorum",
+	}},
+	{code: DiagnosticBudgetError, terms: []string{"budget.", "target_tokens must be less"}},
+	{code: DiagnosticFallbackError, terms: []string{"on_error", "fallback"}},
+	{code: DiagnosticConflict, terms: []string{"duplicate", "conflict"}},
+}
+
+func applyDiagnosticClassification(diagnostic *Diagnostic, message string) {
+	lower := strings.ToLower(message)
+	if rule, ok := matchClassificationRule(lower); ok {
+		if rule.code != "" {
+			diagnostic.Code = rule.code
+		}
+		if rule.stage != "" {
+			diagnostic.Stage = rule.stage
+		}
+	}
+	if field := fieldFromDecisionMessage(message); field != "" && diagnostic.Field == "" {
+		diagnostic.Field = field
+	}
+}
+
+func matchClassificationRule(lower string) (classificationRule, bool) {
+	for _, rule := range diagnosticClassificationRules {
+		if containsAny(lower, rule.terms) {
+			return rule, true
+		}
+	}
+	return classificationRule{}, false
+}
+
+func containsAny(haystack string, terms []string) bool {
+	for _, term := range terms {
+		if strings.Contains(haystack, term) {
+			return true
+		}
+	}
+	return false
+}
+
+func extractFieldPath(message string) string {
+	trimmed := strings.TrimSpace(message)
+	if match := fieldPathPattern.FindStringSubmatch(trimmed); len(match) > 1 {
+		candidate := match[1]
+		if strings.Contains(candidate, ".") || strings.Contains(candidate, "[") {
+			return strings.TrimSuffix(candidate, ":")
+		}
+		switch candidate {
+		case "version", "listeners", "providers", "routing", "entrypoints", "recipes", "global":
+			return candidate
+		}
+	}
+	return ""
+}
+
+func fieldFromDecisionMessage(message string) string {
+	match := decisionNamePattern.FindStringSubmatch(message)
+	if len(match) != 2 {
+		return ""
+	}
+	return `routing.decisions["` + match[1] + `"]` + decisionFieldSuffix(strings.ToLower(message))
+}
+
+func decisionFieldSuffix(lower string) string {
+	switch {
+	case strings.Contains(lower, "algorithm"):
+		return ".algorithm" + algorithmFieldSuffix(lower)
+	case strings.Contains(lower, "plugin"):
+		return ".plugins"
+	case strings.Contains(lower, "modelrefs") || strings.Contains(lower, "model '"):
+		return ".modelRefs"
+	case strings.Contains(lower, "signal") || strings.Contains(lower, "condition"):
+		return ".rules"
+	default:
+		return ""
+	}
+}
+
+func algorithmFieldSuffix(lower string) string {
+	switch {
+	case strings.Contains(lower, "on_error"):
+		return ".on_error"
+	case strings.Contains(lower, "fusion"):
+		return ".fusion"
+	case strings.Contains(lower, "workflows"):
+		return ".workflows"
+	case strings.Contains(lower, "prompt"):
+		return ".prompt"
+	default:
+		return ""
+	}
+}
+
+func recipeFromMessage(message, field string) string {
+	if match := decisionNamePattern.FindStringSubmatch(message); len(match) == 2 {
+		return string(DefaultRecipeName)
+	}
+	if strings.HasPrefix(field, "routing.") || strings.HasPrefix(field, "recipes.") {
+		return string(DefaultRecipeName)
+	}
+	return ""
+}
+
+func resourceFromField(field string) string {
+	if field == "" {
+		return ""
+	}
+	trimmed := strings.TrimSpace(field)
+	end := len(trimmed)
+	for i, r := range trimmed {
+		if r == '.' || r == '[' {
+			end = i
+			break
+		}
+	}
+	return trimmed[:end]
+}

--- a/src/semantic-router/pkg/config/diff.go
+++ b/src/semantic-router/pkg/config/diff.go
@@ -1,0 +1,290 @@
+package config
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+)
+
+// DiffCanonicalDocuments walks two redacted YAML documents against the
+// canonical schema. Named slices are keyed by name when present.
+func DiffCanonicalDocuments(active, candidate map[string]interface{}) *ConfigDiff {
+	diff := &ConfigDiff{
+		Added:   []DiffEntry{},
+		Removed: []DiffEntry{},
+		Changed: []DiffEntry{},
+	}
+	left := normalizeYAMLValue(active)
+	right := normalizeYAMLValue(candidate)
+	walkDiff(diff, "", left, right)
+	return diff
+}
+
+func walkDiff(diff *ConfigDiff, path string, left, right any) {
+	if !diff.accept() {
+		diff.Truncated = true
+		return
+	}
+	if reflect.DeepEqual(comparableYAMLValue(left), comparableYAMLValue(right)) {
+		return
+	}
+	leftMap, leftIsMap := asStringMap(left)
+	rightMap, rightIsMap := asStringMap(right)
+	if leftIsMap && rightIsMap {
+		walkMapDiff(diff, path, leftMap, rightMap)
+		return
+	}
+	leftSlice, leftIsSlice := asSlice(left)
+	rightSlice, rightIsSlice := asSlice(right)
+	if leftIsSlice && rightIsSlice {
+		walkSliceDiff(diff, path, leftSlice, rightSlice)
+		return
+	}
+	if left == nil {
+		diff.add(DiffEntry{Field: displayDiffPath(path), New: redactDiffValue(path, right)})
+		return
+	}
+	if right == nil {
+		diff.remove(DiffEntry{Field: displayDiffPath(path), Old: redactDiffValue(path, left)})
+		return
+	}
+	diff.change(DiffEntry{
+		Field: displayDiffPath(path),
+		Old:   redactDiffValue(path, left),
+		New:   redactDiffValue(path, right),
+	})
+}
+
+func walkMapDiff(diff *ConfigDiff, path string, left, right map[string]interface{}) {
+	keys := make([]string, 0, len(left)+len(right))
+	seen := map[string]struct{}{}
+	for key := range left {
+		keys = append(keys, key)
+		seen[key] = struct{}{}
+	}
+	for key := range right {
+		if _, ok := seen[key]; !ok {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		child := joinPath(path, key)
+		leftValue, leftOK := left[key]
+		rightValue, rightOK := right[key]
+		switch {
+		case leftOK && rightOK:
+			walkDiff(diff, child, leftValue, rightValue)
+		case rightOK:
+			diff.add(DiffEntry{Field: displayDiffPath(child), New: redactDiffValue(child, rightValue)})
+		default:
+			diff.remove(DiffEntry{Field: displayDiffPath(child), Old: redactDiffValue(child, leftValue)})
+		}
+	}
+}
+
+func walkSliceDiff(diff *ConfigDiff, path string, left, right []interface{}) {
+	if keyedSlice(left) && keyedSlice(right) {
+		walkNamedSliceDiff(diff, path, left, right)
+		return
+	}
+	limit := len(left)
+	if len(right) > limit {
+		limit = len(right)
+	}
+	for i := 0; i < limit; i++ {
+		child := fmt.Sprintf("%s[%d]", path, i)
+		var leftValue, rightValue any
+		if i < len(left) {
+			leftValue = left[i]
+		}
+		if i < len(right) {
+			rightValue = right[i]
+		}
+		if i >= len(left) {
+			diff.add(DiffEntry{Field: displayDiffPath(child), New: redactDiffValue(child, rightValue)})
+			continue
+		}
+		if i >= len(right) {
+			diff.remove(DiffEntry{Field: displayDiffPath(child), Old: redactDiffValue(child, leftValue)})
+			continue
+		}
+		walkDiff(diff, child, leftValue, rightValue)
+	}
+}
+
+func walkNamedSliceDiff(diff *ConfigDiff, path string, left, right []interface{}) {
+	leftByName := namedSliceMap(left)
+	rightByName := namedSliceMap(right)
+	names := make([]string, 0, len(leftByName)+len(rightByName))
+	seen := map[string]struct{}{}
+	for name := range leftByName {
+		names = append(names, name)
+		seen[name] = struct{}{}
+	}
+	for name := range rightByName {
+		if _, ok := seen[name]; !ok {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		child := fmt.Sprintf("%s[%q]", path, name)
+		leftValue, leftOK := leftByName[name]
+		rightValue, rightOK := rightByName[name]
+		switch {
+		case leftOK && rightOK:
+			walkDiff(diff, child, leftValue, rightValue)
+		case rightOK:
+			diff.add(DiffEntry{Field: displayDiffPath(child), New: redactDiffValue(child, rightValue)})
+		default:
+			diff.remove(DiffEntry{Field: displayDiffPath(child), Old: redactDiffValue(child, leftValue)})
+		}
+	}
+}
+
+func keyedSlice(items []interface{}) bool {
+	if len(items) == 0 {
+		return false
+	}
+	for _, item := range items {
+		itemMap, ok := asStringMap(item)
+		if !ok {
+			return false
+		}
+		name, _ := itemMap["name"].(string)
+		if strings.TrimSpace(name) == "" {
+			return false
+		}
+	}
+	return true
+}
+
+func namedSliceMap(items []interface{}) map[string]any {
+	out := make(map[string]any, len(items))
+	for _, item := range items {
+		itemMap, ok := asStringMap(item)
+		if !ok {
+			continue
+		}
+		name, _ := itemMap["name"].(string)
+		if name != "" {
+			out[name] = item
+		}
+	}
+	return out
+}
+
+func (d *ConfigDiff) accept() bool {
+	return d != nil && d.size() < DiffEntryLimit
+}
+
+func (d *ConfigDiff) size() int {
+	return len(d.Added) + len(d.Removed) + len(d.Changed)
+}
+
+func (d *ConfigDiff) add(entry DiffEntry) {
+	if !d.accept() {
+		d.Truncated = true
+		return
+	}
+	d.Added = append(d.Added, entry)
+}
+
+func (d *ConfigDiff) remove(entry DiffEntry) {
+	if !d.accept() {
+		d.Truncated = true
+		return
+	}
+	d.Removed = append(d.Removed, entry)
+}
+
+func (d *ConfigDiff) change(entry DiffEntry) {
+	if !d.accept() {
+		d.Truncated = true
+		return
+	}
+	d.Changed = append(d.Changed, entry)
+}
+
+func redactDiffValue(path string, value any) any {
+	if isSensitiveConfigKey(lastPathSegment(path)) {
+		return RedactedConfigValue
+	}
+	return RedactSensitiveConfigValue(normalizeYAMLValue(value))
+}
+
+func lastPathSegment(path string) string {
+	segment := path
+	if index := strings.LastIndex(segment, "."); index >= 0 {
+		segment = segment[index+1:]
+	}
+	if index := strings.Index(segment, "["); index >= 0 {
+		segment = segment[:index]
+	}
+	return segment
+}
+
+func displayDiffPath(path string) string {
+	if path == "" {
+		return "."
+	}
+	return path
+}
+
+func asStringMap(value any) (map[string]interface{}, bool) {
+	normalized := normalizeYAMLValue(value)
+	typed, ok := normalized.(map[string]interface{})
+	return typed, ok
+}
+
+func asSlice(value any) ([]interface{}, bool) {
+	normalized := normalizeYAMLValue(value)
+	typed, ok := normalized.([]interface{})
+	return typed, ok
+}
+
+func normalizeYAMLValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]interface{}:
+		out := make(map[string]interface{}, len(typed))
+		for key, nested := range typed {
+			out[key] = normalizeYAMLValue(nested)
+		}
+		return out
+	case map[interface{}]interface{}:
+		return normalizeYAMLValue(nestedStringMap(typed))
+	case []interface{}:
+		out := make([]interface{}, len(typed))
+		for i, nested := range typed {
+			out[i] = normalizeYAMLValue(nested)
+		}
+		return out
+	default:
+		return typed
+	}
+}
+
+func comparableYAMLValue(value any) any {
+	switch typed := value.(type) {
+	case int:
+		return int64(typed)
+	case int32:
+		return int64(typed)
+	case int64:
+		return typed
+	case uint:
+		return int64(typed)
+	case uint32:
+		return int64(typed)
+	case uint64:
+		return int64(typed)
+	case float32:
+		return float64(typed)
+	case map[string]interface{}, []interface{}:
+		return normalizeYAMLValue(typed)
+	default:
+		return typed
+	}
+}

--- a/src/semantic-router/pkg/config/diff.go
+++ b/src/semantic-router/pkg/config/diff.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"math"
 	"reflect"
 	"sort"
 	"strings"
@@ -275,11 +276,11 @@ func comparableYAMLValue(value any) any {
 	case int64:
 		return typed
 	case uint:
-		return int64(typed)
+		return signedIfFits(uint64(typed))
 	case uint32:
 		return int64(typed)
 	case uint64:
-		return int64(typed)
+		return signedIfFits(typed)
 	case float32:
 		return float64(typed)
 	case map[string]interface{}, []interface{}:
@@ -287,4 +288,11 @@ func comparableYAMLValue(value any) any {
 	default:
 		return typed
 	}
+}
+
+func signedIfFits(value uint64) any {
+	if value > uint64(math.MaxInt64) {
+		return value
+	}
+	return int64(value)
 }

--- a/src/semantic-router/pkg/config/dryrun.go
+++ b/src/semantic-router/pkg/config/dryrun.go
@@ -1,0 +1,95 @@
+package config
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v2"
+)
+
+// Evaluate validates a candidate document without mutating desired, active,
+// runtime, persistence, or version-history state.
+func Evaluate(candidate []byte, opts EvaluateOptions) EvaluateResult {
+	result := EvaluateResult{
+		ContractVersion: DiagnosticContractVersion,
+		Errors:          []Diagnostic{},
+		Warnings:        []Diagnostic{},
+	}
+
+	raw, err := parseRawConfigMap(candidate)
+	if err != nil {
+		result.Errors = append(result.Errors, classifyEvaluationError(err))
+		attachDiff(&result, nil, opts)
+		return result
+	}
+	if raw == nil {
+		raw = map[string]interface{}{}
+	}
+
+	unknown := CollectUnknownFieldDiagnostics(raw)
+	if len(unknown) > 0 {
+		result.Errors = append(result.Errors, unknown...)
+		attachDiff(&result, raw, opts)
+		return result
+	}
+
+	if _, err := ParseYAMLBytesWithoutEnvExpansion(candidate); err != nil {
+		result.Errors = append(result.Errors, classifyEvaluationError(err))
+		attachDiff(&result, raw, opts)
+		return result
+	}
+
+	normalized, err := marshalRedactedYAML(raw)
+	if err != nil {
+		result.Errors = append(result.Errors, Diagnostic{
+			Code:     DiagnosticValidationError,
+			Severity: SeverityError,
+			Stage:    StageValidate,
+			Message:  err.Error(),
+		})
+		attachDiff(&result, raw, opts)
+		return result
+	}
+
+	result.Valid = true
+	result.NormalizedYAML = string(normalized)
+	attachDiff(&result, raw, opts)
+	return result
+}
+
+func attachDiff(result *EvaluateResult, candidate map[string]interface{}, opts EvaluateOptions) {
+	if result == nil || !opts.CompareToActive {
+		return
+	}
+	if len(opts.ActiveYAML) == 0 {
+		result.Warnings = append(result.Warnings, Diagnostic{
+			Code:     DiagnosticNoActiveSnapshot,
+			Severity: SeverityWarning,
+			Stage:    StageValidate,
+			Message:  "no active snapshot available for comparison",
+		})
+		return
+	}
+	active, err := parseRawConfigMap(opts.ActiveYAML)
+	if err != nil {
+		result.Warnings = append(result.Warnings, Diagnostic{
+			Code:     DiagnosticYAMLParseError,
+			Severity: SeverityWarning,
+			Stage:    StageParse,
+			Message:  fmt.Sprintf("active snapshot could not be parsed for diff: %v", err),
+		})
+		return
+	}
+	if candidate == nil {
+		return
+	}
+	result.Diff = DiffCanonicalDocuments(active, candidate)
+}
+
+func marshalRedactedYAML(raw map[string]interface{}) ([]byte, error) {
+	redacted := RedactSensitiveConfigValue(normalizeYAMLValue(raw))
+	encoded, err := yaml.Marshal(redacted)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode redacted config: %w", err)
+	}
+	return encoded, nil
+}

--- a/src/semantic-router/pkg/config/dryrun.go
+++ b/src/semantic-router/pkg/config/dryrun.go
@@ -32,7 +32,8 @@ func Evaluate(candidate []byte, opts EvaluateOptions) EvaluateResult {
 		return result
 	}
 
-	if _, err := ParseYAMLBytesWithoutEnvExpansion(candidate); err != nil {
+	_, err = ParseYAMLBytesWithoutEnvExpansion(candidate)
+	if err != nil {
 		result.Errors = append(result.Errors, classifyEvaluationError(err))
 		attachDiff(&result, raw, opts)
 		return result

--- a/src/semantic-router/pkg/config/dryrun_redact.go
+++ b/src/semantic-router/pkg/config/dryrun_redact.go
@@ -1,19 +1,30 @@
 package config
 
-import "strings"
+import (
+	"regexp"
+	"strings"
+)
 
 // RedactedConfigValue replaces plaintext secret fields in dry-run output.
 const RedactedConfigValue = "[REDACTED]"
 
+var environmentReferencePattern = regexp.MustCompile(
+	`^\$(?:\{[A-Za-z_][A-Za-z0-9_]*\}|[A-Za-z_][A-Za-z0-9_]*)$`,
+)
+
 // RedactSensitiveConfigValue replaces known secret keys with [REDACTED].
-// Environment-variable names (*_env) stay visible.
+// Environment-variable names (*_env) and pure ${VAR}/$VAR references stay visible.
 func RedactSensitiveConfigValue(value any) any {
 	switch typed := value.(type) {
 	case map[string]interface{}:
 		out := make(map[string]interface{}, len(typed))
 		for key, nested := range typed {
 			if isSensitiveConfigKey(key) {
-				out[key] = RedactedConfigValue
+				if isPureEnvironmentReference(nested) {
+					out[key] = nested
+				} else {
+					out[key] = RedactedConfigValue
+				}
 				continue
 			}
 			out[key] = RedactSensitiveConfigValue(nested)
@@ -30,15 +41,22 @@ func RedactSensitiveConfigValue(value any) any {
 	}
 }
 
+func isPureEnvironmentReference(value any) bool {
+	text, ok := value.(string)
+	return ok && environmentReferencePattern.MatchString(strings.TrimSpace(text))
+}
+
 func isSensitiveConfigKey(key string) bool {
 	normalized := strings.ToLower(strings.TrimSpace(key))
-	compact := strings.ReplaceAll(normalized, "_", "")
+	compact := strings.NewReplacer("_", "", "-", "", " ", "").Replace(normalized)
+	// Env var names (api_key_env) and presence flags stay visible.
 	if strings.HasSuffix(compact, "env") || strings.HasSuffix(compact, "envset") {
 		return false
 	}
 	switch compact {
-	case "apikey", "accesskey", "password", "authpassword",
-		"clientsecret", "privatekey", "secret":
+	case "apikey", "xapikey", "accesskey", "password", "authpassword",
+		"clientsecret", "privatekey", "authorization", "proxyauthorization",
+		"credential", "secret", "token":
 		return true
 	}
 	for _, suffix := range []string{
@@ -47,6 +65,9 @@ func isSensitiveConfigKey(key string) bool {
 		"password",
 		"clientsecret",
 		"privatekey",
+		"authorization",
+		"credential",
+		"token",
 	} {
 		if strings.HasSuffix(compact, suffix) {
 			return true

--- a/src/semantic-router/pkg/config/dryrun_redact.go
+++ b/src/semantic-router/pkg/config/dryrun_redact.go
@@ -1,0 +1,56 @@
+package config
+
+import "strings"
+
+// RedactedConfigValue replaces plaintext secret fields in dry-run output.
+const RedactedConfigValue = "[REDACTED]"
+
+// RedactSensitiveConfigValue replaces known secret keys with [REDACTED].
+// Environment-variable names (*_env) stay visible.
+func RedactSensitiveConfigValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]interface{}:
+		out := make(map[string]interface{}, len(typed))
+		for key, nested := range typed {
+			if isSensitiveConfigKey(key) {
+				out[key] = RedactedConfigValue
+				continue
+			}
+			out[key] = RedactSensitiveConfigValue(nested)
+		}
+		return out
+	case []interface{}:
+		out := make([]interface{}, len(typed))
+		for i, nested := range typed {
+			out[i] = RedactSensitiveConfigValue(nested)
+		}
+		return out
+	default:
+		return value
+	}
+}
+
+func isSensitiveConfigKey(key string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(key))
+	compact := strings.ReplaceAll(normalized, "_", "")
+	if strings.HasSuffix(compact, "env") || strings.HasSuffix(compact, "envset") {
+		return false
+	}
+	switch compact {
+	case "apikey", "accesskey", "password", "authpassword",
+		"clientsecret", "privatekey", "secret":
+		return true
+	}
+	for _, suffix := range []string{
+		"apikey",
+		"accesskey",
+		"password",
+		"clientsecret",
+		"privatekey",
+	} {
+		if strings.HasSuffix(compact, suffix) {
+			return true
+		}
+	}
+	return false
+}

--- a/src/semantic-router/pkg/config/dryrun_test.go
+++ b/src/semantic-router/pkg/config/dryrun_test.go
@@ -1,0 +1,260 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type evaluateGoldenCase struct {
+	name         string
+	file         string
+	wantValid    bool
+	wantCode     string
+	wantStage    string
+	wantField    string
+	wantSeverity string
+}
+
+func TestEvaluateGoldenCorpus(t *testing.T) {
+	cases := []evaluateGoldenCase{
+		{
+			name:      "valid",
+			file:      "valid.yaml",
+			wantValid: true,
+		},
+		{
+			name:         "unknown_field",
+			file:         "unknown-field.yaml",
+			wantValid:    false,
+			wantCode:     DiagnosticUnknownField,
+			wantStage:    StageParse,
+			wantField:    "not_a_real_field",
+			wantSeverity: SeverityError,
+		},
+		{
+			name:      "parse_error",
+			file:      "parse-error.yaml",
+			wantValid: false,
+			wantCode:  DiagnosticYAMLParseError,
+			wantStage: StageParse,
+		},
+		{
+			name:      "reference",
+			file:      "reference.yaml",
+			wantValid: false,
+			wantCode:  DiagnosticReferenceError,
+			wantStage: StageResolve,
+			wantField: "routing.decisions",
+		},
+		{
+			name:      "cycle",
+			file:      "cycle.yaml",
+			wantValid: false,
+			wantCode:  DiagnosticCycleError,
+			wantStage: StageResolve,
+			wantField: "routing.projections.scores",
+		},
+		{
+			name:      "quorum",
+			file:      "quorum.yaml",
+			wantValid: false,
+			wantCode:  DiagnosticQuorumError,
+			wantField: "routing.decisions",
+		},
+		{
+			name:      "budget",
+			file:      "budget.yaml",
+			wantValid: false,
+			wantCode:  DiagnosticBudgetError,
+		},
+		{
+			name:      "fallback",
+			file:      "fallback.yaml",
+			wantValid: false,
+			wantCode:  DiagnosticFallbackError,
+			wantField: "routing.decisions",
+		},
+		{
+			name:      "conflict",
+			file:      "conflict.yaml",
+			wantValid: false,
+			wantCode:  DiagnosticConflict,
+		},
+		{
+			name:      "capability",
+			file:      "capability.yaml",
+			wantValid: false,
+			wantCode:  DiagnosticCapabilityError,
+			wantField: "routing.decisions",
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			assertEvaluateGoldenCase(t, testCase, Evaluate(readDryRunTestdata(t, testCase.file), EvaluateOptions{}))
+		})
+	}
+}
+
+func assertEvaluateGoldenCase(t *testing.T, testCase evaluateGoldenCase, result EvaluateResult) {
+	t.Helper()
+	if result.ContractVersion != DiagnosticContractVersion {
+		t.Fatalf("contract_version = %q", result.ContractVersion)
+	}
+	if result.Valid != testCase.wantValid {
+		t.Fatalf("valid = %v, want %v, errors=%v warnings=%v", result.Valid, testCase.wantValid, result.Errors, result.Warnings)
+	}
+	if testCase.wantCode == "" {
+		if len(result.Errors) != 0 {
+			t.Fatalf("unexpected errors: %+v", result.Errors)
+		}
+		return
+	}
+	found := findDiagnostic(append(append([]Diagnostic{}, result.Errors...), result.Warnings...), testCase.wantCode)
+	if found == nil {
+		t.Fatalf("missing code %s, errors=%+v warnings=%+v", testCase.wantCode, result.Errors, result.Warnings)
+	}
+	if testCase.wantStage != "" && found.Stage != testCase.wantStage {
+		t.Fatalf("stage = %q, want %q", found.Stage, testCase.wantStage)
+	}
+	if testCase.wantField != "" && !strings.Contains(found.Field, testCase.wantField) {
+		t.Fatalf("field = %q, want substring %q", found.Field, testCase.wantField)
+	}
+	if testCase.wantSeverity != "" && found.Severity != testCase.wantSeverity {
+		t.Fatalf("severity = %q, want %q", found.Severity, testCase.wantSeverity)
+	}
+}
+
+func TestEvaluateRedactsSecretsAndPreservesEnvNames(t *testing.T) {
+	const secret = "super-secret-value"
+	result := Evaluate(readDryRunTestdata(t, "redaction.yaml"), EvaluateOptions{
+		CompareToActive: true,
+		ActiveYAML:      readDryRunTestdata(t, "active.yaml"),
+	})
+	if !result.Valid {
+		t.Fatalf("expected valid redaction document, errors=%+v", result.Errors)
+	}
+	if strings.Contains(result.NormalizedYAML, secret) {
+		t.Fatal("normalized YAML leaked a secret")
+	}
+	if !strings.Contains(result.NormalizedYAML, "MY_API_KEY") {
+		t.Fatalf("normalized YAML dropped api_key_env: %s", result.NormalizedYAML)
+	}
+	if !strings.Contains(result.NormalizedYAML, RedactedConfigValue) {
+		t.Fatalf("normalized YAML missing redaction marker: %s", result.NormalizedYAML)
+	}
+	if result.Diff == nil {
+		t.Fatal("expected diff against active snapshot")
+	}
+	if leaked := secretInDiff(result.Diff, secret); leaked != "" {
+		t.Fatalf("diff leaked secret in %s", leaked)
+	}
+}
+
+func TestEvaluateDiffIsBoundedAndSchemaAware(t *testing.T) {
+	result := Evaluate(readDryRunTestdata(t, "valid.yaml"), EvaluateOptions{
+		CompareToActive: true,
+		ActiveYAML:      readDryRunTestdata(t, "active.yaml"),
+	})
+	if result.Diff == nil {
+		t.Fatal("expected diff")
+	}
+	if result.Diff.Truncated {
+		t.Fatal("small diff should not be truncated")
+	}
+	foundDescription := false
+	for _, entry := range result.Diff.Changed {
+		if strings.Contains(entry.Field, `routing.modelCards["m1"]`) {
+			foundDescription = true
+		}
+		if strings.Contains(fmtAny(entry.Old), "active-secret") || strings.Contains(fmtAny(entry.New), "active-secret") {
+			t.Fatalf("diff exposed active secret: %+v", entry)
+		}
+	}
+	if !foundDescription && len(result.Diff.Changed)+len(result.Diff.Added)+len(result.Diff.Removed) == 0 {
+		t.Fatalf("expected a named modelCard or secret-field diff, got %+v", result.Diff)
+	}
+}
+
+func TestEvaluateCompareWithoutActiveAddsWarning(t *testing.T) {
+	result := Evaluate(readDryRunTestdata(t, "valid.yaml"), EvaluateOptions{CompareToActive: true})
+	if result.Diff != nil {
+		t.Fatalf("expected omitted diff, got %+v", result.Diff)
+	}
+	if findDiagnostic(result.Warnings, DiagnosticNoActiveSnapshot) == nil {
+		t.Fatalf("expected no-active-snapshot warning, got %+v", result.Warnings)
+	}
+}
+
+func TestDiffCanonicalDocumentsTruncatesAtBound(t *testing.T) {
+	active := map[string]interface{}{"items": map[string]interface{}{}}
+	candidate := map[string]interface{}{"items": map[string]interface{}{}}
+	activeItems := active["items"].(map[string]interface{})
+	candidateItems := candidate["items"].(map[string]interface{})
+	for i := 0; i < DiffEntryLimit+25; i++ {
+		key := fmt.Sprintf("k%03d", i)
+		activeItems[key] = i
+		candidateItems[key] = i + 1
+	}
+	diff := DiffCanonicalDocuments(active, candidate)
+	if !diff.Truncated {
+		t.Fatal("expected truncated flag")
+	}
+	if got := len(diff.Added) + len(diff.Removed) + len(diff.Changed); got > DiffEntryLimit {
+		t.Fatalf("diff size %d exceeds bound %d", got, DiffEntryLimit)
+	}
+}
+
+func TestEvaluateDoesNotMutateCandidateBytes(t *testing.T) {
+	candidate := readDryRunTestdata(t, "valid.yaml")
+	before := string(candidate)
+	_ = Evaluate(candidate, EvaluateOptions{
+		CompareToActive: true,
+		ActiveYAML:      readDryRunTestdata(t, "active.yaml"),
+	})
+	if string(candidate) != before {
+		t.Fatal("Evaluate mutated the candidate buffer")
+	}
+}
+
+func readDryRunTestdata(t *testing.T, name string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("testdata", "dryrun", name))
+	if err != nil {
+		t.Fatalf("read testdata %s: %v", name, err)
+	}
+	return data
+}
+
+func findDiagnostic(diagnostics []Diagnostic, code string) *Diagnostic {
+	for i := range diagnostics {
+		if diagnostics[i].Code == code {
+			return &diagnostics[i]
+		}
+	}
+	return nil
+}
+
+func secretInDiff(diff *ConfigDiff, secret string) string {
+	if diff == nil {
+		return ""
+	}
+	for _, group := range [][]DiffEntry{diff.Added, diff.Removed, diff.Changed} {
+		for _, entry := range group {
+			if strings.Contains(fmtAny(entry.Old), secret) || strings.Contains(fmtAny(entry.New), secret) {
+				return entry.Field
+			}
+		}
+	}
+	return ""
+}
+
+func fmtAny(value any) string {
+	if value == nil {
+		return ""
+	}
+	return fmt.Sprintf("%v", value)
+}

--- a/src/semantic-router/pkg/config/dryrun_test.go
+++ b/src/semantic-router/pkg/config/dryrun_test.go
@@ -154,6 +154,117 @@ func TestEvaluateRedactsSecretsAndPreservesEnvNames(t *testing.T) {
 	}
 }
 
+func TestRedactSensitiveConfigValueCoversSchemaSecretContract(t *testing.T) {
+	t.Parallel()
+
+	input := map[string]interface{}{
+		"api_key":         "plain-secret",
+		"api_key_env":     "OPENAI_API_KEY",
+		"auth_token":      "auth-token",
+		"Authorization":   "Bearer authorization-token",
+		"x-api-key":       "header-token",
+		"access_token":    "access-token",
+		"client_secret":   "${CLIENT_SECRET:-literal-fallback}",
+		"password":        "$DB_PASSWORD",
+		"tokens_per_unit": 100,
+		"token_filter":    "keep",
+		"llama_stack": map[string]interface{}{
+			"auth_token": "llama-stack-bearer",
+		},
+	}
+
+	redacted, ok := RedactSensitiveConfigValue(input).(map[string]interface{})
+	if !ok {
+		t.Fatal("expected map result")
+	}
+	for _, key := range []string{"api_key", "auth_token", "Authorization", "x-api-key", "access_token"} {
+		if redacted[key] != RedactedConfigValue {
+			t.Fatalf("%s = %v, want %q", key, redacted[key], RedactedConfigValue)
+		}
+	}
+	if redacted["api_key_env"] != "OPENAI_API_KEY" {
+		t.Fatalf("api_key_env should remain visible, got %v", redacted["api_key_env"])
+	}
+	if redacted["password"] != "$DB_PASSWORD" {
+		t.Fatalf("pure environment password reference should remain visible, got %v", redacted["password"])
+	}
+	if redacted["client_secret"] != RedactedConfigValue {
+		t.Fatalf("environment reference with literal fallback must be redacted, got %v", redacted["client_secret"])
+	}
+	if redacted["tokens_per_unit"] != 100 {
+		t.Fatal("tokens_per_unit should not be redacted")
+	}
+	if redacted["token_filter"] != "keep" {
+		t.Fatal("token_filter should not be redacted")
+	}
+	stack := redacted["llama_stack"].(map[string]interface{})
+	if stack["auth_token"] != RedactedConfigValue {
+		t.Fatalf("canonical llama_stack.auth_token = %v, want %q", stack["auth_token"], RedactedConfigValue)
+	}
+}
+
+func TestEvaluateRedactsAuthTokenFromActiveDiff(t *testing.T) {
+	const activeToken = "active-bearer-token"
+	const candidateToken = "candidate-bearer-token"
+	document := func(token string) []byte {
+		return []byte(`
+version: v0.3
+listeners: []
+providers:
+  defaults:
+    model: m1
+  models:
+    - name: m1
+      backend_refs:
+        - endpoint: 127.0.0.1:8000
+          provider: vllm
+routing:
+  modelCards:
+    - name: m1
+  decisions:
+    - name: d1
+      priority: 1
+      rules: {operator: AND, conditions: []}
+      modelRefs:
+        - model: m1
+          use_reasoning: false
+global:
+  stores:
+    vector_store:
+      enabled: true
+      backend_type: llama_stack
+      llama_stack:
+        endpoint: http://llama-stack:8321
+        auth_token: ` + token + `
+`)
+	}
+	result := Evaluate(document(candidateToken), EvaluateOptions{
+		CompareToActive: true,
+		ActiveYAML:      document(activeToken),
+	})
+	if leaked := secretInDiff(result.Diff, activeToken); leaked != "" {
+		t.Fatalf("diff leaked active auth_token in %s", leaked)
+	}
+	if leaked := secretInDiff(result.Diff, candidateToken); leaked != "" {
+		t.Fatalf("diff leaked candidate auth_token in %s", leaked)
+	}
+	if result.Diff == nil {
+		t.Fatal("expected diff against an active snapshot that includes auth_token")
+	}
+	found := false
+	for _, entry := range result.Diff.Changed {
+		if strings.Contains(entry.Field, "auth_token") {
+			found = true
+			if entry.Old != RedactedConfigValue || entry.New != RedactedConfigValue {
+				t.Fatalf("auth_token diff = %+v, want redacted old and new", entry)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected an auth_token change, got %+v", result.Diff)
+	}
+}
+
 func TestEvaluateDiffIsBoundedAndSchemaAware(t *testing.T) {
 	result := Evaluate(readDryRunTestdata(t, "valid.yaml"), EvaluateOptions{
 		CompareToActive: true,

--- a/src/semantic-router/pkg/config/loader.go
+++ b/src/semantic-router/pkg/config/loader.go
@@ -144,6 +144,7 @@ func parseYAMLBytesWithOptions(
 		return nil, err
 	}
 	cfg.ConfigBaseDir = baseDir
+	cfg.SourceDocument = append([]byte(nil), data...)
 	documentDigest := sha256.Sum256(data)
 	cfg.DocumentHash = hex.EncodeToString(documentDigest[:])
 	cfg.SkipExternalAssetValidation = !expandEnvironment

--- a/src/semantic-router/pkg/config/loader_document_hash_test.go
+++ b/src/semantic-router/pkg/config/loader_document_hash_test.go
@@ -18,6 +18,9 @@ func TestParseYAMLBytesRecordsExactDocumentHash(t *testing.T) {
 	if cfg.DocumentHash != want {
 		t.Fatalf("DocumentHash = %q, want %q", cfg.DocumentHash, want)
 	}
+	if string(cfg.SourceDocument) != string(document) {
+		t.Fatal("SourceDocument should retain the exact parsed YAML bytes")
+	}
 }
 
 func TestParseYAMLBytesDocumentHashTracksFormattingChanges(t *testing.T) {

--- a/src/semantic-router/pkg/config/loader_document_hash_test.go
+++ b/src/semantic-router/pkg/config/loader_document_hash_test.go
@@ -2,7 +2,10 @@ package config
 
 import (
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -34,5 +37,32 @@ func TestParseYAMLBytesDocumentHashTracksFormattingChanges(t *testing.T) {
 	}
 	if first.DocumentHash == second.DocumentHash {
 		t.Fatal("document hash should identify the exact runtime file, including formatting")
+	}
+}
+
+func TestRouterConfigJSONOmitsSourceDocument(t *testing.T) {
+	const canary = "redact-me-canary-value-0001"
+	cfg := &RouterConfig{
+		ConfigBaseDir:  "/tmp/runtime-only",
+		DocumentHash:   "runtime-hash",
+		SourceDocument: []byte("auth_token: " + canary + "\n"),
+	}
+	encodedSource := base64.StdEncoding.EncodeToString(cfg.SourceDocument)
+
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("json.Marshal(RouterConfig) error = %v", err)
+	}
+	body := string(data)
+	if strings.Contains(body, canary) {
+		t.Fatalf("RouterConfig JSON leaked SourceDocument canary: %s", body)
+	}
+	if strings.Contains(body, encodedSource) {
+		t.Fatalf("RouterConfig JSON leaked encoded SourceDocument: %s", body)
+	}
+	for _, key := range []string{"SourceDocument", "sourceDocument", "DocumentHash", "documentHash", "ConfigBaseDir", "configBaseDir"} {
+		if strings.Contains(body, `"`+key+`"`) {
+			t.Fatalf("RouterConfig JSON included runtime-only field %q: %s", key, body)
+		}
 	}
 }

--- a/src/semantic-router/pkg/config/testdata/dryrun/active.yaml
+++ b/src/semantic-router/pkg/config/testdata/dryrun/active.yaml
@@ -2,11 +2,12 @@ version: v0.3
 listeners: []
 providers:
   defaults:
-    default_model: m1
+    model: m1
   models:
     - name: m1
       backend_refs:
         - endpoint: 127.0.0.1:8000
+          provider: vllm
           api_key: active-secret
 routing:
   modelCards:

--- a/src/semantic-router/pkg/config/testdata/dryrun/active.yaml
+++ b/src/semantic-router/pkg/config/testdata/dryrun/active.yaml
@@ -1,0 +1,21 @@
+version: v0.3
+listeners: []
+providers:
+  defaults:
+    default_model: m1
+  models:
+    - name: m1
+      backend_refs:
+        - endpoint: 127.0.0.1:8000
+          api_key: active-secret
+routing:
+  modelCards:
+    - name: m1
+      description: active-card
+  decisions:
+    - name: d1
+      priority: 1
+      rules: {operator: AND, conditions: []}
+      modelRefs:
+        - model: m1
+          use_reasoning: false

--- a/src/semantic-router/pkg/config/testdata/dryrun/budget.yaml
+++ b/src/semantic-router/pkg/config/testdata/dryrun/budget.yaml
@@ -1,0 +1,26 @@
+version: v0.3
+listeners: []
+providers:
+  defaults:
+    default_model: m1
+  models:
+    - name: m1
+      backend_refs:
+        - endpoint: 127.0.0.1:8000
+routing:
+  modelCards:
+    - name: m1
+  decisions:
+    - name: compress
+      priority: 1
+      rules: {operator: AND, conditions: []}
+      modelRefs:
+        - model: m1
+          use_reasoning: false
+      plugins:
+        - type: context_compression
+          configuration:
+            enabled: true
+            budget:
+              trigger_tokens: 100
+              target_tokens: 200

--- a/src/semantic-router/pkg/config/testdata/dryrun/budget.yaml
+++ b/src/semantic-router/pkg/config/testdata/dryrun/budget.yaml
@@ -2,11 +2,12 @@ version: v0.3
 listeners: []
 providers:
   defaults:
-    default_model: m1
+    model: m1
   models:
     - name: m1
       backend_refs:
         - endpoint: 127.0.0.1:8000
+          provider: vllm
 routing:
   modelCards:
     - name: m1

--- a/src/semantic-router/pkg/config/testdata/dryrun/capability.yaml
+++ b/src/semantic-router/pkg/config/testdata/dryrun/capability.yaml
@@ -1,0 +1,26 @@
+version: v0.3
+listeners: []
+providers:
+  defaults:
+    default_model: m1
+  models:
+    - name: m1
+      backend_refs:
+        - endpoint: 127.0.0.1:8000
+routing:
+  modelCards:
+    - name: m1
+  decisions:
+    - name: flow
+      priority: 1
+      rules: {operator: AND, conditions: []}
+      modelRefs:
+        - model: m1
+          use_reasoning: false
+      algorithm:
+        type: workflows
+        workflows:
+          mode: static
+          roles:
+            - name: worker
+              models: [ghost]

--- a/src/semantic-router/pkg/config/testdata/dryrun/capability.yaml
+++ b/src/semantic-router/pkg/config/testdata/dryrun/capability.yaml
@@ -2,11 +2,12 @@ version: v0.3
 listeners: []
 providers:
   defaults:
-    default_model: m1
+    model: m1
   models:
     - name: m1
       backend_refs:
         - endpoint: 127.0.0.1:8000
+          provider: vllm
 routing:
   modelCards:
     - name: m1

--- a/src/semantic-router/pkg/config/testdata/dryrun/conflict.yaml
+++ b/src/semantic-router/pkg/config/testdata/dryrun/conflict.yaml
@@ -1,0 +1,25 @@
+version: v0.3
+listeners: []
+providers:
+  defaults:
+    default_model: m1
+  models:
+    - name: m1
+      backend_refs:
+        - endpoint: 127.0.0.1:8000
+routing:
+  modelCards:
+    - name: m1
+  decisions:
+    - name: dup
+      priority: 100
+      rules: {operator: AND, conditions: []}
+      modelRefs:
+        - model: m1
+          use_reasoning: false
+    - name: dup
+      priority: 50
+      rules: {operator: AND, conditions: []}
+      modelRefs:
+        - model: m1
+          use_reasoning: false

--- a/src/semantic-router/pkg/config/testdata/dryrun/conflict.yaml
+++ b/src/semantic-router/pkg/config/testdata/dryrun/conflict.yaml
@@ -2,11 +2,12 @@ version: v0.3
 listeners: []
 providers:
   defaults:
-    default_model: m1
+    model: m1
   models:
     - name: m1
       backend_refs:
         - endpoint: 127.0.0.1:8000
+          provider: vllm
 routing:
   modelCards:
     - name: m1

--- a/src/semantic-router/pkg/config/testdata/dryrun/cycle.yaml
+++ b/src/semantic-router/pkg/config/testdata/dryrun/cycle.yaml
@@ -1,0 +1,33 @@
+version: v0.3
+listeners: []
+providers:
+  defaults:
+    default_model: m1
+  models:
+    - name: m1
+      backend_refs:
+        - endpoint: 127.0.0.1:8000
+routing:
+  modelCards:
+    - name: m1
+  projections:
+    scores:
+      - name: alpha
+        method: weighted_sum
+        inputs:
+          - type: projection
+            name: beta
+            weight: 1.0
+      - name: beta
+        method: weighted_sum
+        inputs:
+          - type: projection
+            name: alpha
+            weight: 1.0
+  decisions:
+    - name: d1
+      priority: 1
+      rules: {operator: AND, conditions: []}
+      modelRefs:
+        - model: m1
+          use_reasoning: false

--- a/src/semantic-router/pkg/config/testdata/dryrun/cycle.yaml
+++ b/src/semantic-router/pkg/config/testdata/dryrun/cycle.yaml
@@ -2,11 +2,12 @@ version: v0.3
 listeners: []
 providers:
   defaults:
-    default_model: m1
+    model: m1
   models:
     - name: m1
       backend_refs:
         - endpoint: 127.0.0.1:8000
+          provider: vllm
 routing:
   modelCards:
     - name: m1

--- a/src/semantic-router/pkg/config/testdata/dryrun/fallback.yaml
+++ b/src/semantic-router/pkg/config/testdata/dryrun/fallback.yaml
@@ -1,0 +1,31 @@
+version: v0.3
+listeners: []
+providers:
+  defaults:
+    default_model: m1
+  models:
+    - name: m1
+      backend_refs:
+        - endpoint: 127.0.0.1:8000
+    - name: m2
+      backend_refs:
+        - endpoint: 127.0.0.1:8001
+routing:
+  modelCards:
+    - name: m1
+    - name: m2
+  decisions:
+    - name: prompt-select
+      priority: 1
+      rules: {operator: AND, conditions: []}
+      modelRefs:
+        - model: m1
+          use_reasoning: false
+        - model: m2
+          use_reasoning: false
+      algorithm:
+        type: prompt
+        on_error: skip
+        prompt:
+          model: m1
+          instructions: pick one

--- a/src/semantic-router/pkg/config/testdata/dryrun/fallback.yaml
+++ b/src/semantic-router/pkg/config/testdata/dryrun/fallback.yaml
@@ -2,14 +2,16 @@ version: v0.3
 listeners: []
 providers:
   defaults:
-    default_model: m1
+    model: m1
   models:
     - name: m1
       backend_refs:
         - endpoint: 127.0.0.1:8000
+          provider: vllm
     - name: m2
       backend_refs:
         - endpoint: 127.0.0.1:8001
+          provider: vllm
 routing:
   modelCards:
     - name: m1

--- a/src/semantic-router/pkg/config/testdata/dryrun/parse-error.yaml
+++ b/src/semantic-router/pkg/config/testdata/dryrun/parse-error.yaml
@@ -1,0 +1,2 @@
+version: v0.3
+providers: [

--- a/src/semantic-router/pkg/config/testdata/dryrun/quorum.yaml
+++ b/src/semantic-router/pkg/config/testdata/dryrun/quorum.yaml
@@ -1,0 +1,29 @@
+version: v0.3
+listeners: []
+providers:
+  defaults:
+    default_model: m1
+  models:
+    - name: m1
+      backend_refs:
+        - endpoint: 127.0.0.1:8000
+    - name: m2
+      backend_refs:
+        - endpoint: 127.0.0.1:8001
+routing:
+  modelCards:
+    - name: m1
+    - name: m2
+  decisions:
+    - name: fusion-panel
+      priority: 1
+      rules: {operator: AND, conditions: []}
+      modelRefs:
+        - model: m1
+          use_reasoning: false
+        - model: m2
+          use_reasoning: false
+      algorithm:
+        type: fusion
+        fusion:
+          min_successful_responses: 3

--- a/src/semantic-router/pkg/config/testdata/dryrun/quorum.yaml
+++ b/src/semantic-router/pkg/config/testdata/dryrun/quorum.yaml
@@ -2,14 +2,16 @@ version: v0.3
 listeners: []
 providers:
   defaults:
-    default_model: m1
+    model: m1
   models:
     - name: m1
       backend_refs:
         - endpoint: 127.0.0.1:8000
+          provider: vllm
     - name: m2
       backend_refs:
         - endpoint: 127.0.0.1:8001
+          provider: vllm
 routing:
   modelCards:
     - name: m1

--- a/src/semantic-router/pkg/config/testdata/dryrun/redaction.yaml
+++ b/src/semantic-router/pkg/config/testdata/dryrun/redaction.yaml
@@ -1,0 +1,21 @@
+version: v0.3
+listeners: []
+providers:
+  defaults:
+    default_model: m1
+  models:
+    - name: m1
+      backend_refs:
+        - endpoint: 127.0.0.1:8000
+          api_key: super-secret-value
+          api_key_env: MY_API_KEY
+routing:
+  modelCards:
+    - name: m1
+  decisions:
+    - name: d1
+      priority: 1
+      rules: {operator: AND, conditions: []}
+      modelRefs:
+        - model: m1
+          use_reasoning: false

--- a/src/semantic-router/pkg/config/testdata/dryrun/redaction.yaml
+++ b/src/semantic-router/pkg/config/testdata/dryrun/redaction.yaml
@@ -2,11 +2,12 @@ version: v0.3
 listeners: []
 providers:
   defaults:
-    default_model: m1
+    model: m1
   models:
     - name: m1
       backend_refs:
         - endpoint: 127.0.0.1:8000
+          provider: vllm
           api_key: super-secret-value
           api_key_env: MY_API_KEY
 routing:

--- a/src/semantic-router/pkg/config/testdata/dryrun/reference.yaml
+++ b/src/semantic-router/pkg/config/testdata/dryrun/reference.yaml
@@ -1,0 +1,28 @@
+version: v0.3
+listeners: []
+providers:
+  defaults:
+    default_model: m1
+  models:
+    - name: m1
+      backend_refs:
+        - endpoint: 127.0.0.1:8000
+routing:
+  modelCards:
+    - name: m1
+  signals:
+    keywords:
+      - name: hello
+        operator: OR
+        keywords: ["hi"]
+  decisions:
+    - name: triage
+      priority: 1
+      rules:
+        operator: OR
+        conditions:
+          - type: keyword
+            name: nope
+      modelRefs:
+        - model: m1
+          use_reasoning: false

--- a/src/semantic-router/pkg/config/testdata/dryrun/reference.yaml
+++ b/src/semantic-router/pkg/config/testdata/dryrun/reference.yaml
@@ -2,11 +2,12 @@ version: v0.3
 listeners: []
 providers:
   defaults:
-    default_model: m1
+    model: m1
   models:
     - name: m1
       backend_refs:
         - endpoint: 127.0.0.1:8000
+          provider: vllm
 routing:
   modelCards:
     - name: m1

--- a/src/semantic-router/pkg/config/testdata/dryrun/unknown-field.yaml
+++ b/src/semantic-router/pkg/config/testdata/dryrun/unknown-field.yaml
@@ -1,0 +1,20 @@
+version: v0.3
+listeners: []
+not_a_real_field: true
+providers:
+  defaults:
+    default_model: m1
+  models:
+    - name: m1
+      backend_refs:
+        - endpoint: 127.0.0.1:8000
+routing:
+  modelCards:
+    - name: m1
+  decisions:
+    - name: d1
+      priority: 1
+      rules: {operator: AND, conditions: []}
+      modelRefs:
+        - model: m1
+          use_reasoning: false

--- a/src/semantic-router/pkg/config/testdata/dryrun/unknown-field.yaml
+++ b/src/semantic-router/pkg/config/testdata/dryrun/unknown-field.yaml
@@ -3,11 +3,12 @@ listeners: []
 not_a_real_field: true
 providers:
   defaults:
-    default_model: m1
+    model: m1
   models:
     - name: m1
       backend_refs:
         - endpoint: 127.0.0.1:8000
+          provider: vllm
 routing:
   modelCards:
     - name: m1

--- a/src/semantic-router/pkg/config/testdata/dryrun/valid.yaml
+++ b/src/semantic-router/pkg/config/testdata/dryrun/valid.yaml
@@ -1,0 +1,19 @@
+version: v0.3
+listeners: []
+providers:
+  defaults:
+    default_model: m1
+  models:
+    - name: m1
+      backend_refs:
+        - endpoint: 127.0.0.1:8000
+routing:
+  modelCards:
+    - name: m1
+  decisions:
+    - name: d1
+      priority: 1
+      rules: {operator: AND, conditions: []}
+      modelRefs:
+        - model: m1
+          use_reasoning: false

--- a/src/semantic-router/pkg/config/testdata/dryrun/valid.yaml
+++ b/src/semantic-router/pkg/config/testdata/dryrun/valid.yaml
@@ -2,11 +2,12 @@ version: v0.3
 listeners: []
 providers:
   defaults:
-    default_model: m1
+    model: m1
   models:
     - name: m1
       backend_refs:
         - endpoint: 127.0.0.1:8000
+          provider: vllm
 routing:
   modelCards:
     - name: m1

--- a/src/semantic-router/pkg/config/validate.go
+++ b/src/semantic-router/pkg/config/validate.go
@@ -16,16 +16,49 @@ func validateKnownFields(raw map[string]interface{}, targetType reflect.Type) er
 	return fmt.Errorf("config contains unknown fields: %s", strings.Join(unknown, "; "))
 }
 
+type unknownFieldRecord struct {
+	Field   string
+	Message string
+}
+
+// CollectUnknownFieldDiagnostics returns schema-unknown YAML keys as
+// field-addressable diagnostics. The loader treats these as fatal; Evaluate
+// surfaces the same findings on the v1 validate contract.
+func CollectUnknownFieldDiagnostics(raw map[string]interface{}) []Diagnostic {
+	records := collectUnknownFieldRecords(raw, reflect.TypeOf(CanonicalConfig{}))
+	diagnostics := make([]Diagnostic, 0, len(records))
+	for _, record := range records {
+		diagnostics = append(diagnostics, Diagnostic{
+			Code:     DiagnosticUnknownField,
+			Severity: SeverityError,
+			Resource: resourceFromField(record.Field),
+			Stage:    StageParse,
+			Field:    record.Field,
+			Message:  record.Message,
+		})
+	}
+	return diagnostics
+}
+
 // collectUnknownFields returns path-aware diagnostics for keys not represented
 // by the canonical Go contract. Opaque StructuredPayload values are excluded;
 // their discriminator-specific validators own those nested fields.
 func collectUnknownFields(raw map[string]interface{}, targetType reflect.Type) []string {
-	var diagnostics []string
-	collectUnknownFieldsRecursive(raw, targetType, "", &diagnostics)
+	records := collectUnknownFieldRecords(raw, targetType)
+	diagnostics := make([]string, 0, len(records))
+	for _, record := range records {
+		diagnostics = append(diagnostics, record.Message)
+	}
 	return diagnostics
 }
 
-func collectUnknownFieldsRecursive(raw map[string]interface{}, t reflect.Type, path string, out *[]string) {
+func collectUnknownFieldRecords(raw map[string]interface{}, targetType reflect.Type) []unknownFieldRecord {
+	var records []unknownFieldRecord
+	collectUnknownFieldsRecursive(raw, targetType, "", &records)
+	return records
+}
+
+func collectUnknownFieldsRecursive(raw map[string]interface{}, t reflect.Type, path string, out *[]unknownFieldRecord) {
 	t = derefType(t)
 	if t.Kind() != reflect.Struct {
 		return
@@ -38,7 +71,10 @@ func collectUnknownFieldsRecursive(raw map[string]interface{}, t reflect.Type, p
 	for key := range raw {
 		entry, ok := known[key]
 		if !ok {
-			*out = append(*out, formatUnknownField(key, path, known))
+			*out = append(*out, unknownFieldRecord{
+				Field:   joinPath(path, key),
+				Message: formatUnknownField(key, path, known),
+			})
 			continue
 		}
 		recurseIntoValue(raw[key], entry.fieldType, joinPath(path, key), out)
@@ -67,7 +103,7 @@ func closestField(unknown string, known map[string]fieldEntry) string {
 	return best
 }
 
-func recurseIntoValue(value interface{}, fieldType reflect.Type, path string, out *[]string) {
+func recurseIntoValue(value interface{}, fieldType reflect.Type, path string, out *[]unknownFieldRecord) {
 	if fieldType == nil {
 		return
 	}
@@ -86,7 +122,7 @@ func recurseIntoValue(value interface{}, fieldType reflect.Type, path string, ou
 	}
 }
 
-func recurseIntoSlice(value interface{}, ft reflect.Type, path string, out *[]string) {
+func recurseIntoSlice(value interface{}, ft reflect.Type, path string, out *[]unknownFieldRecord) {
 	elemType := derefType(ft.Elem())
 	if elemType.Kind() != reflect.Struct {
 		return
@@ -103,7 +139,7 @@ func recurseIntoSlice(value interface{}, ft reflect.Type, path string, out *[]st
 	}
 }
 
-func recurseIntoMap(value interface{}, ft reflect.Type, path string, out *[]string) {
+func recurseIntoMap(value interface{}, ft reflect.Type, path string, out *[]unknownFieldRecord) {
 	elemType := derefType(ft.Elem())
 	if elemType.Kind() != reflect.Struct {
 		return

--- a/tools/linter/yaml/.yamllint
+++ b/tools/linter/yaml/.yamllint
@@ -13,6 +13,8 @@ ignore: |
   # Jinja2 template files (contain {% %} and {{ }} syntax)
   **/*.template.yaml
   **/.vllm-sr/**
+  # Intentionally invalid YAML used as a parse-error fixture.
+  src/semantic-router/pkg/config/testdata/dryrun/parse-error.yaml
 
 rules:
   braces:

--- a/website/docs/api/apiserver.md
+++ b/website/docs/api/apiserver.md
@@ -282,7 +282,7 @@ Validate, inspect, apply, version, and roll back Router configuration and Recipe
 | `DELETE` | `/api/v1/config/recipes/{name}` | Delete an unreferenced named routing recipe; requires If-Match |
 | `GET` | `/api/v1/config/schema` | Discover the canonical Router configuration contract progressively or return the complete JSON Schema |
 | `GET` | `/api/v1/config` | Get the current router config as JSON (secrets redacted without secret_view) |
-| `POST` | `/api/v1/config/validate` | Validate and normalize a router config without writing it |
+| `POST` | `/api/v1/config/validate` | Validate and normalize a router config, returning v1 diagnostics and an optional redacted diff without writing it |
 | `POST` | `/api/v1/config/plan` | Plan an exact merge or replace mutation, including hot-reload compatibility, without writing it |
 | `PATCH` | `/api/v1/config` | Compare-and-swap merge of a router config update (validates, backs up, writes, triggers hot-reload) |
 | `PUT` | `/api/v1/config` | Compare-and-swap replacement of the router config (validates, backs up, writes, triggers hot-reload) |

--- a/website/docs/api/apiserver.md
+++ b/website/docs/api/apiserver.md
@@ -124,7 +124,7 @@ curl -i http://localhost:8080/api/v1/config \
 | Method | Path | Use |
 | --- | --- | --- |
 | `GET` | `/api/v1/config` | Read the active canonical configuration |
-| `POST` | `/api/v1/config/validate` | Validate and normalize without writing |
+| `POST` | `/api/v1/config/validate` | Validate and normalize without writing; returns v1 diagnostics and an optional redacted diff |
 | `POST` | `/api/v1/config/plan` | Plan the exact candidate and return the current/candidate ETags without writing |
 | `PATCH` | `/api/v1/config` | Merge, validate, persist, and hot-reload an update |
 | `PUT` | `/api/v1/config` | Replace, validate, persist, and hot-reload the document |

--- a/website/docs/tutorials/global/api-and-observability.md
+++ b/website/docs/tutorials/global/api-and-observability.md
@@ -39,14 +39,20 @@ it:
 POST /api/v1/config/validate
 Content-Type: application/json
 
-{"yaml":"version: v0.3\n..."}
+{"yaml":"version: v0.3\n...","compare_to_active":true}
 ```
 
-Successful responses include `valid: true` and the normalized canonical YAML.
-Validation uses the same parser and semantic checks as `PATCH /api/v1/config`
-and `PUT /api/v1/config`, but preserves `${ENV_VAR}` references verbatim rather
-than reading process secrets. The endpoint requires `config.read`; plaintext
-secret viewing is not implied.
+Successful and invalid candidate evaluations both return HTTP 200 with
+`contract_version: v1`. Existing fields `valid` and `normalized_yaml` keep their
+meaning. The response also includes field-addressable `errors` and `warnings`
+(`code`, `severity`, `resource`, `recipe`, `stage`, `field`, `message`). Set
+`compare_to_active: true` to include a bounded, schema-aware, redacted
+active-versus-candidate `diff`. Secrets are always `[REDACTED]`; `${ENV_VAR}`
+references and `*_env` names stay visible. Validation uses the same parser and
+semantic checks as `PATCH /api/v1/config` and `PUT /api/v1/config`. The path
+does not write desired config, the active snapshot, runtime state, persistence,
+or version history. The endpoint requires `config.read`; plaintext secret
+viewing is not implied.
 
 ### API
 

--- a/website/docs/tutorials/global/api-and-observability.md
+++ b/website/docs/tutorials/global/api-and-observability.md
@@ -47,12 +47,14 @@ Successful and invalid candidate evaluations both return HTTP 200 with
 meaning. The response also includes field-addressable `errors` and `warnings`
 (`code`, `severity`, `resource`, `recipe`, `stage`, `field`, `message`). Set
 `compare_to_active: true` to include a bounded, schema-aware, redacted
-active-versus-candidate `diff`. Secrets are always `[REDACTED]`; `${ENV_VAR}`
-references and `*_env` names stay visible. Validation uses the same parser and
-semantic checks as `PATCH /api/v1/config` and `PUT /api/v1/config`. The path
-does not write desired config, the active snapshot, runtime state, persistence,
-or version history. The endpoint requires `config.read`; plaintext secret
-viewing is not implied.
+active-versus-candidate `diff`. The active side is the verified in-memory
+runtime snapshot when one exists, otherwise the generated runtime document, not
+desired source after an override or failed activation. Secrets are always
+`[REDACTED]`; `${ENV_VAR}` references and `*_env` names stay visible.
+Validation uses the same parser and semantic checks as `PATCH /api/v1/config`
+and `PUT /api/v1/config`. The path does not write desired config, the active
+snapshot, runtime state, persistence, or version history. The endpoint requires
+`config.read`; plaintext secret viewing is not implied.
 
 ### API
 

--- a/website/static/openapi/apiserver/apiserver.openapi.json
+++ b/website/static/openapi/apiserver/apiserver.openapi.json
@@ -1366,8 +1366,8 @@
     },
     "/api/v1/config/validate": {
       "post": {
-        "summary": "Validate and normalize a router config without writing it",
-        "description": "Validate and normalize a router config without writing it",
+        "summary": "Validate and normalize a router config, returning v1 diagnostics and an optional redacted diff without writing it",
+        "description": "Validate and normalize a router config, returning v1 diagnostics and an optional redacted diff without writing it",
         "operationId": "post_api_v1_config_validate",
         "tags": [
           "config"
@@ -1450,6 +1450,9 @@
               "schema": {
                 "type": "object",
                 "properties": {
+                  "compare_to_active": {
+                    "type": "boolean"
+                  },
                   "yaml": {
                     "type": "string"
                   }


### PR DESCRIPTION
Closes #3477
Related #3188

## Purpose

Extend `POST /config/router/validate` additively with the v1 diagnostic contract from #3188. Later CLI and Dashboard work should call this API instead of adding another validator.

`config.Evaluate` owns parse, unknown-field warnings, semantic validation, redaction, and the optional source-vs-candidate diff. The handler does not write config, backups, or runtime state. Invalid candidates return HTTP 200 with `valid: false` and field-addressable errors. `compare_to_active` adds a bounded (500), redacted diff. Secrets stay `[REDACTED]`; `*_env` names stay visible. Auth remains `config.read`.

## Test Plan

- [x] `go test ./pkg/config/ -run 'TestEvaluate|TestDiffCanonical'`
- [x] `go test ./pkg/apiserver/ -run 'TestHandleConfigValidate|TestConfigValidateRoute'`
- [x] `go test ./...` in `src/semantic-router`
- [x] `make agent-lint` on the changed files
- [x] `make docs-check-translation-coverage`
- [x] `make build-e2e`
- [x] `make recipe-conformance-static`
- [ ] Live `make e2e-test E2E_PROFILE=envoy-ai-gateway` for `apiserver-config-validate`

## Test Result

The listed unit, HTTP, lint, docs, e2e-compile, and recipe-conformance checks passed. The new `apiserver-config-validate` baseline case is registered but was not run against a live cluster.