### PR TITLE
[Feature] Add GPT-6 Astra built-in support

### DIFF
--- a/config/catalog/README.md
+++ b/config/catalog/README.md
@@ -112,7 +112,7 @@ without duplicating its intrinsic identity. Virtual recipes are materialized
 from packaged assets and keep their own evaluation directory.
 
 The built-in physical inventory is curated at the creator-company level. The
-current baseline contains 83 physical cards from 22 mainstream creators and
+current baseline contains 84 physical cards from 22 mainstream creators and
 five separately stored virtual cards. For each creator, prefer roughly the
 latest three generations or representative product lines over accumulating a
 shallow long tail of lesser-known creators. This policy is about Model Cards,

--- a/config/catalog/manifest.yaml
+++ b/config/catalog/manifest.yaml
@@ -106,9 +106,9 @@ inventory:
           - nvidia/nemotron-cascade-2-30b-a3b
       - publisher: OpenAI
         representative_models:
+          - openai/gpt-6-astra
           - openai/gpt-5.6-sol
           - openai/gpt-5.5
-          - openai/gpt-5.4
       - publisher: StepFun
         representative_models:
           - stepfun/step-3.7-flash

--- a/config/catalog/resources/evaluations/single/openai.yaml
+++ b/config/catalog/resources/evaluations/single/openai.yaml
@@ -4912,3 +4912,94 @@
     verification: claimed
     source: https://cdn.openai.com/pdf/419b6906-9da6-406c-a19d-1bb078ac7637/oai_gpt-oss_model_card.pdf
     redistributable: true
+- id: openai/gpt-6-astra-launch-gpqa-diamond@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: idavidrein/gpqa-diamond@1.0.0
+  benchmark_profile: published-standard
+  reasoning_effort: unspecified
+  subject:
+    variant: GPT-6 Astra
+    result_selection: maximum_across_supported_efforts
+    source_kind: official_launch_evaluation
+  metrics:
+    accuracy: 0.96
+  status: available
+  observed_at: 2026-09-07
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://openai.com/index/gpt-6-astra/
+    redistributable: true
+- id: openai/gpt-6-astra-launch-humanitys-last-exam-tools@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: cais/humanitys-last-exam@1.0.0
+  benchmark_profile: with-tools
+  reasoning_effort: unspecified
+  subject:
+    variant: GPT-6 Astra
+    result_selection: maximum_across_supported_efforts
+    tool_policy: tools_enabled
+    source_kind: official_launch_evaluation
+  metrics:
+    accuracy: 0.572
+  status: available
+  observed_at: 2026-09-07
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://openai.com/index/gpt-6-astra/
+    redistributable: true
+- id: openai/gpt-6-astra-launch-deep-swe-1.1@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: datacurve/deep-swe@1.1.0
+  benchmark_profile: published-agent
+  reasoning_effort: unspecified
+  subject:
+    variant: GPT-6 Astra
+    result_selection: maximum_across_supported_efforts
+    source_kind: official_launch_evaluation
+  metrics:
+    resolved: 0.741
+  status: available
+  observed_at: 2026-09-07
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://openai.com/index/gpt-6-astra/
+    redistributable: true
+- id: openai/gpt-6-astra-launch-arc-agi-2@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: arc-prize/arc-agi-2@1.0.0
+  benchmark_profile: semi-private
+  reasoning_effort: unspecified
+  subject:
+    variant: GPT-6 Astra
+    result_selection: maximum_across_supported_efforts
+    source_kind: official_launch_evaluation
+  metrics:
+    accuracy: 0.95
+  status: available
+  observed_at: 2026-09-07
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://openai.com/index/gpt-6-astra/
+    redistributable: true
+- id: openai/gpt-6-astra-launch-arc-agi-1@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: arc-prize/arc-agi-1@1.0.0
+  benchmark_profile: semi-private
+  reasoning_effort: unspecified
+  subject:
+    variant: GPT-6 Astra
+    result_selection: maximum_across_supported_efforts
+    source_kind: official_launch_evaluation
+  metrics:
+    accuracy: 0.985
+  status: available
+  observed_at: 2026-09-07
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://openai.com/index/gpt-6-astra/
+    redistributable: true

--- a/config/catalog/resources/models/single/openai.yaml
+++ b/config/catalog/resources/models/single/openai.yaml
@@ -1,3 +1,45 @@
+- id: openai/gpt-6-astra
+  display_name: GPT-6 Astra
+  description: OpenAI flagship model for complex reasoning, coding, computer use, research, and document creation.
+  kind: physical
+  publisher: OpenAI
+  presentation:
+    logo: package:openai
+    monogram: O
+    monochrome: true
+  distribution:
+    type: proprietary_api
+    source: https://developers.openai.com/api/docs/models/gpt-6-astra
+  family: gpt-6
+  lifecycle: active
+  limits:
+    context_window_size: 1050000
+    max_output_tokens: 128000
+  capabilities:
+  - chat
+  - reasoning
+  - tools
+  - structured_output
+  - vision
+  - long_context
+  modalities:
+    input:
+    - text
+    - image
+    output:
+    - text
+  reasoning_family: gpt-6-astra
+  verification:
+    authority: OpenAI
+    status: claimed
+    verified_at: 2026-09-07
+    source: https://developers.openai.com/api/docs/models/gpt-6-astra
+  tags:
+  - frontier
+  - proprietary
+  - agentic
+  released_at: '2026-09-03'
+  knowledge_cutoff: '2026-04-30'
 - id: openai/gpt-5.6-sol
   display_name: GPT-5.6 Sol
   description: OpenAI high-capability GPT-5.6 model for demanding reasoning and agentic work.

--- a/config/catalog/resources/providers/openai.yaml
+++ b/config/catalog/resources/providers/openai.yaml
@@ -28,6 +28,48 @@ conformance:
   status: fixture_verified
   verified_at: 2026-09-04
 models:
+- catalog: openai/gpt-6-astra
+  relationship: first_party
+  id: gpt-6-astra
+  protocols:
+  - openai/chat-completions@1
+  - openai/responses@1
+  reasoning_modes: [enabled]
+  reasoning_efforts: [low, medium, high, xhigh, max]
+  reasoning_efforts_by_protocol:
+    openai/chat-completions@1: [low, medium, high, xhigh]
+  pricing:
+    currency: USD
+    prompt_per_1m: 10.0
+    cached_input_per_1m: 1.0
+    cache_write_per_1m: 12.5
+    completion_per_1m: 50.0
+  restrictions:
+    tools_protocols:
+    - openai/responses@1
+    long_context_pricing:
+      input_threshold_tokens: 272000
+      prompt_multiplier: 2.0
+      cached_input_multiplier: 2.0
+      cache_write_multiplier: 2.0
+      completion_multiplier: 1.5
+    unsupported_request_fields:
+      openai/chat-completions@1:
+      - temperature
+      - top_p
+      - top_logprobs
+      - logprobs
+      openai/responses@1:
+      - temperature
+      - top_p
+      - top_logprobs
+    unsupported_include_values:
+    - message.output_text.logprobs
+  lifecycle: active
+  verification:
+    status: claimed
+    verified_at: 2026-09-07
+    source: https://developers.openai.com/api/docs/models/gpt-6-astra
 - catalog: openai/gpt-5.4
   relationship: first_party
   id: gpt-5.4

--- a/config/catalog/resources/reasoning-families.yaml
+++ b/config/catalog/resources/reasoning-families.yaml
@@ -87,6 +87,12 @@
   disabled: none
   modes: [enabled, disabled]
   default_mode: enabled
+- id: gpt-6-astra
+  type: reasoning_effort
+  parameter: reasoning_effort
+  levels: [low, medium, high, xhigh, max]
+  modes: [enabled]
+  default_mode: enabled
 - id: gpt-5.6
   type: reasoning_effort
   parameter: reasoning_effort

--- a/config/catalog/schemas/catalog-resources-v1.schema.json
+++ b/config/catalog/schemas/catalog-resources-v1.schema.json
@@ -112,6 +112,11 @@
           "items": {"enum": ["enabled", "disabled", "adaptive"]}
         },
         "reasoning_efforts": {"$ref": "#/$defs/stringSet"},
+        "reasoning_efforts_by_protocol": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": {"$ref": "#/$defs/stringSet"}
+        },
         "pricing": {
           "type": "object",
           "additionalProperties": {"type": ["number", "string", "boolean"]}

--- a/config/recipes/built-in/latest/catalog.yaml
+++ b/config/recipes/built-in/latest/catalog.yaml
@@ -1563,6 +1563,58 @@ providers:
     status: fixture_verified
     verified_at: '2026-09-04'
   models:
+  - catalog: openai/gpt-6-astra
+    relationship: first_party
+    id: gpt-6-astra
+    protocols:
+    - openai/chat-completions@1
+    - openai/responses@1
+    reasoning_modes:
+    - enabled
+    reasoning_efforts:
+    - low
+    - medium
+    - high
+    - xhigh
+    - max
+    reasoning_efforts_by_protocol:
+      openai/chat-completions@1:
+      - low
+      - medium
+      - high
+      - xhigh
+    pricing:
+      currency: USD
+      prompt_per_1m: 10.0
+      cached_input_per_1m: 1.0
+      cache_write_per_1m: 12.5
+      completion_per_1m: 50.0
+    restrictions:
+      tools_protocols:
+      - openai/responses@1
+      long_context_pricing:
+        input_threshold_tokens: 272000
+        prompt_multiplier: 2.0
+        cached_input_multiplier: 2.0
+        cache_write_multiplier: 2.0
+        completion_multiplier: 1.5
+      unsupported_request_fields:
+        openai/chat-completions@1:
+        - temperature
+        - top_p
+        - top_logprobs
+        - logprobs
+        openai/responses@1:
+        - temperature
+        - top_p
+        - top_logprobs
+      unsupported_include_values:
+      - message.output_text.logprobs
+    lifecycle: active
+    verification:
+      status: claimed
+      verified_at: '2026-09-07'
+      source: https://developers.openai.com/api/docs/models/gpt-6-astra
   - catalog: openai/gpt-5.4
     relationship: first_party
     id: gpt-5.4
@@ -3601,6 +3653,18 @@ reasoning_families:
   modes:
   - enabled
   - disabled
+  default_mode: enabled
+- id: gpt-6-astra
+  type: reasoning_effort
+  parameter: reasoning_effort
+  levels:
+  - low
+  - medium
+  - high
+  - xhigh
+  - max
+  modes:
+  - enabled
   default_mode: enabled
 - id: gpt-5.6
   type: reasoning_effort
@@ -6069,6 +6133,48 @@ models:
   - moe
   - efficient
   released_at: '2026-03-19'
+- id: openai/gpt-6-astra
+  display_name: GPT-6 Astra
+  description: OpenAI flagship model for complex reasoning, coding, computer use, research, and document creation.
+  kind: physical
+  publisher: OpenAI
+  presentation:
+    logo: package:openai
+    monogram: O
+    monochrome: true
+  distribution:
+    type: proprietary_api
+    source: https://developers.openai.com/api/docs/models/gpt-6-astra
+  family: gpt-6
+  lifecycle: active
+  limits:
+    context_window_size: 1050000
+    max_output_tokens: 128000
+  capabilities:
+  - chat
+  - reasoning
+  - tools
+  - structured_output
+  - vision
+  - long_context
+  modalities:
+    input:
+    - text
+    - image
+    output:
+    - text
+  reasoning_family: gpt-6-astra
+  verification:
+    authority: OpenAI
+    status: claimed
+    verified_at: '2026-09-07'
+    source: https://developers.openai.com/api/docs/models/gpt-6-astra
+  tags:
+  - frontier
+  - proprietary
+  - agentic
+  released_at: '2026-09-03'
+  knowledge_cutoff: '2026-04-30'
 - id: openai/gpt-5.6-sol
   display_name: GPT-5.6 Sol
   description: OpenAI high-capability GPT-5.6 model for demanding reasoning and agentic work.
@@ -27216,6 +27322,97 @@ evaluations:
     provenance: vendor_claimed
     verification: claimed
     source: https://cdn.openai.com/pdf/419b6906-9da6-406c-a19d-1bb078ac7637/oai_gpt-oss_model_card.pdf
+    redistributable: true
+- id: openai/gpt-6-astra-launch-gpqa-diamond@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: idavidrein/gpqa-diamond@1.0.0
+  benchmark_profile: published-standard
+  reasoning_effort: unspecified
+  subject:
+    variant: GPT-6 Astra
+    result_selection: maximum_across_supported_efforts
+    source_kind: official_launch_evaluation
+  metrics:
+    accuracy: 0.96
+  status: available
+  observed_at: '2026-09-07'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://openai.com/index/gpt-6-astra/
+    redistributable: true
+- id: openai/gpt-6-astra-launch-humanitys-last-exam-tools@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: cais/humanitys-last-exam@1.0.0
+  benchmark_profile: with-tools
+  reasoning_effort: unspecified
+  subject:
+    variant: GPT-6 Astra
+    result_selection: maximum_across_supported_efforts
+    tool_policy: tools_enabled
+    source_kind: official_launch_evaluation
+  metrics:
+    accuracy: 0.572
+  status: available
+  observed_at: '2026-09-07'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://openai.com/index/gpt-6-astra/
+    redistributable: true
+- id: openai/gpt-6-astra-launch-deep-swe-1.1@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: datacurve/deep-swe@1.1.0
+  benchmark_profile: published-agent
+  reasoning_effort: unspecified
+  subject:
+    variant: GPT-6 Astra
+    result_selection: maximum_across_supported_efforts
+    source_kind: official_launch_evaluation
+  metrics:
+    resolved: 0.741
+  status: available
+  observed_at: '2026-09-07'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://openai.com/index/gpt-6-astra/
+    redistributable: true
+- id: openai/gpt-6-astra-launch-arc-agi-2@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: arc-prize/arc-agi-2@1.0.0
+  benchmark_profile: semi-private
+  reasoning_effort: unspecified
+  subject:
+    variant: GPT-6 Astra
+    result_selection: maximum_across_supported_efforts
+    source_kind: official_launch_evaluation
+  metrics:
+    accuracy: 0.95
+  status: available
+  observed_at: '2026-09-07'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://openai.com/index/gpt-6-astra/
+    redistributable: true
+- id: openai/gpt-6-astra-launch-arc-agi-1@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: arc-prize/arc-agi-1@1.0.0
+  benchmark_profile: semi-private
+  reasoning_effort: unspecified
+  subject:
+    variant: GPT-6 Astra
+    result_selection: maximum_across_supported_efforts
+    source_kind: official_launch_evaluation
+  metrics:
+    accuracy: 0.985
+  status: available
+  observed_at: '2026-09-07'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://openai.com/index/gpt-6-astra/
     redistributable: true
 - id: independent/qwen3-7-max-critpt@1.0.0
   model: qwen/qwen3.7-max

--- a/dashboard/backend/handlers/model_catalog_reasoning_contract.go
+++ b/dashboard/backend/handlers/model_catalog_reasoning_contract.go
@@ -57,7 +57,8 @@ func validCatalogReasoningBindingContract(
 		return true
 	}
 	if model.ReasoningFamily == "" {
-		return len(binding.ReasoningModes) == 0 && len(binding.ReasoningEfforts) == 0
+		return len(binding.ReasoningModes) == 0 && len(binding.ReasoningEfforts) == 0 &&
+			len(binding.ReasoningEffortsByProtocol) == 0
 	}
 	family, exists := reasoning[model.ReasoningFamily]
 	if !exists {
@@ -79,9 +80,18 @@ func validCatalogReasoningBindingContract(
 			!catalogContains(binding.ReasoningModes, family.DefaultMode)) {
 		return false
 	}
-	return len(binding.ReasoningEfforts) == 0 ||
-		(catalogStringSubset(binding.ReasoningEfforts, family.Levels) &&
-			(family.Default == "" || catalogContains(binding.ReasoningEfforts, family.Default)))
+	if len(binding.ReasoningEfforts) > 0 &&
+		(!catalogStringSubset(binding.ReasoningEfforts, family.Levels) ||
+			(family.Default != "" && !catalogContains(binding.ReasoningEfforts, family.Default))) {
+		return false
+	}
+	for _, efforts := range binding.ReasoningEffortsByProtocol {
+		if !catalogStringSubset(efforts, family.Levels) ||
+			(family.Default != "" && !catalogContains(efforts, family.Default)) {
+			return false
+		}
+	}
+	return true
 }
 
 func catalogStringSubset(values, allowed []string) bool {
@@ -100,10 +110,27 @@ func validCatalogReasoningBindingValues(binding modelcatalog.CatalogModelBinding
 	) {
 		return false
 	}
-	return len(binding.ReasoningEfforts) == 0 || validCatalogStringSet(
+	if len(binding.ReasoningEfforts) > 0 && !validCatalogStringSet(
 		binding.ReasoningEfforts,
 		func(value string) bool { return strings.TrimSpace(value) != "" },
-	)
+	) {
+		return false
+	}
+	if binding.ReasoningEffortsByProtocol == nil {
+		return true
+	}
+	if len(binding.ReasoningEffortsByProtocol) == 0 || len(binding.ReasoningEfforts) == 0 {
+		return false
+	}
+	for protocol, efforts := range binding.ReasoningEffortsByProtocol {
+		if !catalogContains(binding.Protocols, protocol) || len(efforts) == 0 ||
+			!validCatalogStringSet(efforts, func(value string) bool {
+				return strings.TrimSpace(value) != "" && catalogContains(binding.ReasoningEfforts, value)
+			}) {
+			return false
+		}
+	}
+	return true
 }
 
 func validCatalogStringSet(values []string, allowed func(string) bool) bool {

--- a/dashboard/backend/handlers/model_catalog_test.go
+++ b/dashboard/backend/handlers/model_catalog_test.go
@@ -315,6 +315,86 @@ func TestCatalogProviderBindingMustProjectCompleteReasoningContract(t *testing.T
 	}
 }
 
+func TestCatalogProviderBindingValidatesProtocolReasoningEfforts(t *testing.T) {
+	t.Parallel()
+
+	const (
+		chat      = "openai/chat-completions@1"
+		responses = "openai/responses@1"
+	)
+	models := map[string]struct{}{"example/model": {}}
+	protocols := map[string]struct{}{chat: {}, responses: {}}
+	definitions := []modelcatalog.ModelCard{{
+		ID: "example/model", Kind: "physical", Lifecycle: "active", ReasoningFamily: "effort",
+	}}
+	reasoning := map[string]modelcatalog.ReasoningFamilyDefinition{
+		"effort": {
+			ID: "effort", Type: "reasoning_effort", Parameter: "reasoning_effort",
+			Levels: []string{"low", "max"}, Default: "low",
+			Modes: []string{"enabled"}, DefaultMode: "enabled",
+		},
+	}
+
+	for _, test := range []struct {
+		name       string
+		efforts    []string
+		byProtocol map[string][]string
+		wantError  bool
+	}{
+		{
+			name: "valid narrowing", efforts: []string{"low", "max"},
+			byProtocol: map[string][]string{chat: {"low"}},
+		},
+		{
+			name: "empty overrides", efforts: []string{"low", "max"},
+			byProtocol: map[string][]string{}, wantError: true,
+		},
+		{
+			name:       "requires provider efforts",
+			byProtocol: map[string][]string{chat: {"low"}}, wantError: true,
+		},
+		{
+			name: "requires bound protocol", efforts: []string{"low", "max"},
+			byProtocol: map[string][]string{"anthropic/messages@1": {"low"}}, wantError: true,
+		},
+		{
+			name: "cannot expand provider efforts", efforts: []string{"low"},
+			byProtocol: map[string][]string{chat: {"max"}}, wantError: true,
+		},
+		{
+			name: "requires nonempty effort set", efforts: []string{"low", "max"},
+			byProtocol: map[string][]string{chat: {}}, wantError: true,
+		},
+		{
+			name: "preserves family default", efforts: []string{"low", "max"},
+			byProtocol: map[string][]string{chat: {"max"}}, wantError: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			provider := modelcatalog.ProviderDefinition{
+				ID: "example", Protocols: []string{chat, responses},
+				ReasoningTransport: modelcatalog.ReasoningTransportTopLevelEffort,
+				Models: []modelcatalog.CatalogModelBinding{{
+					Catalog: "example/model", Relationship: modelcatalog.CatalogModelRelationshipFirstParty,
+					ID: "example-model", Protocols: []string{chat, responses},
+					ReasoningEfforts: test.efforts, ReasoningEffortsByProtocol: test.byProtocol,
+					Lifecycle: "active", Verification: modelcatalog.CatalogBindingVerification{Status: "claimed"},
+				}},
+			}
+			err := validateCatalogProviderBindings(
+				[]modelcatalog.ProviderDefinition{provider}, models, protocols, definitions, reasoning,
+			)
+			if test.wantError && (err == nil || !strings.Contains(err.Error(), "malformed provider catalog model")) {
+				t.Fatalf("malformed protocol effort contract accepted: %v", err)
+			}
+			if !test.wantError && err != nil {
+				t.Fatalf("valid protocol effort contract rejected: %v", err)
+			}
+		})
+	}
+}
+
 func TestCatalogHTTPSURLsAllowDocumentFragments(t *testing.T) {
 	t.Parallel()
 

--- a/dashboard/backend/handlers/model_catalog_test.go
+++ b/dashboard/backend/handlers/model_catalog_test.go
@@ -371,7 +371,7 @@ func TestGeneratedPublicModelCatalogSatisfiesDashboardContract(t *testing.T) {
 	if unmarshalErr := json.Unmarshal(normalized, &document); unmarshalErr != nil {
 		t.Fatalf("decode normalized public catalog: %v", unmarshalErr)
 	}
-	if len(document.Models) != 88 || len(document.Providers) != 60 || len(document.Evaluations) != 1360 {
+	if len(document.Models) != 89 || len(document.Providers) != 60 || len(document.Evaluations) != 1365 {
 		t.Fatalf(
 			"unexpected generated inventory: models=%d providers=%d evaluations=%d",
 			len(document.Models),

--- a/dashboard/frontend/src/pages/configPageModelNormalization.test.ts
+++ b/dashboard/frontend/src/pages/configPageModelNormalization.test.ts
@@ -88,4 +88,30 @@ describe('config page model normalization', () => {
       }),
     ])
   })
+
+  it('narrows reasoning efforts to the selected provider protocol', () => {
+    const builtIn = catalog.models.find((model) => model.id === 'openai/gpt-6-astra')
+    expect(builtIn).toBeDefined()
+    const config: ConfigData = {
+      providers: {
+        models: [
+          {
+            name: 'astra-chat',
+            catalog: builtIn!.id,
+            backend_refs: [{ name: 'chat', provider: 'openai' }],
+          },
+          {
+            name: 'astra-responses',
+            catalog: builtIn!.id,
+            api_format: 'responses',
+            backend_refs: [{ name: 'responses', provider: 'openai' }],
+          },
+        ],
+      },
+    }
+
+    const [chat, responses] = getNormalizedModels(config, true, catalog)
+    expect(chat.reasoning_efforts).toEqual(['low', 'medium', 'high', 'xhigh'])
+    expect(responses.reasoning_efforts).toEqual(['low', 'medium', 'high', 'xhigh', 'max'])
+  })
 })

--- a/dashboard/frontend/src/pages/configPageModelNormalization.ts
+++ b/dashboard/frontend/src/pages/configPageModelNormalization.ts
@@ -29,6 +29,13 @@ const intersectValues = <Value extends string>(
   return current.filter((value) => allowed.has(value))
 }
 
+const catalogProtocolForAPIFormat = (apiFormat?: string): string | undefined => {
+  if (apiFormat === 'openai') return 'openai/chat-completions@1'
+  if (apiFormat === 'responses') return 'openai/responses@1'
+  if (apiFormat === 'anthropic') return 'anthropic/messages@1'
+  return undefined
+}
+
 const catalogReasoningConstraints = (
   model: ProviderModelConfig,
   catalog?: BuiltInModelCatalog | null,
@@ -39,8 +46,14 @@ const catalogReasoningConstraints = (
   for (const backend of model.backend_refs ?? []) {
     const provider = catalog.providers.find((candidate) => candidate.id === backend.provider)
     const binding = provider?.models?.find((candidate) => candidate.catalog === model.catalog)
+    const protocol = model.api_format
+      ? catalogProtocolForAPIFormat(model.api_format)
+      : provider?.default_protocol
+    const bindingEfforts = protocol
+      ? (binding?.reasoning_efforts_by_protocol?.[protocol] ?? binding?.reasoning_efforts)
+      : binding?.reasoning_efforts
     reasoningModes = intersectValues(reasoningModes, binding?.reasoning_modes)
-    reasoningEfforts = intersectValues(reasoningEfforts, binding?.reasoning_efforts)
+    reasoningEfforts = intersectValues(reasoningEfforts, bindingEfforts)
   }
   return { reasoning_modes: reasoningModes, reasoning_efforts: reasoningEfforts }
 }

--- a/dashboard/frontend/src/types/modelCatalog.ts
+++ b/dashboard/frontend/src/types/modelCatalog.ts
@@ -89,6 +89,7 @@ export interface CatalogModelBinding {
     | 'deepseek_thinking'
   reasoning_modes?: Array<'enabled' | 'disabled' | 'adaptive'>
   reasoning_efforts?: string[]
+  reasoning_efforts_by_protocol?: Record<string, string[]>
   pricing?: Record<string, string | number | boolean>
   restrictions?: Record<string, unknown>
   lifecycle: ModelCatalogLifecycle

--- a/dashboard/frontend/src/utils/modelCatalogApi.test.ts
+++ b/dashboard/frontend/src/utils/modelCatalogApi.test.ts
@@ -193,6 +193,18 @@ describe('built-in model catalog API nested metadata', () => {
       },
     ],
     [
+      'protocol-specific reasoning efforts',
+      (payload: Record<string, unknown>) => {
+        const providers = payload.providers as Array<Record<string, unknown>>
+        const provider = providers.find((candidate) => candidate.id === 'openai')!
+        const models = provider.models as Array<Record<string, unknown>>
+        const astra = models.find((candidate) => candidate.catalog === 'openai/gpt-6-astra')!
+        astra.reasoning_efforts_by_protocol = {
+          'anthropic/messages@1': ['low'],
+        }
+      },
+    ],
+    [
       'index normalization',
       (payload: Record<string, unknown>) => {
         const indices = payload.indices as Array<Record<string, unknown>>

--- a/dashboard/frontend/src/utils/modelCatalogApi.ts
+++ b/dashboard/frontend/src/utils/modelCatalogApi.ts
@@ -259,6 +259,31 @@ function isValidReasoningEffortFlags(value: Record<string, unknown>): boolean {
   )
 }
 
+function isReasoningEffortsByProtocol(
+  value: unknown,
+  protocols: unknown,
+  reasoningEfforts: unknown,
+): value is Record<string, string[]> | undefined {
+  if (value === undefined) return true
+  if (
+    !isRecord(value) ||
+    Object.keys(value).length === 0 ||
+    !isStringArray(protocols) ||
+    !isStringArray(reasoningEfforts)
+  ) {
+    return false
+  }
+  const boundProtocols = new Set(protocols)
+  const providerEfforts = new Set(reasoningEfforts)
+  return Object.entries(value).every(
+    ([protocol, efforts]) =>
+      boundProtocols.has(protocol) &&
+      isStringArray(efforts) &&
+      new Set(efforts).size === efforts.length &&
+      efforts.every((effort) => providerEfforts.has(effort)),
+  )
+}
+
 function isCatalogModelBinding(value: unknown): value is CatalogModelBinding {
   return (
     isRecord(value) &&
@@ -287,6 +312,11 @@ function isCatalogModelBinding(value: unknown): value is CatalogModelBinding {
           ['enabled', 'disabled', 'adaptive'].includes(mode),
         ))) &&
     (value.reasoning_efforts === undefined || isStringArray(value.reasoning_efforts)) &&
+    isReasoningEffortsByProtocol(
+      value.reasoning_efforts_by_protocol,
+      value.protocols,
+      value.reasoning_efforts,
+    ) &&
     ['experimental', 'active', 'deprecated', 'removed'].includes(String(value.lifecycle)) &&
     isRecord(value.verification) &&
     ['claimed', 'imported', 'reproduced'].includes(String(value.verification.status))

--- a/e2e/profiles/response-api/profile.go
+++ b/e2e/profiles/response-api/profile.go
@@ -72,7 +72,7 @@ func (p *Profile) GetTestCases() []string {
 		"response-api-edge-concurrent-requests",
 		"response-api-image-file-id",
 		"input-modality-cross-protocol",
-		"model-catalog-astra-day0",
+		"model-catalog-astra",
 		"protocol-codec-chat-backend-buffered-matrix",
 		"protocol-codec-chat-backend-streaming-matrix",
 		"protocol-codec-responses-backend-buffered-matrix",

--- a/e2e/profiles/response-api/profile.go
+++ b/e2e/profiles/response-api/profile.go
@@ -72,6 +72,7 @@ func (p *Profile) GetTestCases() []string {
 		"response-api-edge-concurrent-requests",
 		"response-api-image-file-id",
 		"input-modality-cross-protocol",
+		"model-catalog-astra-day0",
 		"protocol-codec-chat-backend-buffered-matrix",
 		"protocol-codec-chat-backend-streaming-matrix",
 		"protocol-codec-responses-backend-buffered-matrix",

--- a/e2e/profiles/response-api/values.yaml
+++ b/e2e/profiles/response-api/values.yaml
@@ -23,6 +23,23 @@ config:
             provider: vllm
             endpoint: mock-vllm.default.svc.cluster.local:8000
             weight: 1
+      # Day-0 catalog coverage: the card supplies the provider-native model ID,
+      # reasoning family, pricing, limits, capabilities, and presentation.
+      - name: astra-chat-day0
+        catalog: openai/gpt-6-astra
+        backend_refs:
+          - name: mock-openai
+            provider: openai
+            base_url: http://mock-vllm.default.svc.cluster.local:8000/v1
+            api_key_env: VSR_E2E_OPENAI_API_KEY
+      - name: astra-responses-day0
+        catalog: openai/gpt-6-astra
+        api_format: responses
+        backend_refs:
+          - name: mock-openai
+            provider: openai
+            base_url: http://mock-vllm.default.svc.cluster.local:8000/v1
+            api_key_env: VSR_E2E_OPENAI_API_KEY
   routing:
     decisions:
       - name: default_decision
@@ -130,3 +147,7 @@ resources:
 # E2E/Kind: disable PVC for reliable CI (same as other e2e profiles).
 persistence:
   enabled: false
+
+extraEnv:
+  - name: VSR_E2E_OPENAI_API_KEY
+    value: astra-day0-fixture-key

--- a/e2e/profiles/response-api/values.yaml
+++ b/e2e/profiles/response-api/values.yaml
@@ -23,16 +23,16 @@ config:
             provider: vllm
             endpoint: mock-vllm.default.svc.cluster.local:8000
             weight: 1
-      # Day-0 catalog coverage: the card supplies the provider-native model ID,
+      # Built-in catalog coverage: the card supplies the provider-native model ID,
       # reasoning family, pricing, limits, capabilities, and presentation.
-      - name: astra-chat-day0
+      - name: astra-chat
         catalog: openai/gpt-6-astra
         backend_refs:
           - name: mock-openai
             provider: openai
             base_url: http://mock-vllm.default.svc.cluster.local:8000/v1
             api_key_env: VSR_E2E_OPENAI_API_KEY
-      - name: astra-responses-day0
+      - name: astra-responses
         catalog: openai/gpt-6-astra
         api_format: responses
         backend_refs:
@@ -150,4 +150,4 @@ persistence:
 
 extraEnv:
   - name: VSR_E2E_OPENAI_API_KEY
-    value: astra-day0-fixture-key
+    value: astra-fixture-key

--- a/e2e/testcases/model_catalog_astra.go
+++ b/e2e/testcases/model_catalog_astra.go
@@ -12,20 +12,20 @@ import (
 )
 
 const (
-	astraChatAlias      = "astra-chat-day0"
-	astraResponsesAlias = "astra-responses-day0"
+	astraChatAlias      = "astra-chat"
+	astraResponsesAlias = "astra-responses"
 	astraProviderModel  = "gpt-6-astra"
 )
 
 func init() {
-	pkgtestcases.Register("model-catalog-astra-day0", pkgtestcases.TestCase{
-		Description: "A catalog-only Day-0 model materializes and emits exact OpenAI Chat and Responses reasoning controls",
-		Tags:        []string{"model-catalog", "day0", "openai", "reasoning", "response-api"},
-		Fn:          testModelCatalogAstraDay0,
+	pkgtestcases.Register("model-catalog-astra", pkgtestcases.TestCase{
+		Description: "A catalog-backed built-in model materializes and emits exact OpenAI Chat and Responses reasoning controls",
+		Tags:        []string{"model-catalog", "built-in", "openai", "reasoning", "response-api"},
+		Fn:          testModelCatalogAstra,
 	})
 }
 
-func testModelCatalogAstraDay0(
+func testModelCatalogAstra(
 	ctx context.Context,
 	client *kubernetes.Clientset,
 	opts pkgtestcases.TestCaseOptions,
@@ -42,7 +42,7 @@ func testModelCatalogAstraDay0(
 	}
 	defer providerSession.Close()
 
-	chatSessionID := "astra-day0-chat"
+	chatSessionID := "astra-chat-contract"
 	if _, err := sendProtocolMatrixRequestWithHeaders(
 		ctx,
 		routerSession,
@@ -50,7 +50,7 @@ func testModelCatalogAstraDay0(
 		map[string]any{
 			"model": astraChatAlias,
 			"messages": []map[string]string{{
-				"role": "user", "content": "Astra Day-0 Chat contract",
+				"role": "user", "content": "Astra Chat contract",
 			}},
 			"reasoning_effort": "xhigh",
 		},
@@ -63,14 +63,14 @@ func testModelCatalogAstraDay0(
 		return err
 	}
 
-	responsesSessionID := "astra-day0-responses"
+	responsesSessionID := "astra-responses-contract"
 	if _, err := sendProtocolMatrixRequestWithHeaders(
 		ctx,
 		routerSession,
 		"/v1/responses",
 		map[string]any{
 			"model":     astraResponsesAlias,
-			"input":     "Astra Day-0 Responses contract",
+			"input":     "Astra Responses contract",
 			"reasoning": map[string]any{"effort": "max"},
 			"store":     false,
 		},
@@ -83,7 +83,7 @@ func testModelCatalogAstraDay0(
 		return err
 	}
 
-	toolSessionID := "astra-day0-responses-tools"
+	toolSessionID := "astra-responses-tools-contract"
 	if _, err := sendProtocolMatrixRequestWithHeaders(
 		ctx,
 		routerSession,

--- a/e2e/testcases/model_catalog_astra_day0.go
+++ b/e2e/testcases/model_catalog_astra_day0.go
@@ -1,0 +1,211 @@
+package testcases
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/vllm-project/semantic-router/e2e/pkg/fixtures"
+	pkgtestcases "github.com/vllm-project/semantic-router/e2e/pkg/testcases"
+)
+
+const (
+	astraChatAlias      = "astra-chat-day0"
+	astraResponsesAlias = "astra-responses-day0"
+	astraProviderModel  = "gpt-6-astra"
+)
+
+func init() {
+	pkgtestcases.Register("model-catalog-astra-day0", pkgtestcases.TestCase{
+		Description: "A catalog-only Day-0 model materializes and emits exact OpenAI Chat and Responses reasoning controls",
+		Tags:        []string{"model-catalog", "day0", "openai", "reasoning", "response-api"},
+		Fn:          testModelCatalogAstraDay0,
+	})
+}
+
+func testModelCatalogAstraDay0(
+	ctx context.Context,
+	client *kubernetes.Clientset,
+	opts pkgtestcases.TestCaseOptions,
+) error {
+	routerSession, err := fixtures.OpenServiceSession(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+	defer routerSession.Close()
+
+	providerSession, err := openProtocolCodecProviderSession(ctx, client, opts, "openai.responses.v1")
+	if err != nil {
+		return err
+	}
+	defer providerSession.Close()
+
+	chatSessionID := "astra-day0-chat"
+	if _, err := sendProtocolMatrixRequestWithHeaders(
+		ctx,
+		routerSession,
+		"/v1/chat/completions",
+		map[string]any{
+			"model": astraChatAlias,
+			"messages": []map[string]string{{
+				"role": "user", "content": "Astra Day-0 Chat contract",
+			}},
+			"reasoning_effort": "xhigh",
+		},
+		false,
+		map[string]string{"x-vsr-test-session-id": chatSessionID},
+	); err != nil {
+		return fmt.Errorf("astra Chat request: %w", err)
+	}
+	if err := verifyAstraProviderRequest(ctx, providerSession, chatSessionID, false, "xhigh", false); err != nil {
+		return err
+	}
+
+	responsesSessionID := "astra-day0-responses"
+	if _, err := sendProtocolMatrixRequestWithHeaders(
+		ctx,
+		routerSession,
+		"/v1/responses",
+		map[string]any{
+			"model":     astraResponsesAlias,
+			"input":     "Astra Day-0 Responses contract",
+			"reasoning": map[string]any{"effort": "max"},
+			"store":     false,
+		},
+		false,
+		map[string]string{"x-vsr-test-session-id": responsesSessionID},
+	); err != nil {
+		return fmt.Errorf("astra Responses request: %w", err)
+	}
+	if err := verifyAstraProviderRequest(ctx, providerSession, responsesSessionID, true, "max", false); err != nil {
+		return err
+	}
+
+	toolSessionID := "astra-day0-responses-tools"
+	if _, err := sendProtocolMatrixRequestWithHeaders(
+		ctx,
+		routerSession,
+		"/v1/responses",
+		map[string]any{
+			"model":     astraResponsesAlias,
+			"input":     "__mock_tool_call__",
+			"reasoning": map[string]any{"effort": "high"},
+			"store":     false,
+			"tools":     []any{protocolLookupTool()},
+			"tool_choice": map[string]any{
+				"type": "function",
+				"name": "lookup",
+			},
+		},
+		false,
+		map[string]string{"x-vsr-test-session-id": toolSessionID},
+	); err != nil {
+		return fmt.Errorf("astra Responses tool request: %w", err)
+	}
+	if err := verifyAstraProviderRequest(ctx, providerSession, toolSessionID, true, "high", true); err != nil {
+		return err
+	}
+
+	if opts.SetDetails != nil {
+		opts.SetDetails(map[string]interface{}{
+			"catalog":            "openai/gpt-6-astra",
+			"provider_model_id":  astraProviderModel,
+			"protocols_verified": []string{"openai.chat.v1", "openai.responses.v1"},
+			"responses_tools":    true,
+		})
+	}
+	return nil
+}
+
+func verifyAstraProviderRequest(
+	ctx context.Context,
+	providerSession *fixtures.ServiceSession,
+	sessionID string,
+	responses bool,
+	wantEffort string,
+	wantTools bool,
+) error {
+	observed, err := lastProviderSimulatorRequest(ctx, providerSession, sessionID)
+	if err != nil {
+		return fmt.Errorf("read Astra provider request: %w", err)
+	}
+	var debug struct {
+		Body map[string]json.RawMessage `json:"body"`
+	}
+	if err := json.Unmarshal(observed, &debug); err != nil {
+		return fmt.Errorf("decode Astra provider request: %w", err)
+	}
+
+	var model string
+	if err := json.Unmarshal(debug.Body["model"], &model); err != nil || model != astraProviderModel {
+		return fmt.Errorf("astra provider model = %q, want %q: %s", model, astraProviderModel, truncateString(string(observed), 600))
+	}
+	if responses {
+		if _, found := debug.Body["input"]; !found {
+			return fmt.Errorf("astra Responses request lost input: %s", truncateString(string(observed), 600))
+		}
+		if _, found := debug.Body["messages"]; found {
+			return fmt.Errorf("astra Responses request leaked messages: %s", truncateString(string(observed), 600))
+		}
+		if _, found := debug.Body["reasoning_effort"]; found {
+			return fmt.Errorf("astra Responses request leaked top-level reasoning_effort: %s", truncateString(string(observed), 600))
+		}
+		var reasoning struct {
+			Effort string `json:"effort"`
+		}
+		if err := json.Unmarshal(debug.Body["reasoning"], &reasoning); err != nil || reasoning.Effort != wantEffort {
+			return fmt.Errorf("astra Responses effort = %q, want %q: %s", reasoning.Effort, wantEffort, truncateString(string(observed), 600))
+		}
+		_, hasTools := debug.Body["tools"]
+		if hasTools != wantTools {
+			return fmt.Errorf("astra Responses tools present = %t, want %t: %s", hasTools, wantTools, truncateString(string(observed), 600))
+		}
+		if wantTools {
+			var tools []struct {
+				Type        string `json:"type"`
+				Name        string `json:"name"`
+				Description string `json:"description"`
+				Parameters  struct {
+					Type       string `json:"type"`
+					Properties map[string]struct {
+						Type string `json:"type"`
+					} `json:"properties"`
+					Required []string `json:"required"`
+				} `json:"parameters"`
+			}
+			if err := json.Unmarshal(debug.Body["tools"], &tools); err != nil || len(tools) != 1 ||
+				tools[0].Type != "function" || tools[0].Name != "lookup" ||
+				tools[0].Description != "Look up a value" || tools[0].Parameters.Type != "object" ||
+				tools[0].Parameters.Properties["query"].Type != "string" ||
+				len(tools[0].Parameters.Required) != 1 || tools[0].Parameters.Required[0] != "query" {
+				return fmt.Errorf("astra Responses tool schema was not preserved: %s", truncateString(string(observed), 600))
+			}
+			var toolChoice struct {
+				Type string `json:"type"`
+				Name string `json:"name"`
+			}
+			if err := json.Unmarshal(debug.Body["tool_choice"], &toolChoice); err != nil ||
+				toolChoice.Type != "function" || toolChoice.Name != "lookup" {
+				return fmt.Errorf("astra Responses tool choice was not preserved: %s", truncateString(string(observed), 600))
+			}
+		}
+		return nil
+	}
+
+	if _, found := debug.Body["messages"]; !found {
+		return fmt.Errorf("astra Chat request lost messages: %s", truncateString(string(observed), 600))
+	}
+	if _, found := debug.Body["input"]; found {
+		return fmt.Errorf("astra Chat request leaked input: %s", truncateString(string(observed), 600))
+	}
+	if _, found := debug.Body["reasoning"]; found {
+		return fmt.Errorf("astra Chat request leaked a reasoning object: %s", truncateString(string(observed), 600))
+	}
+	var effort string
+	if err := json.Unmarshal(debug.Body["reasoning_effort"], &effort); err != nil || effort != wantEffort {
+		return fmt.Errorf("astra Chat effort = %q, want %q: %s", effort, wantEffort, truncateString(string(observed), 600))
+	}
+	return nil
+}

--- a/src/semantic-router/pkg/catalog/compiler_model_provider.go
+++ b/src/semantic-router/pkg/catalog/compiler_model_provider.go
@@ -169,6 +169,7 @@ func (registry *Registry) findCatalogBinding(providerID, modelID, nativeModelID,
 		}
 		copy := catalogBinding
 		copy.Protocols = append([]string(nil), catalogBinding.Protocols...)
+		copy.ReasoningEffortsByProtocol = cloneStringSliceMap(catalogBinding.ReasoningEffortsByProtocol)
 		copy.Restrictions = cloneMap(catalogBinding.Restrictions)
 		return &copy
 	}

--- a/src/semantic-router/pkg/catalog/registry.go
+++ b/src/semantic-router/pkg/catalog/registry.go
@@ -252,6 +252,7 @@ func cloneProvider(value ProviderDefinition) ProviderDefinition {
 		value.Models[index].Protocols = append([]string(nil), value.Models[index].Protocols...)
 		value.Models[index].ReasoningModes = append([]string(nil), value.Models[index].ReasoningModes...)
 		value.Models[index].ReasoningEfforts = append([]string(nil), value.Models[index].ReasoningEfforts...)
+		value.Models[index].ReasoningEffortsByProtocol = cloneStringSliceMap(value.Models[index].ReasoningEffortsByProtocol)
 		value.Models[index].Restrictions = cloneArbitraryMap(value.Models[index].Restrictions)
 		value.Models[index].Pricing.CacheWritePer1M = cloneFloatPointer(value.Models[index].Pricing.CacheWritePer1M)
 	}
@@ -375,6 +376,17 @@ func cloneMap[Value any](source map[string]Value) map[string]Value {
 	result := make(map[string]Value, len(source))
 	for key, value := range source {
 		result[key] = value
+	}
+	return result
+}
+
+func cloneStringSliceMap(source map[string][]string) map[string][]string {
+	if source == nil {
+		return nil
+	}
+	result := make(map[string][]string, len(source))
+	for key, value := range source {
+		result[key] = append([]string(nil), value...)
 	}
 	return result
 }

--- a/src/semantic-router/pkg/catalog/types.go
+++ b/src/semantic-router/pkg/catalog/types.go
@@ -75,13 +75,15 @@ type CatalogModelBinding struct {
 	Protocols          []string                 `json:"protocols"`
 	ReasoningTransport ReasoningTransport       `json:"reasoning_transport,omitempty"`
 	// ReasoningModes and ReasoningEfforts narrow the model-level capability to
-	// values accepted by this provider's API. They never expand the family.
-	ReasoningModes   []string                   `json:"reasoning_modes,omitempty"`
-	ReasoningEfforts []string                   `json:"reasoning_efforts,omitempty"`
-	Pricing          Pricing                    `json:"pricing,omitempty"`
-	Restrictions     map[string]any             `json:"restrictions,omitempty"`
-	Lifecycle        string                     `json:"lifecycle,omitempty"`
-	Verification     CatalogBindingVerification `json:"verification"`
+	// values accepted by this provider's API. A protocol override can narrow the
+	// common effort set further; neither form may expand the model family.
+	ReasoningModes             []string                   `json:"reasoning_modes,omitempty"`
+	ReasoningEfforts           []string                   `json:"reasoning_efforts,omitempty"`
+	ReasoningEffortsByProtocol map[string][]string        `json:"reasoning_efforts_by_protocol,omitempty"`
+	Pricing                    Pricing                    `json:"pricing,omitempty"`
+	Restrictions               map[string]any             `json:"restrictions,omitempty"`
+	Lifecycle                  string                     `json:"lifecycle,omitempty"`
+	Verification               CatalogBindingVerification `json:"verification"`
 }
 
 type ReasoningTransport string

--- a/src/semantic-router/pkg/catalog/zz_generated_catalog.go
+++ b/src/semantic-router/pkg/catalog/zz_generated_catalog.go
@@ -2,7 +2,7 @@
 
 package catalog
 
-const builtInCatalogDigest = "sha256:8107b30319c355de69ae7c3905e57977a1e9f8b4313006b4c0974deff74d8ff1"
+const builtInCatalogDigest = "sha256:b0ffa7072ac6a77e8d40f3a6fc1bf8b0be230ffd643651cb013a0124bcafc432"
 
 const builtInCatalogJSON = `{
   "benchmarks": [
@@ -25062,6 +25062,122 @@ const builtInCatalogJSON = `{
       }
     },
     {
+      "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+      "benchmark_profile": "published-standard",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://openai.com/index/gpt-6-astra/",
+        "verification": "claimed"
+      },
+      "id": "openai/gpt-6-astra-launch-gpqa-diamond@1.0.0",
+      "metrics": {
+        "accuracy": 0.96
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-07",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "result_selection": "maximum_across_supported_efforts",
+        "source_kind": "official_launch_evaluation",
+        "variant": "GPT-6 Astra"
+      }
+    },
+    {
+      "benchmark": "cais/humanitys-last-exam@1.0.0",
+      "benchmark_profile": "with-tools",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://openai.com/index/gpt-6-astra/",
+        "verification": "claimed"
+      },
+      "id": "openai/gpt-6-astra-launch-humanitys-last-exam-tools@1.0.0",
+      "metrics": {
+        "accuracy": 0.572
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-07",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "result_selection": "maximum_across_supported_efforts",
+        "source_kind": "official_launch_evaluation",
+        "tool_policy": "tools_enabled",
+        "variant": "GPT-6 Astra"
+      }
+    },
+    {
+      "benchmark": "datacurve/deep-swe@1.1.0",
+      "benchmark_profile": "published-agent",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://openai.com/index/gpt-6-astra/",
+        "verification": "claimed"
+      },
+      "id": "openai/gpt-6-astra-launch-deep-swe-1.1@1.0.0",
+      "metrics": {
+        "resolved": 0.741
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-07",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "result_selection": "maximum_across_supported_efforts",
+        "source_kind": "official_launch_evaluation",
+        "variant": "GPT-6 Astra"
+      }
+    },
+    {
+      "benchmark": "arc-prize/arc-agi-2@1.0.0",
+      "benchmark_profile": "semi-private",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://openai.com/index/gpt-6-astra/",
+        "verification": "claimed"
+      },
+      "id": "openai/gpt-6-astra-launch-arc-agi-2@1.0.0",
+      "metrics": {
+        "accuracy": 0.95
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-07",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "result_selection": "maximum_across_supported_efforts",
+        "source_kind": "official_launch_evaluation",
+        "variant": "GPT-6 Astra"
+      }
+    },
+    {
+      "benchmark": "arc-prize/arc-agi-1@1.0.0",
+      "benchmark_profile": "semi-private",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://openai.com/index/gpt-6-astra/",
+        "verification": "claimed"
+      },
+      "id": "openai/gpt-6-astra-launch-arc-agi-1@1.0.0",
+      "metrics": {
+        "accuracy": 0.985
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-07",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "result_selection": "maximum_across_supported_efforts",
+        "source_kind": "official_launch_evaluation",
+        "variant": "GPT-6 Astra"
+      }
+    },
+    {
       "benchmark": "artificial-analysis/critpt@1.0.0",
       "benchmark_profile": "independent-standard",
       "evidence": {
@@ -38129,6 +38245,59 @@ const builtInCatalogJSON = `{
         "vision",
         "long_context"
       ],
+      "description": "OpenAI flagship model for complex reasoning, coding, computer use, research, and document creation.",
+      "display_name": "GPT-6 Astra",
+      "distribution": {
+        "source": "https://developers.openai.com/api/docs/models/gpt-6-astra",
+        "type": "proprietary_api"
+      },
+      "family": "gpt-6",
+      "id": "openai/gpt-6-astra",
+      "kind": "physical",
+      "knowledge_cutoff": "2026-04-30",
+      "lifecycle": "active",
+      "limits": {
+        "context_window_size": 1050000,
+        "max_output_tokens": 128000
+      },
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "presentation": {
+        "logo": "package:openai",
+        "monochrome": true,
+        "monogram": "O"
+      },
+      "publisher": "OpenAI",
+      "reasoning_family": "gpt-6-astra",
+      "released_at": "2026-09-03",
+      "tags": [
+        "frontier",
+        "proprietary",
+        "agentic"
+      ],
+      "verification": {
+        "authority": "OpenAI",
+        "source": "https://developers.openai.com/api/docs/models/gpt-6-astra",
+        "status": "claimed",
+        "verified_at": "2026-09-07"
+      }
+    },
+    {
+      "capabilities": [
+        "chat",
+        "reasoning",
+        "tools",
+        "structured_output",
+        "vision",
+        "long_context"
+      ],
       "description": "OpenAI high-capability GPT-5.6 model for demanding reasoning and agentic work.",
       "display_name": "GPT-5.6 Sol",
       "distribution": {
@@ -42331,6 +42500,74 @@ const builtInCatalogJSON = `{
       "id": "openai",
       "models": [
         {
+          "catalog": "openai/gpt-6-astra",
+          "id": "gpt-6-astra",
+          "lifecycle": "active",
+          "pricing": {
+            "cache_write_per_1m": 12.5,
+            "cached_input_per_1m": 1.0,
+            "completion_per_1m": 50.0,
+            "currency": "USD",
+            "prompt_per_1m": 10.0
+          },
+          "protocols": [
+            "openai/chat-completions@1",
+            "openai/responses@1"
+          ],
+          "reasoning_efforts": [
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max"
+          ],
+          "reasoning_efforts_by_protocol": {
+            "openai/chat-completions@1": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          },
+          "reasoning_modes": [
+            "enabled"
+          ],
+          "relationship": "first_party",
+          "restrictions": {
+            "long_context_pricing": {
+              "cache_write_multiplier": 2.0,
+              "cached_input_multiplier": 2.0,
+              "completion_multiplier": 1.5,
+              "input_threshold_tokens": 272000,
+              "prompt_multiplier": 2.0
+            },
+            "tools_protocols": [
+              "openai/responses@1"
+            ],
+            "unsupported_include_values": [
+              "message.output_text.logprobs"
+            ],
+            "unsupported_request_fields": {
+              "openai/chat-completions@1": [
+                "temperature",
+                "top_p",
+                "top_logprobs",
+                "logprobs"
+              ],
+              "openai/responses@1": [
+                "temperature",
+                "top_p",
+                "top_logprobs"
+              ]
+            }
+          },
+          "verification": {
+            "source": "https://developers.openai.com/api/docs/models/gpt-6-astra",
+            "status": "claimed",
+            "verified_at": "2026-09-07"
+          }
+        },
+        {
           "catalog": "openai/gpt-5.4",
           "id": "gpt-5.4",
           "lifecycle": "active",
@@ -45103,6 +45340,22 @@ const builtInCatalogJSON = `{
       "modes": [
         "enabled",
         "disabled"
+      ],
+      "parameter": "reasoning_effort",
+      "type": "reasoning_effort"
+    },
+    {
+      "default_mode": "enabled",
+      "id": "gpt-6-astra",
+      "levels": [
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
+      "modes": [
+        "enabled"
       ],
       "parameter": "reasoning_effort",
       "type": "reasoning_effort"

--- a/src/semantic-router/pkg/config/canonical_catalog.go
+++ b/src/semantic-router/pkg/config/canonical_catalog.go
@@ -253,6 +253,9 @@ func materializedProviderProfile(
 	if effective.CatalogBinding != nil {
 		reasoningModes = append([]string(nil), effective.CatalogBinding.ReasoningModes...)
 		reasoningEfforts = append([]string(nil), effective.CatalogBinding.ReasoningEfforts...)
+		if protocolEfforts, ok := effective.CatalogBinding.ReasoningEffortsByProtocol[effective.Binding.Protocol]; ok {
+			reasoningEfforts = append([]string(nil), protocolEfforts...)
+		}
 	}
 	return ProviderProfile{
 		Type: provider.Definition.ID, Protocol: effective.Binding.Protocol, BaseURL: baseURL,

--- a/src/semantic-router/pkg/config/canonical_router_replay_test.go
+++ b/src/semantic-router/pkg/config/canonical_router_replay_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -299,6 +300,125 @@ routing: {}
 	profile, ok := cfg.ProviderProfiles["production_primary"]
 	if !ok || profile.Protocol != "openai/responses@1" {
 		t.Fatalf("provider profile = %+v, want Responses protocol", profile)
+	}
+}
+
+func TestGPT6AstraCatalogMaterializesItsExactReasoningContract(t *testing.T) {
+	cfg, err := ParseYAMLBytes([]byte(`
+version: v0.3
+providers:
+  models:
+    - name: astra
+      catalog: openai/gpt-6-astra
+      api_format: responses
+      backend_refs:
+        - name: primary
+          provider: openai
+routing:
+  decisions:
+    - name: astra_default
+      priority: 1
+      rules:
+        operator: AND
+        conditions: []
+      modelRefs:
+        - model: astra
+          use_reasoning: true
+          reasoning_effort: max
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	family := cfg.GetModelReasoningFamily("astra")
+	if family == nil {
+		t.Fatal("Astra reasoning family is missing")
+	}
+	if got := strings.Join(family.Levels, ","); got != "low,medium,high,xhigh,max" {
+		t.Fatalf("Astra reasoning levels = %q", got)
+	}
+	if family.Default != "" || family.Disabled != "" ||
+		len(family.Modes) != 1 || family.Modes[0] != ReasoningModeEnabled {
+		t.Fatalf("Astra reasoning contract = %+v", *family)
+	}
+	profile, ok := cfg.ProviderProfiles["astra_primary"]
+	if !ok || profile.Protocol != "openai/responses@1" {
+		t.Fatalf("Astra provider profile = %+v", profile)
+	}
+	if got := strings.Join(profile.ReasoningEfforts, ","); got != "low,medium,high,xhigh,max" {
+		t.Fatalf("Astra provider efforts = %q", got)
+	}
+	if got := cfg.ResolveExternalModelID("astra", "astra_primary"); got != "gpt-6-astra" {
+		t.Fatalf("Astra provider model ID = %q", got)
+	}
+}
+
+func TestGPT6AstraCatalogNarrowsChatReasoningEfforts(t *testing.T) {
+	configForEffort := func(effort string) []byte {
+		return []byte(fmt.Sprintf(`
+version: v0.3
+providers:
+  models:
+    - name: astra
+      catalog: openai/gpt-6-astra
+      backend_refs:
+        - name: primary
+          provider: openai
+routing:
+  decisions:
+    - name: astra_default
+      priority: 1
+      rules:
+        operator: AND
+        conditions: []
+      modelRefs:
+        - model: astra
+          use_reasoning: true
+          reasoning_effort: %s
+`, effort))
+	}
+
+	cfg, err := ParseYAMLBytes(configForEffort("xhigh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	profile, ok := cfg.ProviderProfiles["astra_primary"]
+	if !ok || profile.Protocol != "openai/chat-completions@1" {
+		t.Fatalf("Astra Chat provider profile = %+v", profile)
+	}
+	if got := strings.Join(profile.ReasoningEfforts, ","); got != "low,medium,high,xhigh" {
+		t.Fatalf("Astra Chat provider efforts = %q", got)
+	}
+
+	_, err = ParseYAMLBytes(configForEffort("max"))
+	if err == nil || !strings.Contains(err.Error(), `reasoning_effort "max" is not supported by provider "openai"`) {
+		t.Fatalf("expected Astra Chat max-effort rejection, got %v", err)
+	}
+}
+
+func TestGPT6AstraCatalogRejectsDisabledReasoning(t *testing.T) {
+	_, err := ParseYAMLBytes([]byte(`
+version: v0.3
+providers:
+  models:
+    - name: astra
+      catalog: openai/gpt-6-astra
+      backend_refs:
+        - name: primary
+          provider: openai
+routing:
+  decisions:
+    - name: astra_disabled
+      priority: 1
+      rules:
+        operator: AND
+        conditions: []
+      modelRefs:
+        - model: astra
+          use_reasoning: false
+`))
+	if err == nil || !strings.Contains(err.Error(), "always-on reasoning family") {
+		t.Fatalf("expected Astra disable rejection, got %v", err)
 	}
 }
 

--- a/src/semantic-router/pkg/extproc/provider_request_catalog_contract_test.go
+++ b/src/semantic-router/pkg/extproc/provider_request_catalog_contract_test.go
@@ -33,6 +33,17 @@ type catalogReasoningWireCase struct {
 func TestBuiltInCatalogReasoningWireContracts(t *testing.T) {
 	tests := []catalogReasoningWireCase{
 		{
+			name: "OpenAI Astra Chat xhigh effort", catalog: "openai/gpt-6-astra", provider: "openai",
+			enabled: true, effort: "xhigh", wantTransport: modelcatalog.ReasoningTransportTopLevelEffort,
+			wantControls: map[string]interface{}{"reasoning_effort": "xhigh"},
+		},
+		{
+			name: "OpenAI Astra Responses max effort", catalog: "openai/gpt-6-astra", provider: "openai",
+			apiFormat: config.APIFormatResponses, enabled: true, effort: "max",
+			wantTransport: modelcatalog.ReasoningTransportTopLevelEffort,
+			wantControls:  map[string]interface{}{"reasoning": map[string]interface{}{"effort": "max"}},
+		},
+		{
 			name: "OpenAI Chat effort", catalog: "openai/gpt-5.6-sol", provider: "openai",
 			enabled: true, effort: "high", wantTransport: modelcatalog.ReasoningTransportTopLevelEffort,
 			wantControls: map[string]interface{}{"reasoning_effort": "high"},

--- a/tools/catalog/catalog_validation.py
+++ b/tools/catalog/catalog_validation.py
@@ -155,6 +155,7 @@ def _validate_provider_binding(
             "reasoning_transport",
             "reasoning_modes",
             "reasoning_efforts",
+            "reasoning_efforts_by_protocol",
             "pricing",
             "restrictions",
             "lifecycle",
@@ -174,6 +175,8 @@ def _validate_provider_binding(
         raise CatalogBuildError(f"{path}.reasoning_transport is unsupported")
     if model_id not in models:
         raise CatalogBuildError(f"{path}.catalog references an unknown model")
+    protocols = _sequence(item.get("protocols"), f"{path}.protocols")
+    _validate_binding_protocols(protocols, path, provider, protocol_ids)
     _validate_reasoning_transport_family(
         item,
         path,
@@ -181,7 +184,13 @@ def _validate_provider_binding(
         models[model_id],
         reasoning_families,
     )
-    _validate_reasoning_binding_values(item, path, models[model_id], reasoning_families)
+    _validate_reasoning_binding_values(
+        item,
+        path,
+        models[model_id],
+        reasoning_families,
+        protocols,
+    )
     if native_id in native_ids:
         raise CatalogBuildError(
             f"{path}.id duplicates a provider-native model identifier"
@@ -192,8 +201,7 @@ def _validate_provider_binding(
         if verification.get("source") is not None:
             _validate_https_url(verification["source"], f"{path}.verification.source")
     _validate_provider_model_id_policy(item, path)
-    protocols = _sequence(item.get("protocols"), f"{path}.protocols")
-    _validate_binding_protocols(protocols, path, provider, protocol_ids)
+    _validate_provider_model_api_restrictions(item, path, protocols)
     for protocol in protocols:
         pair = (model_id, str(protocol))
         if pair in pairs:
@@ -265,15 +273,21 @@ def _validated_reasoning_modes(item: dict[str, Any], path: str) -> list[Any] | N
     return values
 
 
-def _validated_reasoning_efforts(item: dict[str, Any], path: str) -> list[Any] | None:
+def _validated_reasoning_efforts(item: dict[str, Any], path: str) -> list[str] | None:
     efforts = item.get("reasoning_efforts")
     if efforts is None:
         return None
-    values = _sequence(efforts, f"{path}.reasoning_efforts")
+    return _validated_reasoning_effort_values(efforts, f"{path}.reasoning_efforts")
+
+
+def _validated_reasoning_effort_values(value: Any, path: str) -> list[str]:
+    raw_values = _sequence(value, path)
+    values = [
+        _nonempty_string(raw_value, f"{path}[{index}]")
+        for index, raw_value in enumerate(raw_values)
+    ]
     if not values or len(values) != len(set(values)):
-        raise CatalogBuildError(f"{path}.reasoning_efforts is invalid")
-    for index, value in enumerate(values):
-        _nonempty_string(value, f"{path}.reasoning_efforts[{index}]")
+        raise CatalogBuildError(f"{path} is invalid")
     return values
 
 
@@ -296,7 +310,7 @@ def _validate_reasoning_mode_subset(
 
 
 def _validate_reasoning_effort_subset(
-    efforts: list[Any] | None,
+    efforts: list[str] | None,
     family: dict[str, Any],
     path: str,
 ) -> None:
@@ -319,10 +333,12 @@ def _validate_reasoning_binding_values(
     path: str,
     model: dict[str, Any],
     reasoning_families: dict[str, dict[str, Any]],
+    protocols: list[Any],
 ) -> None:
     modes = _validated_reasoning_modes(item, path)
     efforts = _validated_reasoning_efforts(item, path)
-    if modes is None and efforts is None:
+    efforts_by_protocol = item.get("reasoning_efforts_by_protocol")
+    if modes is None and efforts is None and efforts_by_protocol is None:
         return
     family_id = model.get("reasoning_family")
     family = reasoning_families.get(str(family_id))
@@ -332,6 +348,31 @@ def _validate_reasoning_binding_values(
         )
     _validate_reasoning_mode_subset(modes, family, path)
     _validate_reasoning_effort_subset(efforts, family, path)
+    if efforts_by_protocol is None:
+        return
+    if efforts is None:
+        raise CatalogBuildError(
+            f"{path}.reasoning_efforts_by_protocol requires reasoning_efforts"
+        )
+    overrides = _mapping(
+        efforts_by_protocol,
+        f"{path}.reasoning_efforts_by_protocol",
+    )
+    if not overrides:
+        raise CatalogBuildError(
+            f"{path}.reasoning_efforts_by_protocol must not be empty"
+        )
+    supported_protocols = {str(protocol) for protocol in protocols}
+    for protocol, raw_values in overrides.items():
+        override_path = f"{path}.reasoning_efforts_by_protocol.{protocol}"
+        if protocol not in supported_protocols:
+            raise CatalogBuildError(f"{override_path} references an unbound protocol")
+        values = _validated_reasoning_effort_values(raw_values, override_path)
+        if not set(values).issubset(efforts):
+            raise CatalogBuildError(
+                f"{override_path} must narrow the provider reasoning_efforts"
+            )
+        _validate_reasoning_effort_subset(values, family, override_path)
 
 
 def _validate_provider_model_id_policy(item: dict[str, Any], path: str) -> None:
@@ -349,6 +390,113 @@ def _validate_provider_model_id_policy(item: dict[str, Any], path: str) -> None:
         restrictions.get("catalog_model_name"),
         f"{path}.restrictions.catalog_model_name",
     )
+
+
+def _validate_provider_model_api_restrictions(
+    item: dict[str, Any], path: str, protocols: list[Any]
+) -> None:
+    """Validate protocol-scoped model constraints without closing extensions."""
+
+    if "restrictions" not in item:
+        return
+    restrictions = _mapping(item["restrictions"], f"{path}.restrictions")
+    supported_protocols = {str(protocol) for protocol in protocols}
+
+    tools_protocols = restrictions.get("tools_protocols")
+    if tools_protocols is not None:
+        values = _sequence(tools_protocols, f"{path}.restrictions.tools_protocols")
+        normalized_values = [
+            _nonempty_string(value, f"{path}.restrictions.tools_protocols[{index}]")
+            for index, value in enumerate(values)
+        ]
+        if not normalized_values or len(normalized_values) != len(
+            set(normalized_values)
+        ):
+            raise CatalogBuildError(
+                f"{path}.restrictions.tools_protocols must be a non-empty unique list"
+            )
+        unknown = sorted(
+            value for value in normalized_values if value not in supported_protocols
+        )
+        if unknown:
+            raise CatalogBuildError(
+                f"{path}.restrictions.tools_protocols references an unbound protocol: "
+                + ", ".join(unknown)
+            )
+
+    long_context_pricing = restrictions.get("long_context_pricing")
+    if long_context_pricing is not None:
+        pricing_path = f"{path}.restrictions.long_context_pricing"
+        pricing = _mapping(long_context_pricing, pricing_path)
+        multiplier_fields = {
+            "prompt_multiplier",
+            "cached_input_multiplier",
+            "cache_write_multiplier",
+            "completion_multiplier",
+        }
+        _reject_unknown(
+            pricing,
+            {"input_threshold_tokens", *multiplier_fields},
+            pricing_path,
+        )
+        threshold = pricing.get("input_threshold_tokens")
+        if (
+            not isinstance(threshold, int)
+            or isinstance(threshold, bool)
+            or threshold <= 0
+        ):
+            raise CatalogBuildError(
+                f"{pricing_path}.input_threshold_tokens must be a positive integer"
+            )
+        present_multipliers = multiplier_fields & pricing.keys()
+        if not present_multipliers:
+            raise CatalogBuildError(
+                f"{pricing_path} must declare at least one price multiplier"
+            )
+        for field in sorted(present_multipliers):
+            value = pricing[field]
+            if not _is_finite_number(value) or value <= 0:
+                raise CatalogBuildError(f"{pricing_path}.{field} must be positive")
+
+    unsupported_include_values = restrictions.get("unsupported_include_values")
+    if unsupported_include_values is not None:
+        include_path = f"{path}.restrictions.unsupported_include_values"
+        raw_values = _sequence(unsupported_include_values, include_path)
+        values = [
+            _nonempty_string(value, f"{include_path}[{index}]")
+            for index, value in enumerate(raw_values)
+        ]
+        if not values or len(values) != len(set(values)):
+            raise CatalogBuildError(f"{include_path} must be a non-empty unique list")
+        for index, value in enumerate(values):
+            if not re.fullmatch(r"[a-z][a-z0-9_]*(?:\.[a-z][a-z0-9_]*)*", value):
+                raise CatalogBuildError(
+                    f"{include_path}[{index}] must be a dotted JSON field path"
+                )
+
+    unsupported_fields = restrictions.get("unsupported_request_fields")
+    if unsupported_fields is None:
+        return
+    fields_by_protocol = _mapping(
+        unsupported_fields,
+        f"{path}.restrictions.unsupported_request_fields",
+    )
+    for protocol, raw_fields in fields_by_protocol.items():
+        protocol_path = f"{path}.restrictions.unsupported_request_fields.{protocol}"
+        if protocol not in supported_protocols:
+            raise CatalogBuildError(f"{protocol_path} references an unbound protocol")
+        raw_field_values = _sequence(raw_fields, protocol_path)
+        fields = [
+            _nonempty_string(field, f"{protocol_path}[{index}]")
+            for index, field in enumerate(raw_field_values)
+        ]
+        if not fields or len(fields) != len(set(fields)):
+            raise CatalogBuildError(f"{protocol_path} must be a non-empty unique list")
+        for index, name in enumerate(fields):
+            if not re.fullmatch(r"[a-z][a-z0-9_]*", name):
+                raise CatalogBuildError(
+                    f"{protocol_path}[{index}] must be a JSON field name"
+                )
 
 
 def _validate_binding_protocols(

--- a/tools/catalog/tests/test_generate_model_catalog.py
+++ b/tools/catalog/tests/test_generate_model_catalog.py
@@ -192,7 +192,142 @@ class ModelCatalogCompilerTests(unittest.TestCase):
                 self.assertIn(
                     physical_models[model_id]["lifecycle"], {"active", "experimental"}
                 )
-        self.assertNotIn("openai/gpt-6-astra", physical_models)
+        self.assertIn("openai/gpt-6-astra", physical_models)
+
+    def test_gpt_6_astra_day_zero_contract_is_complete(self) -> None:
+        manifest, resources, _ = catalog.load_and_validate()
+        models = {model["id"]: model for model in resources["models"]}
+        astra = models["openai/gpt-6-astra"]
+        self.assertEqual(
+            astra["limits"],
+            {
+                "context_window_size": 1_050_000,
+                "max_output_tokens": 128_000,
+            },
+        )
+        self.assertEqual(astra["knowledge_cutoff"], "2026-04-30")
+        self.assertEqual(astra["reasoning_family"], "gpt-6-astra")
+        self.assertTrue(
+            {"chat", "reasoning", "tools", "structured_output", "vision"}.issubset(
+                astra["capabilities"]
+            )
+        )
+
+        families = {family["id"]: family for family in resources["reasoning_families"]}
+        reasoning = families["gpt-6-astra"]
+        self.assertEqual(reasoning["levels"], ["low", "medium", "high", "xhigh", "max"])
+        self.assertEqual(reasoning["modes"], ["enabled"])
+        self.assertNotIn("disabled", reasoning)
+        self.assertNotIn(
+            "default",
+            reasoning,
+            "the official Astra model page does not publish a default effort",
+        )
+
+        providers = {provider["id"]: provider for provider in resources["providers"]}
+        binding = next(
+            item
+            for item in providers["openai"]["models"]
+            if item["catalog"] == "openai/gpt-6-astra"
+        )
+        self.assertEqual(binding["id"], "gpt-6-astra")
+        self.assertEqual(
+            binding["protocols"],
+            ["openai/chat-completions@1", "openai/responses@1"],
+        )
+        self.assertEqual(binding["reasoning_modes"], ["enabled"])
+        self.assertEqual(binding["reasoning_efforts"], reasoning["levels"])
+        self.assertEqual(
+            binding["reasoning_efforts_by_protocol"],
+            {
+                "openai/chat-completions@1": [
+                    "low",
+                    "medium",
+                    "high",
+                    "xhigh",
+                ]
+            },
+        )
+        self.assertEqual(
+            binding["pricing"],
+            {
+                "currency": "USD",
+                "prompt_per_1m": 10.0,
+                "cached_input_per_1m": 1.0,
+                "cache_write_per_1m": 12.5,
+                "completion_per_1m": 50.0,
+            },
+        )
+        self.assertEqual(
+            binding["restrictions"],
+            {
+                "tools_protocols": ["openai/responses@1"],
+                "long_context_pricing": {
+                    "input_threshold_tokens": 272000,
+                    "prompt_multiplier": 2.0,
+                    "cached_input_multiplier": 2.0,
+                    "cache_write_multiplier": 2.0,
+                    "completion_multiplier": 1.5,
+                },
+                "unsupported_request_fields": {
+                    "openai/chat-completions@1": [
+                        "temperature",
+                        "top_p",
+                        "top_logprobs",
+                        "logprobs",
+                    ],
+                    "openai/responses@1": [
+                        "temperature",
+                        "top_p",
+                        "top_logprobs",
+                    ],
+                },
+                "unsupported_include_values": ["message.output_text.logprobs"],
+            },
+        )
+
+        evaluations = [
+            item
+            for item in resources["evaluations"]
+            if item["model"] == "openai/gpt-6-astra"
+        ]
+        self.assertEqual(len(evaluations), 5)
+        self.assertEqual(
+            {item["benchmark"] for item in evaluations},
+            {
+                "idavidrein/gpqa-diamond@1.0.0",
+                "cais/humanitys-last-exam@1.0.0",
+                "datacurve/deep-swe@1.1.0",
+                "arc-prize/arc-agi-1@1.0.0",
+                "arc-prize/arc-agi-2@1.0.0",
+            },
+        )
+        self.assertTrue(
+            all(item["reasoning_effort"] == "unspecified" for item in evaluations)
+        )
+        self.assertTrue(
+            all(
+                item["subject"]["result_selection"]
+                == "maximum_across_supported_efforts"
+                for item in evaluations
+            )
+        )
+        self.assertTrue(
+            all(
+                item["evidence"]["provenance"] == "vendor_claimed"
+                for item in evaluations
+            )
+        )
+
+        openai_inventory = next(
+            creator
+            for creator in manifest["inventory"]["physical"]["creators"]
+            if creator["publisher"] == "OpenAI"
+        )
+        self.assertEqual(
+            openai_inventory["representative_models"],
+            ["openai/gpt-6-astra", "openai/gpt-5.6-sol", "openai/gpt-5.5"],
+        )
 
     def test_baidu_creator_has_exact_evidence_buckets_and_real_bindings(self) -> None:
         manifest, resources, _ = catalog.load_and_validate()
@@ -632,6 +767,7 @@ class ModelCatalogCompilerTests(unittest.TestCase):
             {
                 "openai/gpt-5.4",
                 "openai/gpt-5.5",
+                "openai/gpt-6-astra",
                 "openai/gpt-5.6-luna",
                 "openai/gpt-5.6-sol",
                 "openai/gpt-5.6-terra",

--- a/tools/catalog/tests/test_generate_model_catalog_validation.py
+++ b/tools/catalog/tests/test_generate_model_catalog_validation.py
@@ -501,6 +501,174 @@ class ModelCatalogValidationTests(unittest.TestCase):
                 providers, models, {"openai/chat-completions@1"}
             )
 
+    def test_provider_model_api_restrictions_are_protocol_scoped(self) -> None:
+        protocols = {
+            "openai/chat-completions@1",
+            "openai/responses@1",
+        }
+        binding = {
+            "catalog": "example/model",
+            "relationship": "first_party",
+            "id": "native-model",
+            "protocols": sorted(protocols),
+            "restrictions": {
+                "tools_protocols": ["openai/responses@1"],
+                "long_context_pricing": {
+                    "input_threshold_tokens": 272000,
+                    "prompt_multiplier": 2.0,
+                    "completion_multiplier": 1.5,
+                },
+                "unsupported_request_fields": {
+                    "openai/chat-completions@1": ["temperature", "logprobs"],
+                },
+                "unsupported_include_values": ["message.output_text.logprobs"],
+            },
+        }
+        providers = {
+            "example": {
+                "protocols": sorted(protocols),
+                "supported_operations": [
+                    f"{protocol}#create" for protocol in sorted(protocols)
+                ],
+                "models": [binding],
+            }
+        }
+        models = {"example/model": {"kind": "physical", "lifecycle": "active"}}
+
+        catalog._validate_provider_bindings(providers, models, protocols)
+
+        binding["restrictions"]["tools_protocols"] = ["anthropic/messages@1"]
+        with self.assertRaisesRegex(
+            catalog.CatalogBuildError, "tools_protocols references an unbound protocol"
+        ):
+            catalog._validate_provider_bindings(providers, models, protocols)
+
+        binding["restrictions"]["tools_protocols"] = ["openai/responses@1"]
+        binding["restrictions"]["unsupported_request_fields"] = {
+            "openai/responses@1": ["temperature", "temperature"]
+        }
+        with self.assertRaisesRegex(
+            catalog.CatalogBuildError, "must be a non-empty unique list"
+        ):
+            catalog._validate_provider_bindings(providers, models, protocols)
+
+        binding["restrictions"]["unsupported_request_fields"] = {
+            "openai/responses@1": ["reasoning.effort"]
+        }
+        with self.assertRaisesRegex(
+            catalog.CatalogBuildError, "must be a JSON field name"
+        ):
+            catalog._validate_provider_bindings(providers, models, protocols)
+
+        binding["restrictions"]["unsupported_request_fields"] = {
+            "openai/responses@1": ["temperature"]
+        }
+        binding["restrictions"]["long_context_pricing"] = {
+            "input_threshold_tokens": 0,
+            "prompt_multiplier": 2.0,
+        }
+        with self.assertRaisesRegex(
+            catalog.CatalogBuildError,
+            "input_threshold_tokens must be a positive integer",
+        ):
+            catalog._validate_provider_bindings(providers, models, protocols)
+
+        binding["restrictions"]["long_context_pricing"] = {
+            "input_threshold_tokens": 272000,
+            "prompt_multiplier": float("inf"),
+        }
+        with self.assertRaisesRegex(
+            catalog.CatalogBuildError, "prompt_multiplier must be positive"
+        ):
+            catalog._validate_provider_bindings(providers, models, protocols)
+
+        binding["restrictions"]["long_context_pricing"] = {
+            "input_threshold_tokens": 272000,
+            "prompt_multiplier": 2.0,
+        }
+        binding["restrictions"]["unsupported_include_values"] = [
+            "message.output_text.logprobs",
+            "message.output_text.logprobs",
+        ]
+        with self.assertRaisesRegex(
+            catalog.CatalogBuildError, "must be a non-empty unique list"
+        ):
+            catalog._validate_provider_bindings(providers, models, protocols)
+
+        binding["restrictions"]["unsupported_include_values"] = [
+            "message[0].output_text"
+        ]
+        with self.assertRaisesRegex(
+            catalog.CatalogBuildError, "must be a dotted JSON field path"
+        ):
+            catalog._validate_provider_bindings(providers, models, protocols)
+
+    def test_provider_reasoning_efforts_can_be_narrowed_by_protocol(self) -> None:
+        protocols = {
+            "openai/chat-completions@1",
+            "openai/responses@1",
+        }
+        binding = {
+            "catalog": "example/model",
+            "relationship": "first_party",
+            "id": "native-model",
+            "protocols": sorted(protocols),
+            "reasoning_efforts": ["low", "max"],
+            "reasoning_efforts_by_protocol": {
+                "openai/chat-completions@1": ["low"],
+            },
+        }
+        providers = {
+            "example": {
+                "protocols": sorted(protocols),
+                "supported_operations": [
+                    f"{protocol}#create" for protocol in sorted(protocols)
+                ],
+                "reasoning_transport": "top_level_effort",
+                "models": [binding],
+            }
+        }
+        models = {
+            "example/model": {
+                "kind": "physical",
+                "lifecycle": "active",
+                "reasoning_family": "example",
+            }
+        }
+        families = {
+            "example": {
+                "type": "reasoning_effort",
+                "parameter": "reasoning_effort",
+                "levels": ["low", "max"],
+                "modes": ["enabled"],
+                "default_mode": "enabled",
+            }
+        }
+
+        catalog._validate_provider_bindings(providers, models, protocols, families)
+
+        binding["reasoning_efforts_by_protocol"] = {"anthropic/messages@1": ["low"]}
+        with self.assertRaisesRegex(
+            catalog.CatalogBuildError, "references an unbound protocol"
+        ):
+            catalog._validate_provider_bindings(providers, models, protocols, families)
+
+        binding["reasoning_efforts_by_protocol"] = {
+            "openai/chat-completions@1": ["medium"]
+        }
+        with self.assertRaisesRegex(
+            catalog.CatalogBuildError,
+            "must narrow the provider reasoning_efforts",
+        ):
+            catalog._validate_provider_bindings(providers, models, protocols, families)
+
+        del binding["reasoning_efforts"]
+        with self.assertRaisesRegex(
+            catalog.CatalogBuildError,
+            "requires reasoning_efforts",
+        ):
+            catalog._validate_provider_bindings(providers, models, protocols, families)
+
     def test_provider_binding_relationship_is_required_and_closed(self) -> None:
         binding = {
             "catalog": "example/model",
@@ -586,9 +754,12 @@ class ModelCatalogValidationTests(unittest.TestCase):
             "terminal_harness",
             "swe_harness",
         ):
-            with self.subTest(subject_key=subject_key), self.assertRaisesRegex(
-                catalog.CatalogBuildError,
-                rf"subject\.{subject_key} is only valid for benchmark families",
+            with (
+                self.subTest(subject_key=subject_key),
+                self.assertRaisesRegex(
+                    catalog.CatalogBuildError,
+                    rf"subject\.{subject_key} is only valid for benchmark families",
+                ),
             ):
                 catalog._validate_evaluations(
                     [

--- a/website/docs/community/model-provider-day-0-support.md
+++ b/website/docs/community/model-provider-day-0-support.md
@@ -172,9 +172,11 @@ sent.
 
 ## Worked example: GPT-6 Astra
 
-GPT-6 Astra is an existing-provider Day-0 change, so its implementation stays
-inside the shared catalog and the existing OpenAI protocol adapters. Its source
-packet is the official [model reference](https://developers.openai.com/api/docs/models/gpt-6-astra),
+GPT-6 Astra is an existing-provider model addition, so its implementation stays
+inside the shared catalog and the existing OpenAI protocol adapters. It is a
+complete worked example of the contribution path above, without claiming that
+the change landed on the model's launch day. Its source packet is the official
+[model reference](https://developers.openai.com/api/docs/models/gpt-6-astra),
 [latest-model guide](https://developers.openai.com/api/docs/guides/latest-model),
 and [launch evaluation report](https://openai.com/index/gpt-6-astra/):
 
@@ -187,7 +189,7 @@ and [launch evaluation report](https://openai.com/index/gpt-6-astra/):
 | Final Chat and Responses request shapes | `src/semantic-router/pkg/extproc/provider_request_catalog_contract_test.go` |
 | Runnable aliases and mock-provider credentials | `e2e/profiles/response-api/values.yaml` |
 | Default CI profile membership | `e2e/profiles/response-api/profile.go` |
-| Black-box model-ID and reasoning projection | `e2e/testcases/model_catalog_astra_day0.go` |
+| Black-box model-ID and reasoning projection | `e2e/testcases/model_catalog_astra.go` |
 
 The official model page does not name a default reasoning effort, so the
 catalog does not invent one. It also does not expose a disabled mode: omitting
@@ -248,7 +250,7 @@ Run the worked example by name:
 ```bash
 make e2e-test-specific \
   E2E_PROFILE=response-api \
-  E2E_TESTS=model-catalog-astra-day0
+  E2E_TESTS=model-catalog-astra
 ```
 
 The profile uses a fixture credential and local mock provider; it never calls

--- a/website/docs/community/model-provider-day-0-support.md
+++ b/website/docs/community/model-provider-day-0-support.md
@@ -170,6 +170,95 @@ metadata endpoints are rejected. Redirects and environment proxies are disabled,
 and resolved addresses are checked again by the dialer before credentials are
 sent.
 
+## Worked example: GPT-6 Astra
+
+GPT-6 Astra is an existing-provider Day-0 change, so its implementation stays
+inside the shared catalog and the existing OpenAI protocol adapters. Its source
+packet is the official [model reference](https://developers.openai.com/api/docs/models/gpt-6-astra),
+[latest-model guide](https://developers.openai.com/api/docs/guides/latest-model),
+and [launch evaluation report](https://openai.com/index/gpt-6-astra/):
+
+| Contract | Source of truth |
+| --- | --- |
+| Identity, limits, modalities, capabilities, and presentation | `config/catalog/resources/models/single/openai.yaml` |
+| OpenAI model ID, Chat/Responses availability, pricing, and API constraints | `config/catalog/resources/providers/openai.yaml` |
+| Always-on `low`, `medium`, `high`, `xhigh`, and `max` reasoning | `config/catalog/resources/reasoning-families.yaml` |
+| Exact vendor-published benchmark results | `config/catalog/resources/evaluations/single/openai.yaml` |
+| Final Chat and Responses request shapes | `src/semantic-router/pkg/extproc/provider_request_catalog_contract_test.go` |
+| Runnable aliases and mock-provider credentials | `e2e/profiles/response-api/values.yaml` |
+| Default CI profile membership | `e2e/profiles/response-api/profile.go` |
+| Black-box model-ID and reasoning projection | `e2e/testcases/model_catalog_astra_day0.go` |
+
+The official model page does not name a default reasoning effort, so the
+catalog does not invent one. It also does not expose a disabled mode: omitting
+an effort lets the API choose its default, while `use_reasoning: false` is
+rejected during configuration validation. Published launch scores are marked
+`unspecified` because the source reports the maximum result across supported
+efforts rather than attributing each score to one effort.
+
+The OpenAI binding records that tools require Responses; requests beyond
+272,000 input tokens use the published long-context multipliers; and
+`temperature`, `top_p`, and `top_logprobs` are unsupported (`logprobs` is also
+unsupported for Chat Completions, and Responses cannot include
+`message.output_text.logprobs`). It also narrows Chat Completions to `low`,
+`medium`, `high`, and `xhigh`, because `max` is Responses-only. These are
+discoverable catalog constraints,
+not silent request rewriting: the Router projects protocol and reasoning
+fields exactly, while OpenAI remains authoritative for rejecting unsupported
+request fields.
+
+Use Responses for Astra tool calls. A minimal routed configuration needs no
+handwritten Model Card or reasoning family:
+
+```yaml
+version: v0.3
+providers:
+  models:
+    - name: astra
+      catalog: openai/gpt-6-astra
+      api_format: responses
+      backend_refs:
+        - name: primary
+          provider: openai
+          api_key_env: OPENAI_API_KEY
+
+routing:
+  decisions:
+    - name: astra_default
+      priority: 1
+      rules:
+        operator: AND
+        conditions: []
+      modelRefs:
+        - model: astra
+          use_reasoning: true
+          reasoning_effort: high
+```
+
+For a plain Chat Completions workload without tools, omit
+`api_format: responses`; the same catalog binding emits top-level
+`reasoning_effort` and rejects a Responses-only effort during startup.
+Responses emits `reasoning.effort`. The black-box E2E also
+proves that a Responses tool definition survives the Router-to-provider hop.
+The generated Router, CLI, Dashboard, and website views all come from these
+authored resources.
+
+Run the worked example by name:
+
+```bash
+make e2e-test-specific \
+  E2E_PROFILE=response-api \
+  E2E_TESTS=model-catalog-astra-day0
+```
+
+The profile uses a fixture credential and local mock provider; it never calls
+the external model API. The test sends Chat with `xhigh`, Responses with
+Responses-only `max`, and a Responses `high` tool request. It then reads the
+mock provider's captured request and checks the provider-native model ID,
+protocol-specific reasoning field, absence of the competing protocol shape,
+and tool preservation. Keep this final-hop assertion when copying the example
+for another model whose protocol or reasoning contract differs.
+
 ## Built-in and custom user configuration
 
 A built-in card is selected with one optional `catalog` reference. The model
@@ -272,14 +361,19 @@ versioned, while metric values must be finite.
 ```bash
 make model-catalog-generate
 make model-catalog-check
-make agent-report ENV=cpu CHANGED_FILES="config/catalog/resources/models/organization.yaml"
+make impact ENV=cpu BASE_REF=upstream/main
+make check BASE_REF=upstream/main
+make verify PROFILE=response-api
 ```
 
 Commit the authored resources, built-in distribution snapshot, Router embed,
-and shared public snapshot together. CLI package assets are ignored build
-staging and must not be committed. Then
-run the gates reported for the actual changed files. A complete Day-0 pull
-request demonstrates:
+and shared public snapshot together. CLI package assets are build-time staging
+outputs, are ignored by Git, and must not be committed. Use the E2E profile
+reported by `impact`
+instead of `response-api` when the model or provider belongs to another
+profile; use `make verify DOMAIN=<domain>` for an explicit integration domain.
+Run `make ci-full BASE_REF=upstream/main` when a complete local PR baseline is
+required. A complete Day-0 pull request demonstrates:
 
 - stable identities and valid references;
 - protocol and capability conformance for every support claim;

--- a/website/docs/proposals/unified-model-catalog-and-evaluation-index.md
+++ b/website/docs/proposals/unified-model-catalog-and-evaluation-index.md
@@ -48,15 +48,15 @@ and a recommended model reference is not a complete built-in model card.
 The old Dashboard therefore contained 40 provider presets, while the Router
 had seven hard-coded runtime types and the packaged catalog had no
 general-purpose physical-model registry. The implemented snapshot compiles 60
-serving providers, three protocol definitions, 83 physical Model Cards, five
-virtual Model Cards, 168 provider-owned model mappings, 64 benchmark
-definitions, and 1,360 exact evaluation records. The five default benchmark
-components produce 1,155 explicit slots over 231 model/effort rows; 124 slots
+serving providers, three protocol definitions, 84 physical Model Cards, five
+virtual Model Cards, 169 provider-owned model mappings, 64 benchmark
+definitions, and 1,365 exact evaluation records. The five default benchmark
+components produce 1,325 explicit slots over 265 model/effort rows; 125 slots
 are currently measured and every other slot stays explicitly missing. Support
 tier, lifecycle, and conformance remain independent, so catalog inclusion is
 not flattened into a native-support or benchmark claim.
 
-All 83 physical cards pass the hard admission rule: at least one exact
+All 84 physical cards pass the hard admission rule: at least one exact
 model, reasoning-effort, and evidence-provenance bucket contains five distinct
 benchmark identities.
 That does not mean every runtime-selectable effort has five published results.
@@ -74,8 +74,8 @@ first 20 individual models from any ranking or endpoint inventory. It focuses
 on roughly twenty mainstream creator companies (22 in this snapshot) and
 represents roughly their latest three generations or product lines. Closely
 related sizes or reasoning variants are included only when they are separately
-selectable and materially useful to operators. GPT-6 Astra remains
-intentionally absent for the separate Day-0 example change.
+selectable and materially useful to operators. GPT-6 Astra is added separately
+as the focused Day-0 example rather than being folded into the baseline change.
 
 | Model creator (`publisher`) | Recent generations and representative lines | Models |
 | --- | --- | ---: |
@@ -164,8 +164,8 @@ and representative.
   model-and-reasoning-effort record.
 - It does not require every new model to have a composite score on release day;
   missing evidence remains explicitly unavailable.
-- GPT-6 Astra is intentionally excluded. It is the separate reference model
-  contribution after this architecture and baseline-catalog change.
+- GPT-6 Astra was intentionally excluded from the architecture baseline and is
+  added by a separate representative model-onboarding contribution.
 
 ## Design principles
 
@@ -564,7 +564,11 @@ A provider-model mapping may further declare `reasoning_modes` or
 new user configuration. They prevent an API-specific surface from accepting a
 mode that is valid for a self-hosted runtime but invalid on that provider; the
 materializer rejects a configured decision before startup when any selected
-backend cannot carry its requested control.
+backend cannot carry its requested control. When one provider exposes the same
+model through several protocols, `reasoning_efforts_by_protocol` can only
+narrow that common set for a named bound protocol. For example, an effort that
+is Responses-only is rejected during startup for a Chat binding instead of
+being sent upstream as a known-invalid request.
 
 The public decision contract remains only `use_reasoning`, optional
 `reasoning_mode`, and optional `reasoning_effort`. At the final dispatch
@@ -721,8 +725,8 @@ The initial population audit makes both coverage and gaps visible. The 64
 benchmark definitions retain all exact measurements as source records, while
 public Hub surfaces remove every exact benchmark/profile/metric tuple measured
 on fewer than ten distinct models. The default five-component matrix
-materializes 1,155 slots over 231
-model/effort rows. At this snapshot, 124 of those slots have an exact
+materializes 1,325 slots over 265
+model/effort rows. At this snapshot, 125 of those slots have an exact
 measurement. Other rows remain explicitly `missing`, `failed`,
 `not_applicable`, or `withheld`; none is fabricated as zero.
 
@@ -1133,9 +1137,9 @@ Protocol and provider adapters remain in narrow runtime packages.
 | 5 | Dashboard catalog API/Add Model migration and website Models page | Logos, forms, Model Hub, and benchmark comparisons consume generated data |
 | 6 | Model/provider contributor guide and repository gates | A compatible model/provider change has one authored source path |
 
-The architecture PR also establishes the initial physical-model baseline. A
-separate follow-up adds GPT-6 Astra as the focused, reviewable model-support
-reference example.
+The architecture change establishes the initial physical-model baseline. The
+focused GPT-6 Astra follow-up demonstrates the complete, reviewable
+model-onboarding path.
 
 ## Acceptance criteria
 

--- a/website/docs/proposals/unified-model-catalog-and-evaluation-index.md
+++ b/website/docs/proposals/unified-model-catalog-and-evaluation-index.md
@@ -75,7 +75,8 @@ on roughly twenty mainstream creator companies (22 in this snapshot) and
 represents roughly their latest three generations or product lines. Closely
 related sizes or reasoning variants are included only when they are separately
 selectable and materially useful to operators. GPT-6 Astra is added separately
-as the focused Day-0 example rather than being folded into the baseline change.
+as the focused model-onboarding example rather than being folded into the
+baseline change.
 
 | Model creator (`publisher`) | Recent generations and representative lines | Models |
 | --- | --- | ---: |
@@ -165,7 +166,7 @@ and representative.
 - It does not require every new model to have a composite score on release day;
   missing evidence remains explicitly unavailable.
 - GPT-6 Astra was intentionally excluded from the architecture baseline and is
-  added by a separate representative model-onboarding contribution.
+  added by the separate representative model-onboarding contribution.
 
 ## Design principles
 

--- a/website/src/data/modelHubCatalogTypes.ts
+++ b/website/src/data/modelHubCatalogTypes.ts
@@ -34,6 +34,9 @@ export interface CatalogModelBinding {
   id: string
   protocols: string[]
   reasoning_transport?: ReasoningTransport
+  reasoning_modes?: Array<'enabled' | 'disabled' | 'adaptive'>
+  reasoning_efforts?: string[]
+  reasoning_efforts_by_protocol?: Record<string, string[]>
   lifecycle: string
 }
 

--- a/website/static/model-catalog/catalog.json
+++ b/website/static/model-catalog/catalog.json
@@ -25056,6 +25056,122 @@
       }
     },
     {
+      "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+      "benchmark_profile": "published-standard",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://openai.com/index/gpt-6-astra/",
+        "verification": "claimed"
+      },
+      "id": "openai/gpt-6-astra-launch-gpqa-diamond@1.0.0",
+      "metrics": {
+        "accuracy": 0.96
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-07",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "result_selection": "maximum_across_supported_efforts",
+        "source_kind": "official_launch_evaluation",
+        "variant": "GPT-6 Astra"
+      }
+    },
+    {
+      "benchmark": "cais/humanitys-last-exam@1.0.0",
+      "benchmark_profile": "with-tools",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://openai.com/index/gpt-6-astra/",
+        "verification": "claimed"
+      },
+      "id": "openai/gpt-6-astra-launch-humanitys-last-exam-tools@1.0.0",
+      "metrics": {
+        "accuracy": 0.572
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-07",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "result_selection": "maximum_across_supported_efforts",
+        "source_kind": "official_launch_evaluation",
+        "tool_policy": "tools_enabled",
+        "variant": "GPT-6 Astra"
+      }
+    },
+    {
+      "benchmark": "datacurve/deep-swe@1.1.0",
+      "benchmark_profile": "published-agent",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://openai.com/index/gpt-6-astra/",
+        "verification": "claimed"
+      },
+      "id": "openai/gpt-6-astra-launch-deep-swe-1.1@1.0.0",
+      "metrics": {
+        "resolved": 0.741
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-07",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "result_selection": "maximum_across_supported_efforts",
+        "source_kind": "official_launch_evaluation",
+        "variant": "GPT-6 Astra"
+      }
+    },
+    {
+      "benchmark": "arc-prize/arc-agi-2@1.0.0",
+      "benchmark_profile": "semi-private",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://openai.com/index/gpt-6-astra/",
+        "verification": "claimed"
+      },
+      "id": "openai/gpt-6-astra-launch-arc-agi-2@1.0.0",
+      "metrics": {
+        "accuracy": 0.95
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-07",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "result_selection": "maximum_across_supported_efforts",
+        "source_kind": "official_launch_evaluation",
+        "variant": "GPT-6 Astra"
+      }
+    },
+    {
+      "benchmark": "arc-prize/arc-agi-1@1.0.0",
+      "benchmark_profile": "semi-private",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://openai.com/index/gpt-6-astra/",
+        "verification": "claimed"
+      },
+      "id": "openai/gpt-6-astra-launch-arc-agi-1@1.0.0",
+      "metrics": {
+        "accuracy": 0.985
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-07",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "result_selection": "maximum_across_supported_efforts",
+        "source_kind": "official_launch_evaluation",
+        "variant": "GPT-6 Astra"
+      }
+    },
+    {
       "benchmark": "artificial-analysis/critpt@1.0.0",
       "benchmark_profile": "independent-standard",
       "evidence": {
@@ -38123,6 +38239,59 @@
         "vision",
         "long_context"
       ],
+      "description": "OpenAI flagship model for complex reasoning, coding, computer use, research, and document creation.",
+      "display_name": "GPT-6 Astra",
+      "distribution": {
+        "source": "https://developers.openai.com/api/docs/models/gpt-6-astra",
+        "type": "proprietary_api"
+      },
+      "family": "gpt-6",
+      "id": "openai/gpt-6-astra",
+      "kind": "physical",
+      "knowledge_cutoff": "2026-04-30",
+      "lifecycle": "active",
+      "limits": {
+        "context_window_size": 1050000,
+        "max_output_tokens": 128000
+      },
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "presentation": {
+        "logo": "package:openai",
+        "monochrome": true,
+        "monogram": "O"
+      },
+      "publisher": "OpenAI",
+      "reasoning_family": "gpt-6-astra",
+      "released_at": "2026-09-03",
+      "tags": [
+        "frontier",
+        "proprietary",
+        "agentic"
+      ],
+      "verification": {
+        "authority": "OpenAI",
+        "source": "https://developers.openai.com/api/docs/models/gpt-6-astra",
+        "status": "claimed",
+        "verified_at": "2026-09-07"
+      }
+    },
+    {
+      "capabilities": [
+        "chat",
+        "reasoning",
+        "tools",
+        "structured_output",
+        "vision",
+        "long_context"
+      ],
       "description": "OpenAI high-capability GPT-5.6 model for demanding reasoning and agentic work.",
       "display_name": "GPT-5.6 Sol",
       "distribution": {
@@ -42325,6 +42494,74 @@
       "id": "openai",
       "models": [
         {
+          "catalog": "openai/gpt-6-astra",
+          "id": "gpt-6-astra",
+          "lifecycle": "active",
+          "pricing": {
+            "cache_write_per_1m": 12.5,
+            "cached_input_per_1m": 1.0,
+            "completion_per_1m": 50.0,
+            "currency": "USD",
+            "prompt_per_1m": 10.0
+          },
+          "protocols": [
+            "openai/chat-completions@1",
+            "openai/responses@1"
+          ],
+          "reasoning_efforts": [
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max"
+          ],
+          "reasoning_efforts_by_protocol": {
+            "openai/chat-completions@1": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          },
+          "reasoning_modes": [
+            "enabled"
+          ],
+          "relationship": "first_party",
+          "restrictions": {
+            "long_context_pricing": {
+              "cache_write_multiplier": 2.0,
+              "cached_input_multiplier": 2.0,
+              "completion_multiplier": 1.5,
+              "input_threshold_tokens": 272000,
+              "prompt_multiplier": 2.0
+            },
+            "tools_protocols": [
+              "openai/responses@1"
+            ],
+            "unsupported_include_values": [
+              "message.output_text.logprobs"
+            ],
+            "unsupported_request_fields": {
+              "openai/chat-completions@1": [
+                "temperature",
+                "top_p",
+                "top_logprobs",
+                "logprobs"
+              ],
+              "openai/responses@1": [
+                "temperature",
+                "top_p",
+                "top_logprobs"
+              ]
+            }
+          },
+          "verification": {
+            "source": "https://developers.openai.com/api/docs/models/gpt-6-astra",
+            "status": "claimed",
+            "verified_at": "2026-09-07"
+          }
+        },
+        {
           "catalog": "openai/gpt-5.4",
           "id": "gpt-5.4",
           "lifecycle": "active",
@@ -45097,6 +45334,22 @@
       "modes": [
         "enabled",
         "disabled"
+      ],
+      "parameter": "reasoning_effort",
+      "type": "reasoning_effort"
+    },
+    {
+      "default_mode": "enabled",
+      "id": "gpt-6-astra",
+      "levels": [
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
+      "modes": [
+        "enabled"
       ],
       "parameter": "reasoning_effort",
       "type": "reasoning_effort"


### PR DESCRIPTION
Related #2358

## Purpose

Add GPT-6 Astra as a built-in OpenAI model and provide a complete, copyable
model-onboarding example for future contributors.

- Adds Astra's intrinsic model card, OpenAI Chat/Responses binding, pricing,
  long-context pricing tiers, unsupported request fields, always-on reasoning
  family, and five launch evaluation records.
- Models the protocol difference explicitly: Chat supports `low` through
  `xhigh`, while Responses additionally supports `max`. The new
  `reasoning_efforts_by_protocol` field may only narrow the model binding's
  validated global effort set.
- Validates protocol-specific reasoning metadata in the catalog compiler,
  Router startup materialization, Dashboard backend, Dashboard frontend API
  guard, and add-model normalization. Invalid or ambiguous configurations fail
  before traffic is served.
- Proves the provider-native wire contract: Chat emits `reasoning_effort`,
  Responses emits `reasoning.effort`, unsupported competing shapes are removed,
  and tools are preserved.
- Adds `model-catalog-astra` to the `response-api` E2E profile. The case checks
  the native model ID, both request protocols, the Responses-only `max` level,
  and the final request body observed by the provider simulator.
- Updates the model-onboarding guide and catalog proposal with the source
  packet, exact authored files, minimal user YAML, evidence rules, generation
  workflow, validation commands, and named E2E command.
- Keeps model facts single-source: contributors edit only
  `config/catalog/manifest.yaml` and `config/catalog/resources/**`. Generation
  updates the built-in release catalog, the Router's embedded catalog, and the
  shared public catalog consumed by the website and Dashboard; the CLI stages
  that same release asset when packaging instead of maintaining another
  checked-in copy.

Authoritative sources:

- https://developers.openai.com/api/docs/models/gpt-6-astra
- https://developers.openai.com/api/docs/guides/latest-model
- https://developers.openai.com/api/docs/guides/reasoning
- https://openai.com/index/gpt-6-astra/

## Test Plan

```bash
make model-catalog-check
make impact ENV=cpu BASE_REF=upstream/main
make check BASE_REF=upstream/main
make verify PROFILE=response-api
make e2e-test-specific \
  E2E_PROFILE=response-api \
  E2E_TESTS=model-catalog-astra
```

## Test Result

- `model-catalog-check`: passed, 58 tests.
- Exact-head `make check`: passed, including generated-artifact drift,
  pre-commit, security and architecture checks, the complete Semantic Router
  suite, Dashboard lint/typecheck/frontend tests (184 files, 861 tests),
  Dashboard backend tests, recipe conformance, and E2E binary build.
- `model-catalog-astra`: passed 1/1 through Envoy, ExtProc, and the local
  provider simulator; no external OpenAI request or credential is required.
- GitHub `response-api` integration, all three live CPU recipe shards, and
  `PR Gate` passed on exact head
  `3cf960a54c68d7b67474e4b104ef80d21530b588`.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category, such as `[Feature]`, `[Bug]`, `[Docs]`, `[Test]`, `[Research]`, `[Community]`, or `[CI/Build]`
- [x] The title does not stack prefixes such as `[Router][Docs]`; affected modules belong in labels and the PR body
- [x] The PR links an `accepted` issue with exactly one owner: one `wg/*` label for project work or `owner/maintainers` for repository governance
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
