### PR TITLE
[Bug] Skip ONNX weights when downloading candle embedding models

### DIFF
--- a/src/semantic-router/pkg/modeldownload/config_parser.go
+++ b/src/semantic-router/pkg/modeldownload/config_parser.go
@@ -134,7 +134,7 @@ func BuildModelSpecs(cfg *config.RouterConfig) ([]ModelSpec, error) {
 			RepoID:          repoID,
 			Revision:        "main",
 			RequiredFiles:   requiredFiles,
-			ExcludePatterns: excludePatternsByModel[path],
+			ExcludePatterns: excludePatternsByModel[config.ResolveModelPath(path)],
 		})
 	}
 
@@ -222,6 +222,12 @@ var onnxWeightExcludePatterns = []string{
 // the download exclude globs for artifacts the selected embedding backend never
 // loads. Only the candle backend is narrowed: OpenVINO consumes the ONNX exports
 // and the remote backend provisions no local embedding models.
+//
+// Keys are canonical registry paths (config.ResolveModelPath), matching how the
+// embedding runtime resolves the same fields before loading. Callers look the map
+// up by the resolved path too, so the narrowing holds whether the configured value
+// is the canonical directory or a registry alias, and whether or not the collected
+// provisioning paths have already been canonicalized upstream.
 func candleEmbeddingModelExcludePatterns(cfg *config.RouterConfig) map[string][]string {
 	excluded := make(map[string][]string)
 	if cfg.EmbeddingModels.EmbeddingBackend() != config.EmbeddingBackendCandle {
@@ -229,10 +235,11 @@ func candleEmbeddingModelExcludePatterns(cfg *config.RouterConfig) map[string][]
 	}
 
 	for path := range candleEmbeddingModelRequiredFiles(cfg) {
-		if path == "" || !strings.HasPrefix(path, "models/") {
+		resolved := config.ResolveModelPath(path)
+		if resolved == "" || !strings.HasPrefix(resolved, "models/") {
 			continue
 		}
-		excluded[path] = append([]string(nil), onnxWeightExcludePatterns...)
+		excluded[resolved] = append([]string(nil), onnxWeightExcludePatterns...)
 	}
 	return excluded
 }

--- a/src/semantic-router/pkg/modeldownload/config_parser.go
+++ b/src/semantic-router/pkg/modeldownload/config_parser.go
@@ -101,6 +101,7 @@ func BuildModelSpecs(cfg *config.RouterConfig) ([]ModelSpec, error) {
 	paths := filterDisabledOptionalModelPaths(cfg, extractProvisioningModelPaths(cfg))
 	requiredFilesByModel := ExtractRequiredFilesByModel(cfg)
 	addEmbeddingModelRequiredFiles(cfg, requiredFilesByModel)
+	excludePatternsByModel := candleEmbeddingModelExcludePatterns(cfg)
 
 	// Allow empty paths for API-only configurations
 	if len(paths) == 0 {
@@ -129,10 +130,11 @@ func BuildModelSpecs(cfg *config.RouterConfig) ([]ModelSpec, error) {
 		}
 
 		specs = append(specs, ModelSpec{
-			LocalPath:     path,
-			RepoID:        repoID,
-			Revision:      "main",
-			RequiredFiles: requiredFiles,
+			LocalPath:       path,
+			RepoID:          repoID,
+			Revision:        "main",
+			RequiredFiles:   requiredFiles,
+			ExcludePatterns: excludePatternsByModel[path],
 		})
 	}
 
@@ -202,6 +204,37 @@ func candleEmbeddingModelRequiredFiles(cfg *config.RouterConfig) map[string][]st
 	add(cfg.GemmaModelPath, gemmaDenseWeightFiles)
 	add(cfg.MultiModalModelPath, embeddingModelWeightFiles)
 	return required
+}
+
+// onnxWeightExcludePatterns match the ONNX inference exports published beside the
+// safetensors weights in the embedding model repositories. The candle runtime never
+// opens them, yet they dominate the snapshot size (about 4.3 GB of the 4.9 GB
+// mmbert-embed-32k-2d-matryoshka repository), so a candle deployment skips them at
+// download time. Small manifests such as onnx/model_config.json, which
+// config.MmBertAvailableLayers reads, are not matched and stay in the snapshot.
+var onnxWeightExcludePatterns = []string{
+	"*.onnx",
+	"*.onnx.data",
+	"*.onnx_data",
+}
+
+// candleEmbeddingModelExcludePatterns returns, per configured embedding model path,
+// the download exclude globs for artifacts the selected embedding backend never
+// loads. Only the candle backend is narrowed: OpenVINO consumes the ONNX exports
+// and the remote backend provisions no local embedding models.
+func candleEmbeddingModelExcludePatterns(cfg *config.RouterConfig) map[string][]string {
+	excluded := make(map[string][]string)
+	if cfg.EmbeddingModels.EmbeddingBackend() != config.EmbeddingBackendCandle {
+		return excluded
+	}
+
+	for path := range candleEmbeddingModelRequiredFiles(cfg) {
+		if path == "" || !strings.HasPrefix(path, "models/") {
+			continue
+		}
+		excluded[path] = append([]string(nil), onnxWeightExcludePatterns...)
+	}
+	return excluded
 }
 
 // addEmbeddingModelRequiredFiles marks every configured candle embedding model as

--- a/src/semantic-router/pkg/modeldownload/download_scope_test.go
+++ b/src/semantic-router/pkg/modeldownload/download_scope_test.go
@@ -1,0 +1,103 @@
+package modeldownload
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+// TestBuildModelSpecsExcludesOnnxWeightsForCandleEmbeddingModels guards the download
+// scope for the default local backend: the candle runtime loads model.safetensors +
+// tokenizer.json, so the multi-gigabyte ONNX exports shipped in the same repository
+// must not be fetched. Every candle embedding path gets the same narrowing.
+func TestBuildModelSpecsExcludesOnnxWeightsForCandleEmbeddingModels(t *testing.T) {
+	specs, err := BuildModelSpecs(newCandleEmbeddingConfig())
+	if err != nil {
+		t.Fatalf("BuildModelSpecs() error = %v", err)
+	}
+
+	for _, modelPath := range []string{
+		testEmbeddingModelPath,
+		testQwen3ModelPath,
+		testGemmaModelPath,
+		testMultiModalModelPath,
+	} {
+		spec, ok := findSpecByPath(specs, modelPath)
+		if !ok {
+			t.Fatalf("BuildModelSpecs() did not produce a spec for %q", modelPath)
+		}
+		if !reflect.DeepEqual(spec.ExcludePatterns, onnxWeightExcludePatterns) {
+			t.Fatalf("%s ExcludePatterns = %#v, want %#v", modelPath, spec.ExcludePatterns, onnxWeightExcludePatterns)
+		}
+	}
+}
+
+// TestBuildModelSpecsKeepsFullSnapshotForOpenVINOBackend keeps ONNX deployments whole:
+// the OpenVINO embedding backend consumes the ONNX exports, so it must keep receiving
+// the unfiltered repository.
+func TestBuildModelSpecsKeepsFullSnapshotForOpenVINOBackend(t *testing.T) {
+	cfg := newCandleEmbeddingConfig()
+	cfg.EmbeddingModels.EmbeddingConfig = config.HNSWConfig{
+		Backend: config.EmbeddingBackendOpenVINO,
+	}
+
+	specs, err := BuildModelSpecs(cfg)
+	if err != nil {
+		t.Fatalf("BuildModelSpecs() error = %v", err)
+	}
+
+	for _, spec := range specs {
+		if len(spec.ExcludePatterns) != 0 {
+			t.Fatalf("%s ExcludePatterns = %#v, want none for the openvino backend", spec.LocalPath, spec.ExcludePatterns)
+		}
+	}
+}
+
+// TestBuildModelSpecsLeavesNonEmbeddingModelsUnfiltered limits the blast radius to the
+// embedding runtime: other locally provisioned models keep the full snapshot until their
+// own runtime contract is encoded.
+func TestBuildModelSpecsLeavesNonEmbeddingModelsUnfiltered(t *testing.T) {
+	const bertModelPath = "models/all-MiniLM-L12-v2"
+	cfg := newEmbeddingOnlyConfig()
+	cfg.MoMRegistry[bertModelPath] = "sentence-transformers/all-MiniLM-L12-v2"
+	cfg.BertModelPath = bertModelPath
+
+	specs, err := BuildModelSpecs(cfg)
+	if err != nil {
+		t.Fatalf("BuildModelSpecs() error = %v", err)
+	}
+
+	spec, ok := findSpecByPath(specs, bertModelPath)
+	if !ok {
+		t.Fatalf("BuildModelSpecs() did not produce a spec for %q; got %#v", bertModelPath, specs)
+	}
+	if len(spec.ExcludePatterns) != 0 {
+		t.Fatalf("%s ExcludePatterns = %#v, want none", bertModelPath, spec.ExcludePatterns)
+	}
+}
+
+// TestOnnxWeightExcludePatternsNeverMatchCandleRequiredFiles keeps the exclude list
+// and the completeness contract aligned: a pattern that matched a hard-loaded file
+// would make every download incomplete and loop forever.
+func TestOnnxWeightExcludePatternsNeverMatchCandleRequiredFiles(t *testing.T) {
+	required := candleEmbeddingModelRequiredFiles(newCandleEmbeddingConfig())
+	protected := append([]string{}, DefaultRequiredFiles...)
+	protected = append(protected, "onnx/model_config.json")
+	for _, files := range required {
+		protected = append(protected, files...)
+	}
+
+	for _, pattern := range onnxWeightExcludePatterns {
+		suffix := strings.TrimPrefix(pattern, "*")
+		if suffix == pattern {
+			t.Fatalf("exclude pattern %q must be a suffix glob so it cannot shadow required files", pattern)
+		}
+		for _, file := range protected {
+			if strings.HasSuffix(file, suffix) {
+				t.Fatalf("exclude pattern %q matches required file %q", pattern, file)
+			}
+		}
+	}
+}

--- a/src/semantic-router/pkg/modeldownload/download_scope_test.go
+++ b/src/semantic-router/pkg/modeldownload/download_scope_test.go
@@ -34,6 +34,45 @@ func TestBuildModelSpecsExcludesOnnxWeightsForCandleEmbeddingModels(t *testing.T
 	}
 }
 
+// TestBuildModelSpecsExcludesOnnxWeightsForAliasedEmbeddingModel keeps the narrowing
+// attached to the model when the config names it by a registry alias. The exclude map
+// is keyed and looked up by the canonical path, so it must match whether the collected
+// provisioning path is the literal alias or has already been canonicalized (#2828).
+func TestBuildModelSpecsExcludesOnnxWeightsForAliasedEmbeddingModel(t *testing.T) {
+	for _, configured := range []string{
+		"models/mom-embedding-ultra", // models/-prefixed alias
+		testEmbeddingModelPath,       // canonical path
+	} {
+		t.Run(configured, func(t *testing.T) {
+			cfg := &config.RouterConfig{
+				MoMRegistry: config.ToLegacyRegistry(),
+				InlineModels: config.InlineModels{
+					EmbeddingModels: config.EmbeddingModels{MmBertModelPath: configured},
+				},
+			}
+
+			specs, err := BuildModelSpecs(cfg)
+			if err != nil {
+				t.Fatalf("BuildModelSpecs() error = %v", err)
+			}
+
+			found := false
+			for _, spec := range specs {
+				if config.ResolveModelPath(spec.LocalPath) != testEmbeddingModelPath {
+					continue
+				}
+				found = true
+				if !reflect.DeepEqual(spec.ExcludePatterns, onnxWeightExcludePatterns) {
+					t.Fatalf("%s ExcludePatterns = %#v, want %#v", spec.LocalPath, spec.ExcludePatterns, onnxWeightExcludePatterns)
+				}
+			}
+			if !found {
+				t.Fatalf("BuildModelSpecs() produced no spec resolving to %q; got %#v", testEmbeddingModelPath, specs)
+			}
+		})
+	}
+}
+
 // TestBuildModelSpecsKeepsFullSnapshotForOpenVINOBackend keeps ONNX deployments whole:
 // the OpenVINO embedding backend consumes the ONNX exports, so it must keep receiving
 // the unfiltered repository.

--- a/src/semantic-router/pkg/modeldownload/downloader.go
+++ b/src/semantic-router/pkg/modeldownload/downloader.go
@@ -118,8 +118,12 @@ func DownloadModelWithProgress(spec ModelSpec, config DownloadConfig) error {
 }
 
 // buildDownloadArgs assembles the huggingface-cli argument list for spec.
-// Exclude patterns are appended last because `--exclude` consumes every
-// positional value that follows it.
+//
+// Every exclude pattern gets its own `--exclude` flag. The typer-based `hf download`
+// takes `--exclude` as a repeatable single-value option, so `--exclude a b c` keeps
+// only `a` and treats `b` and `c` as extra positional filenames; the legacy
+// `huggingface-cli download` accepted `nargs=*`. Repeating the flag is the form both
+// CLIs parse the same way, whichever one the image ends up installing.
 func buildDownloadArgs(spec ModelSpec) []string {
 	args := []string{
 		"download",
@@ -132,9 +136,11 @@ func buildDownloadArgs(spec ModelSpec) []string {
 		args = append(args, "--revision", spec.Revision)
 	}
 
-	if len(spec.ExcludePatterns) > 0 {
-		args = append(args, "--exclude")
-		args = append(args, spec.ExcludePatterns...)
+	for _, pattern := range spec.ExcludePatterns {
+		if pattern == "" {
+			continue
+		}
+		args = append(args, "--exclude", pattern)
 	}
 
 	return args

--- a/src/semantic-router/pkg/modeldownload/downloader.go
+++ b/src/semantic-router/pkg/modeldownload/downloader.go
@@ -75,17 +75,7 @@ func IsGatedModelError(err error, repoID string, hfToken string) bool {
 func DownloadModelWithProgress(spec ModelSpec, config DownloadConfig) error {
 	logging.Infof("Downloading model: %s", spec.LocalPath)
 
-	// Build huggingface-cli command
-	args := []string{
-		"download",
-		spec.RepoID,
-		"--local-dir", spec.LocalPath,
-	}
-
-	// Add revision if specified
-	if spec.Revision != "" && spec.Revision != "main" {
-		args = append(args, "--revision", spec.Revision)
-	}
+	args := buildDownloadArgs(spec)
 
 	// Use detected CLI command, default to "hf"
 	cliCmd := hfCommand
@@ -125,6 +115,29 @@ func DownloadModelWithProgress(spec ModelSpec, config DownloadConfig) error {
 	logging.Infof("Successfully downloaded model: %s", spec.LocalPath)
 
 	return nil
+}
+
+// buildDownloadArgs assembles the huggingface-cli argument list for spec.
+// Exclude patterns are appended last because `--exclude` consumes every
+// positional value that follows it.
+func buildDownloadArgs(spec ModelSpec) []string {
+	args := []string{
+		"download",
+		spec.RepoID,
+		"--local-dir", spec.LocalPath,
+	}
+
+	// Add revision if specified
+	if spec.Revision != "" && spec.Revision != "main" {
+		args = append(args, "--revision", spec.Revision)
+	}
+
+	if len(spec.ExcludePatterns) > 0 {
+		args = append(args, "--exclude")
+		args = append(args, spec.ExcludePatterns...)
+	}
+
+	return args
 }
 
 // EnsureModels ensures all required models are downloaded

--- a/src/semantic-router/pkg/modeldownload/downloader_test.go
+++ b/src/semantic-router/pkg/modeldownload/downloader_test.go
@@ -2,6 +2,7 @@ package modeldownload
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -25,15 +26,16 @@ func TestBuildDownloadArgsFetchesFullSnapshotByDefault(t *testing.T) {
 	}
 }
 
-// TestBuildDownloadArgsAppendsExcludePatternsLast guards the CLI contract:
-// `--exclude` is variadic, so it must come after every other flag or it would
-// swallow them as patterns.
-func TestBuildDownloadArgsAppendsExcludePatternsLast(t *testing.T) {
+// TestBuildDownloadArgsRepeatsExcludeFlagPerPattern guards the CLI contract: the
+// typer-based `hf download` takes `--exclude` as a repeatable single-value option, so
+// one flag followed by several patterns silently drops all but the first and passes
+// the rest as positional filenames. Each pattern must carry its own flag.
+func TestBuildDownloadArgsRepeatsExcludeFlagPerPattern(t *testing.T) {
 	spec := ModelSpec{
 		LocalPath:       testEmbeddingModelPath,
 		RepoID:          testEmbeddingRepoID,
 		Revision:        "abc123",
-		ExcludePatterns: []string{"*.onnx", "*.onnx.data"},
+		ExcludePatterns: []string{"*.onnx", "*.onnx.data", "*.onnx_data"},
 	}
 
 	got := buildDownloadArgs(spec)
@@ -42,7 +44,47 @@ func TestBuildDownloadArgsAppendsExcludePatternsLast(t *testing.T) {
 		testEmbeddingRepoID,
 		"--local-dir", testEmbeddingModelPath,
 		"--revision", "abc123",
-		"--exclude", "*.onnx", "*.onnx.data",
+		"--exclude", "*.onnx",
+		"--exclude", "*.onnx.data",
+		"--exclude", "*.onnx_data",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("buildDownloadArgs() = %#v, want %#v", got, want)
+	}
+
+	// No two patterns may ever share one flag: with the typer CLI the second would be
+	// parsed as a positional filename instead of a filter.
+	flags := 0
+	for i, arg := range got {
+		if arg != "--exclude" {
+			continue
+		}
+		flags++
+		if i+1 >= len(got) || strings.HasPrefix(got[i+1], "-") {
+			t.Fatalf("buildDownloadArgs() = %#v: --exclude at %d carries no pattern", got, i)
+		}
+	}
+	if flags != len(spec.ExcludePatterns) {
+		t.Fatalf("buildDownloadArgs() = %#v: %d --exclude flags for %d patterns", got, flags, len(spec.ExcludePatterns))
+	}
+}
+
+// TestBuildDownloadArgsSkipsEmptyExcludePatterns keeps a stray empty entry from
+// producing a bare `--exclude` that would swallow nothing or error out.
+func TestBuildDownloadArgsSkipsEmptyExcludePatterns(t *testing.T) {
+	spec := ModelSpec{
+		LocalPath:       testEmbeddingModelPath,
+		RepoID:          testEmbeddingRepoID,
+		Revision:        "main",
+		ExcludePatterns: []string{"", "*.onnx", ""},
+	}
+
+	got := buildDownloadArgs(spec)
+	want := []string{
+		"download",
+		testEmbeddingRepoID,
+		"--local-dir", testEmbeddingModelPath,
+		"--exclude", "*.onnx",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("buildDownloadArgs() = %#v, want %#v", got, want)

--- a/src/semantic-router/pkg/modeldownload/downloader_test.go
+++ b/src/semantic-router/pkg/modeldownload/downloader_test.go
@@ -1,0 +1,50 @@
+package modeldownload
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestBuildDownloadArgsFetchesFullSnapshotByDefault keeps the historical contract for
+// models without a narrowed download scope: repo ID plus --local-dir, nothing else.
+func TestBuildDownloadArgsFetchesFullSnapshotByDefault(t *testing.T) {
+	spec := ModelSpec{
+		LocalPath: "models/category_classifier_modernbert-base_model",
+		RepoID:    "llm-semantic-router/category_classifier_modernbert-base_model",
+		Revision:  "main",
+	}
+
+	got := buildDownloadArgs(spec)
+	want := []string{
+		"download",
+		spec.RepoID,
+		"--local-dir", spec.LocalPath,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("buildDownloadArgs() = %#v, want %#v", got, want)
+	}
+}
+
+// TestBuildDownloadArgsAppendsExcludePatternsLast guards the CLI contract:
+// `--exclude` is variadic, so it must come after every other flag or it would
+// swallow them as patterns.
+func TestBuildDownloadArgsAppendsExcludePatternsLast(t *testing.T) {
+	spec := ModelSpec{
+		LocalPath:       testEmbeddingModelPath,
+		RepoID:          testEmbeddingRepoID,
+		Revision:        "abc123",
+		ExcludePatterns: []string{"*.onnx", "*.onnx.data"},
+	}
+
+	got := buildDownloadArgs(spec)
+	want := []string{
+		"download",
+		testEmbeddingRepoID,
+		"--local-dir", testEmbeddingModelPath,
+		"--revision", "abc123",
+		"--exclude", "*.onnx", "*.onnx.data",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("buildDownloadArgs() = %#v, want %#v", got, want)
+	}
+}

--- a/src/semantic-router/pkg/modeldownload/types.go
+++ b/src/semantic-router/pkg/modeldownload/types.go
@@ -10,6 +10,9 @@ type ModelSpec struct {
 	Revision string
 	// Required files to verify model completeness
 	RequiredFiles []string
+	// Glob patterns passed to `hf download --exclude` so artifacts the configured
+	// runtime never loads are skipped. Empty means the full snapshot is fetched.
+	ExcludePatterns []string
 }
 
 // DownloadConfig contains configuration for model downloading


### PR DESCRIPTION
Closes #3532

## Purpose

The runtime model downloader (`src/semantic-router/pkg/modeldownload`) ran `hf download <repo> --local-dir <path>` with no file filter, so a candle deployment of `llm-semantic-router/mmbert-embed-32k-2d-matryoshka` fetched the whole repository: about 4.3 GB of `onnx/**/model.onnx`, `model.onnx.data` and `model_fa_fp16.onnx` exports on top of the ~650 MB (`config.json`, `model.safetensors`, `tokenizer.json`) the candle runtime actually loads. On a fresh machine that blocks router startup for the whole transfer and can exhaust disk before the embedding model is usable.

This change:

- adds `ModelSpec.ExcludePatterns`, forwarded to `hf download` by a new pure helper `buildDownloadArgs` as **one `--exclude <pattern>` flag per pattern**. The typer-based `hf` CLI takes `--exclude` as a repeatable single-value option (one flag followed by several patterns keeps only the first and treats the rest as positional filenames), while the legacy `huggingface-cli` took `nargs=*`; the repeated form is parsed identically by both, whichever CLI the image ends up installing;
- populates it with `*.onnx`, `*.onnx.data`, `*.onnx_data` for every candle embedding model path (mmBERT, Qwen3, Gemma, multimodal) when `EmbeddingModels.EmbeddingBackend()` is `candle`. The exclude map is keyed and looked up by `config.ResolveModelPath`, so the narrowing holds when the model is configured by a registry alias and does not depend on whether the collected provisioning paths are canonicalized first (#2828 can land before or after this);
- leaves OpenVINO deployments on the full snapshot (they consume the ONNX exports), leaves remote backends unchanged (they provision nothing), and leaves non-embedding models (classifiers, semantic-cache BERT) unchanged to keep the blast radius on the embedding runtime;
- excludes weight files only, so the `onnx/model_config.json` layer manifest read by `config.MmBertAvailableLayers` is still downloaded.

Modules affected: `src/semantic-router/pkg/modeldownload` only (router service platform surface, `router-core` rules). Owner: `wg/router-models-inference-runtime` (accepted issue #3532).

## Test Plan

- `make agent-report ENV=cpu CHANGED_FILES="src/semantic-router/pkg/modeldownload/downloader.go,src/semantic-router/pkg/modeldownload/config_parser.go,src/semantic-router/pkg/modeldownload/types.go,src/semantic-router/pkg/modeldownload/downloader_test.go,src/semantic-router/pkg/modeldownload/download_scope_test.go"` → primary skill `project-change`, fast tests `make test-semantic-router`
- Unit tests in `downloader_test.go` and `download_scope_test.go`:
  - `TestBuildDownloadArgsFetchesFullSnapshotByDefault`: models without a scope keep the historical argument list
  - `TestBuildDownloadArgsRepeatsExcludeFlagPerPattern`: every pattern carries its own `--exclude`, the flag count equals the pattern count, `--exclude` trails `--revision`
  - `TestBuildDownloadArgsSkipsEmptyExcludePatterns`: an empty entry never produces a bare `--exclude`
  - `TestBuildModelSpecsExcludesOnnxWeightsForCandleEmbeddingModels`: all four candle paths get the exclude list
  - `TestBuildModelSpecsExcludesOnnxWeightsForAliasedEmbeddingModel`: `models/mom-embedding-ultra` (alias) and the canonical path are both narrowed; matches specs by resolved `LocalPath`, so it passes with or without #2828
  - `TestBuildModelSpecsKeepsFullSnapshotForOpenVINOBackend`: OpenVINO is unfiltered
  - `TestBuildModelSpecsLeavesNonEmbeddingModelsUnfiltered`: semantic-cache BERT is unfiltered
  - `TestOnnxWeightExcludePatternsNeverMatchCandleRequiredFiles`: exclude globs can never shadow a completeness-required file (would otherwise cause an endless re-download loop)
- `cd src/semantic-router && go test ./pkg/modeldownload/... && go vet ./pkg/modeldownload/...`
- `gofmt -l src/semantic-router/pkg/modeldownload/`
- Exclude globs checked against the live repository file list with `huggingface_hub.utils.filter_repo_objects` (the filter `hf download --exclude` uses)
- End-to-end download check: in a clean `python:3.12-slim` container with unpinned `huggingface_hub` (the same install as `tools/docker/Dockerfile.extproc` and `test-and-build.yml`), run the exact argv `buildDownloadArgs` produced before and after the fix against the live `llm-semantic-router/mmbert-embed-32k-2d-matryoshka` repository into a fresh `--local-dir`, then list the files on disk
- `make agent-ci-gate CHANGED_FILES="..."` (same file list)

## Test Result

- `go test ./pkg/modeldownload/... -v -run 'DownloadArgs|ExcludesOnnx|OpenVINO|Unfiltered|NeverMatch|Aliased'`: 8/8 PASS (macOS, Intel, Go 1.25.0)
- `go test ./pkg/modeldownload/...`: `ok … 1.323s`; `go vet ./pkg/modeldownload/...`: clean; `gofmt -l`: no output
- Exclude globs vs. the repository file list: 16 files kept (including `config.json`, `model.safetensors`, `tokenizer.json`, `onnx/model_config.json` and the per-layer `onnx/*/config.json`), 12 dropped (every `model.onnx`, `model.onnx.data`, `model_fa_fp16.onnx`)
- End-to-end download check, `hf` 1.30.0:
  - **before** (`--exclude "*.onnx" "*.onnx.data" "*.onnx_data"`, the argv of the first revision): `UserWarning: Ignoring '--exclude' since filenames have been explicitly set`; `Fetching 4 files`, 2.12 GB: the directory holds only `onnx/layer-{6,11,16,22}/model.onnx.data`; no `model.safetensors`, no `tokenizer.json`. Reproduces the exact-head CI failure: the stray positionals are treated as filename globs, so the CLI downloads precisely the ONNX weights and nothing the candle runtime needs
  - **after** (`--exclude "*.onnx" --exclude "*.onnx.data" --exclude "*.onnx_data"`): `Fetching 16 files`, 614 MB; `model.safetensors`, `tokenizer.json`, `config.json`, `onnx/model_config.json` and the per-layer `onnx/*/config.json` present; `find` for `*.onnx`, `*.onnx.data`, `*.onnx_data` returns nothing
- `make agent-ci-gate`: passed on the first revision (`fd526d02`: agent-report, pre-commit baseline, Go structural lint, structure and architecture checks); not re-run on `86ce721d`, which only touches the same package's Go sources and tests
- Manual fresh download through the router binary itself: not re-run locally (the checkout already holds the minimal model directory, so the downloader treats it as complete)

Follow-ups tracked outside this PR: classifier repositories also ship `onnx/` subtrees and are intentionally not narrowed here because the ONNX classifier backend may need them (follow-up on #3532); `IsGatedModelError` returning true for any failure when `HF_TOKEN` is empty, which turns a transient public-repo failure into a "gated, skipping" startup (raised by @adaamko in review, to be filed separately).

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category, such as `[Feature]`, `[Bug]`, `[Docs]`, `[Test]`, `[Research]`, `[Community]`, or `[CI/Build]`
- [x] The title does not stack prefixes such as `[Router][Docs]`; affected modules belong in labels and the PR body
- [x] The PR links an `accepted` issue with exactly one owner: one `wg/*` label for project work or `owner/maintainers` for repository governance
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>