### PR TITLE
[Bug] update Debian security repository URL in Dockerfiles for CUDA and ROCm

### DIFF
--- a/src/vllm-sr/Dockerfile.cuda
+++ b/src/vllm-sr/Dockerfile.cuda
@@ -207,7 +207,8 @@ RUN if [ "$TARGETARCH" != "amd64" ]; then \
       echo "CUDA vllm-sr image only supports TARGETARCH=amd64, got: $TARGETARCH" && exit 1; \
     fi
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN sed -i 's|http://deb.debian.org/debian-security|https://security.debian.org/debian-security|g' /etc/apt/sources.list && \
+    apt-get update && apt-get install -y --no-install-recommends \
       build-essential \
       pkg-config \
       libssl-dev && \

--- a/src/vllm-sr/Dockerfile.rocm
+++ b/src/vllm-sr/Dockerfile.rocm
@@ -209,7 +209,8 @@ RUN if [ "$TARGETARCH" != "amd64" ]; then \
       echo "ROCm vllm-sr image only supports TARGETARCH=amd64, got: $TARGETARCH" && exit 1; \
     fi
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN sed -i 's|http://deb.debian.org/debian-security|https://security.debian.org/debian-security|g' /etc/apt/sources.list && \
+    apt-get update && apt-get install -y --no-install-recommends \
       build-essential \
       pkg-config \
       libssl-dev && \


### PR DESCRIPTION
## Purpose

fix #3528

Fix `Build vllm-sr-cuda` and `Build vllm-sr-rocm` CI failures caused by Debian security mirror 404.

Replace `http://deb.debian.org/debian-security` with `https://security.debian.org/debian-security` in `onnx-builder` stage. The official security.debian.org serves the package correctly; the deb.debian.org CDN node used by CI returns 404 for the URL-encoded package path.

Affected files:
- `src/vllm-sr/Dockerfile.cuda`
- `src/vllm-sr/Dockerfile.rocm`

## Test Plan

- Run CI for this PR
- Verify CUDA and ROCm build tasks pass

## Test Result

| Task | Result |
|------|--------|
| Build vllm-sr-cuda | ✅ Passed |
| Build vllm-sr-rocm | ✅ Passed |
| All other checks | ✅ Passed |

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category, such as `[Feature]`, `[Bug]`, `[Docs]`, `[Test]`, `[Research]`, `[Community]`, or `[CI/Build]`
- [x] The title does not stack prefixes such as `[Router][Docs]`; affected modules belong in labels and the PR body
- [x] The PR links an `accepted` issue with exactly one owner: one `wg/*` label for project work or `owner/maintainers` for repository governance
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
