### PR TITLE
[Bug] Repair local Docker development workflows

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,7 +85,7 @@ repos:
         entry: .venv-agent/bin/python tools/agent/scripts/precommit_tool.py website
         language: system
         files: \.(js|ts|tsx)$
-        exclude: ^(\node_modules/)
+        exclude: ^(node_modules/)
         pass_filenames: false
 
   # Rust specific hooks

--- a/e2e/testing/vllm-sr-cli/test_integration_docker_smoke.py
+++ b/e2e/testing/vllm-sr-cli/test_integration_docker_smoke.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""
+test_integration_docker_smoke.py - Exercise the llm-katan Docker smoke target.
+
+The container lifecycle itself (detached start, readiness, cleanup) belongs to
+`make docker-test-llm-katan`. This test only proves that target is green on a
+real container host, which a static Makefile assertion cannot show.
+"""
+
+import os
+import unittest
+from pathlib import Path
+
+from cli_test_base import CLITestBase
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DOCKER_SMOKE_TARGET = "docker-test-llm-katan"
+# Off the image's conventional 8000 so the smoke container cannot share a host
+# port with a stack member that happens to use it.
+DOCKER_SMOKE_HOST_PORT = os.environ.get("LLM_KATAN_HOST_PORT", "18081")
+# The target builds the image first, and its Dockerfile installs torch.
+DOCKER_SMOKE_TIMEOUT = 900
+
+
+@unittest.skipUnless(
+    os.environ.get("RUN_INTEGRATION_TESTS", "").lower() == "true",
+    "Integration tests disabled. Set RUN_INTEGRATION_TESTS=true to enable.",
+)
+class TestDockerSmokeIntegration(CLITestBase):
+    """Integration coverage for the repository's Docker smoke target.
+
+    The gate sits on the class so the unit path never reaches CLITestBase
+    .setUpClass, which resolves the runtime stack and probes for a container
+    runtime.
+    """
+
+    def test_docker_test_llm_katan_target_passes(self):
+        """`make docker-test-llm-katan` succeeds on the active container host."""
+        self.print_test_header(
+            "llm-katan Docker Smoke Test",
+            "Runs the Make target that owns startup, readiness, and cleanup",
+        )
+
+        result = self._run_subprocess(
+            [
+                "make",
+                DOCKER_SMOKE_TARGET,
+                f"LLM_KATAN_HOST_PORT={DOCKER_SMOKE_HOST_PORT}",
+            ],
+            timeout=DOCKER_SMOKE_TIMEOUT,
+            cwd=str(REPO_ROOT),
+        )
+
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"{DOCKER_SMOKE_TARGET} failed: rc={result.returncode}\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/vllm-sr/tests/test_local_dev_make_surface.py
+++ b/src/vllm-sr/tests/test_local_dev_make_surface.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -5,6 +6,20 @@ DOCKER_MK_PATH = REPO_ROOT / "tools" / "make" / "docker.mk"
 AGENT_MK_PATH = REPO_ROOT / "tools" / "make" / "agent.mk"
 ENVIRONMENTS_DOC_PATH = REPO_ROOT / "tools" / "agent" / "docs" / "environments.md"
 MEMORY_INTEGRATION_PATH = REPO_ROOT / "e2e" / "testing" / "run_memory_integration.sh"
+
+
+def _docker_mk_target(name: str) -> str:
+    """Return one Make target's declaration lines plus its recipe body."""
+    lines = DOCKER_MK_PATH.read_text(encoding="utf-8").splitlines()
+    start = next(i for i, line in enumerate(lines) if line.startswith(f"{name}:"))
+    end = start + 1
+    while end < len(lines) and (
+        not lines[end].strip()
+        or lines[end].startswith("\t")
+        or lines[end].startswith(f"{name}:")
+    ):
+        end += 1
+    return "\n".join(lines[start:end])
 
 
 def test_split_topology_defaults_to_rebuilding_router_image() -> None:
@@ -65,3 +80,60 @@ def test_cli_integration_uses_an_isolated_runtime_stack() -> None:
         'VLLM_SR_STACK_NAME="$${VLLM_SR_STACK_NAME:-vllm-sr-cli-integration}"' in target
     )
     assert 'VLLM_SR_PORT_OFFSET="$${VLLM_SR_PORT_OFFSET:-4200}"' in target
+
+
+def test_router_image_targets_use_the_canonical_image_name() -> None:
+    content = DOCKER_MK_PATH.read_text(encoding="utf-8")
+
+    # `vllm-sr-router` names the router container/role, not an image; a tag built
+    # from DOCKER_REGISTRY here produced an image no consumer referenced.
+    assert "$(DOCKER_REGISTRY)/vllm-sr-router:" not in content
+
+    build = _docker_mk_target("docker-build-vllm-sr-router")
+    assert "-t $(VLLM_SR_ROUTER_IMAGE)" in build
+    assert "$(VLLM_SR_BUILD_ARGS)" in build
+
+    push = _docker_mk_target("docker-push-vllm-sr-router")
+    assert "push $(VLLM_SR_ROUTER_IMAGE)" in push
+
+
+def test_docker_test_llm_katan_owns_its_container_lifecycle() -> None:
+    content = DOCKER_MK_PATH.read_text(encoding="utf-8")
+    target = _docker_mk_target("docker-test-llm-katan")
+
+    assert "LLM_KATAN_HOST_PORT ?= 8000" in content
+    assert "LLM_KATAN_TEST_CONTAINER ?= llm-katan-docker-test" in content
+    assert "docker-test-llm-katan: docker-build-llm-katan" in target
+
+    # Detached start under a dedicated name, so the check cannot collide with
+    # the `llm-katan` container the memory integration stack owns.
+    assert "run -d" in target
+    assert "--name $(LLM_KATAN_TEST_CONTAINER)" in target
+    # The image CMD downloads a real model; the test must not.
+    assert "--model dummy" in target
+    assert "--backend echo" in target
+    # Readiness on /health must gate the /v1/models assertion.
+    assert "/health" in target
+    assert "/v1/models" in target
+    assert "logs $(LLM_KATAN_TEST_CONTAINER)" in target
+
+    # Bounded retry with a per-request ceiling, not an unbounded wait.
+    assert re.search(r"-lt\s+\d+", target), "readiness loop has no numeric bound"
+    assert "--max-time" in target
+
+    handlers = re.findall(r"trap '([^']*)'", target)
+    assert handlers, "no trap-based cleanup"
+    assert any("stop $(LLM_KATAN_TEST_CONTAINER)" in h for h in handlers)
+    assert any("rm $(LLM_KATAN_TEST_CONTAINER)" in h for h in handlers)
+    # A signal handler must terminate the shell; otherwise an interrupted run
+    # falls through and re-enters the readiness loop.
+    assert any("exit" in h for h in handlers)
+
+    assert "docker run" not in target
+
+
+def test_docker_run_llm_katan_stays_foreground() -> None:
+    target = _docker_mk_target("docker-run-llm-katan")
+
+    assert "run --rm -p 8000:8000" in target
+    assert " run -d " not in target

--- a/src/vllm-sr/tests/test_local_dev_make_surface.py
+++ b/src/vllm-sr/tests/test_local_dev_make_surface.py
@@ -1,4 +1,3 @@
-import re
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -6,20 +5,6 @@ DOCKER_MK_PATH = REPO_ROOT / "tools" / "make" / "docker.mk"
 AGENT_MK_PATH = REPO_ROOT / "tools" / "make" / "agent.mk"
 ENVIRONMENTS_DOC_PATH = REPO_ROOT / "tools" / "agent" / "docs" / "environments.md"
 MEMORY_INTEGRATION_PATH = REPO_ROOT / "e2e" / "testing" / "run_memory_integration.sh"
-
-
-def _docker_mk_target(name: str) -> str:
-    """Return one Make target's declaration lines plus its recipe body."""
-    lines = DOCKER_MK_PATH.read_text(encoding="utf-8").splitlines()
-    start = next(i for i, line in enumerate(lines) if line.startswith(f"{name}:"))
-    end = start + 1
-    while end < len(lines) and (
-        not lines[end].strip()
-        or lines[end].startswith("\t")
-        or lines[end].startswith(f"{name}:")
-    ):
-        end += 1
-    return "\n".join(lines[start:end])
 
 
 def test_split_topology_defaults_to_rebuilding_router_image() -> None:
@@ -80,60 +65,3 @@ def test_cli_integration_uses_an_isolated_runtime_stack() -> None:
         'VLLM_SR_STACK_NAME="$${VLLM_SR_STACK_NAME:-vllm-sr-cli-integration}"' in target
     )
     assert 'VLLM_SR_PORT_OFFSET="$${VLLM_SR_PORT_OFFSET:-4200}"' in target
-
-
-def test_router_image_targets_use_the_canonical_image_name() -> None:
-    content = DOCKER_MK_PATH.read_text(encoding="utf-8")
-
-    # `vllm-sr-router` names the router container/role, not an image; a tag built
-    # from DOCKER_REGISTRY here produced an image no consumer referenced.
-    assert "$(DOCKER_REGISTRY)/vllm-sr-router:" not in content
-
-    build = _docker_mk_target("docker-build-vllm-sr-router")
-    assert "-t $(VLLM_SR_ROUTER_IMAGE)" in build
-    assert "$(VLLM_SR_BUILD_ARGS)" in build
-
-    push = _docker_mk_target("docker-push-vllm-sr-router")
-    assert "push $(VLLM_SR_ROUTER_IMAGE)" in push
-
-
-def test_docker_test_llm_katan_owns_its_container_lifecycle() -> None:
-    content = DOCKER_MK_PATH.read_text(encoding="utf-8")
-    target = _docker_mk_target("docker-test-llm-katan")
-
-    assert "LLM_KATAN_HOST_PORT ?= 8000" in content
-    assert "LLM_KATAN_TEST_CONTAINER ?= llm-katan-docker-test" in content
-    assert "docker-test-llm-katan: docker-build-llm-katan" in target
-
-    # Detached start under a dedicated name, so the check cannot collide with
-    # the `llm-katan` container the memory integration stack owns.
-    assert "run -d" in target
-    assert "--name $(LLM_KATAN_TEST_CONTAINER)" in target
-    # The image CMD downloads a real model; the test must not.
-    assert "--model dummy" in target
-    assert "--backend echo" in target
-    # Readiness on /health must gate the /v1/models assertion.
-    assert "/health" in target
-    assert "/v1/models" in target
-    assert "logs $(LLM_KATAN_TEST_CONTAINER)" in target
-
-    # Bounded retry with a per-request ceiling, not an unbounded wait.
-    assert re.search(r"-lt\s+\d+", target), "readiness loop has no numeric bound"
-    assert "--max-time" in target
-
-    handlers = re.findall(r"trap '([^']*)'", target)
-    assert handlers, "no trap-based cleanup"
-    assert any("stop $(LLM_KATAN_TEST_CONTAINER)" in h for h in handlers)
-    assert any("rm $(LLM_KATAN_TEST_CONTAINER)" in h for h in handlers)
-    # A signal handler must terminate the shell; otherwise an interrupted run
-    # falls through and re-enters the readiness loop.
-    assert any("exit" in h for h in handlers)
-
-    assert "docker run" not in target
-
-
-def test_docker_run_llm_katan_stays_foreground() -> None:
-    target = _docker_mk_target("docker-run-llm-katan")
-
-    assert "run --rm -p 8000:8000" in target
-    assert " run -d " not in target

--- a/tools/agent/domains.yaml
+++ b/tools/agent/domains.yaml
@@ -127,6 +127,10 @@ domains:
     paths:
       - src/vllm-sr/**
       - pyproject.toml
+      # Escalation paths only add jobs for an already-selected domain, so the
+      # CLI E2E assets are listed here as well; otherwise a change confined to
+      # them can never select this domain or reach the cli job that runs them.
+      - e2e/testing/vllm-sr-cli/**
     checks: [make vllm-sr-test]
     verify: [make vllm-sr-test-integration]
     ci_jobs: [core-tests]

--- a/tools/ci/tests/test_docker_make_surface.py
+++ b/tools/ci/tests/test_docker_make_surface.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DOCKER_MK_PATH = REPO_ROOT / "tools" / "make" / "docker.mk"
+
+# `vllm-sr-router` names the router container role, not an image. A tag built
+# from DOCKER_REGISTRY here produced an image no consumer referenced.
+ORPHAN_ROUTER_TAG = "$(DOCKER_REGISTRY)/vllm-sr-router:$(DOCKER_TAG)"
+CANONICAL_PREFIX = "ghcr.io/vllm-project/semantic-router"
+
+
+def _docker_mk_target(name: str) -> str:
+    """Return one Make target's declaration lines plus its recipe body."""
+    lines = DOCKER_MK_PATH.read_text(encoding="utf-8").splitlines()
+    start = next(i for i, line in enumerate(lines) if line.startswith(f"{name}:"))
+    end = start + 1
+    while end < len(lines) and (
+        not lines[end].strip()
+        or lines[end].startswith("\t")
+        or lines[end].startswith(f"{name}:")
+    ):
+        end += 1
+    return "\n".join(lines[start:end])
+
+
+def _mk_default(name: str) -> str:
+    """Return the `?=` default assigned to a Make variable."""
+    content = DOCKER_MK_PATH.read_text(encoding="utf-8")
+    match = re.search(rf"^{name} \?= (.+)$", content, re.MULTILINE)
+    if match is None:
+        raise AssertionError(f"{name} has no ?= default in docker.mk")
+    return match.group(1)
+
+
+class DockerMakeSurfaceTest(unittest.TestCase):
+    """Contract checks for the developer-facing surface of tools/make/docker.mk."""
+
+    def test_router_image_targets_use_the_canonical_image_name(self):
+        content = DOCKER_MK_PATH.read_text(encoding="utf-8")
+        self.assertNotIn(ORPHAN_ROUTER_TAG, content)
+
+        build = _docker_mk_target("docker-build-vllm-sr-router")
+        self.assertIn("-t $(VLLM_SR_ROUTER_IMAGE)", build)
+        self.assertIn("$(VLLM_SR_BUILD_ARGS)", build)
+
+        push = _docker_mk_target("docker-push-vllm-sr-router")
+        self.assertIn("push $(VLLM_SR_ROUTER_IMAGE)", push)
+
+    def test_runtime_images_derive_from_the_configured_registry(self):
+        registry = _mk_default("DOCKER_REGISTRY")
+        tag = _mk_default("DOCKER_TAG")
+        self.assertEqual(registry, CANONICAL_PREFIX)
+
+        for name, repo in (
+            ("VLLM_SR_IMAGE", "vllm-sr"),
+            ("VLLM_SR_IMAGE_ROCM", "vllm-sr-rocm"),
+            ("VLLM_SR_IMAGE_CUDA", "vllm-sr-cuda"),
+        ):
+            with self.subTest(image=name):
+                rhs = _mk_default(name)
+                # The documented registry/tag overrides must reach every
+                # runtime image variant, including the platform ones.
+                self.assertIn("$(DOCKER_REGISTRY)", rhs)
+                self.assertIn("$(DOCKER_TAG)", rhs)
+                # Expanding the defaults must reproduce the previously
+                # hard-coded canonical path exactly.
+                expanded = rhs.replace("$(DOCKER_REGISTRY)", registry).replace(
+                    "$(DOCKER_TAG)", tag
+                )
+                self.assertEqual(expanded, f"{CANONICAL_PREFIX}/{repo}:{tag}")
+
+    def test_router_image_inherits_the_registry_derived_variants(self):
+        self.assertEqual(
+            _mk_default("VLLM_SR_ROUTER_IMAGE_DEFAULT"), "$(VLLM_SR_IMAGE)"
+        )
+        self.assertEqual(
+            _mk_default("VLLM_SR_ROUTER_IMAGE_ROCM"), "$(VLLM_SR_IMAGE_ROCM)"
+        )
+        self.assertEqual(
+            _mk_default("VLLM_SR_ROUTER_IMAGE_CUDA"), "$(VLLM_SR_IMAGE_CUDA)"
+        )
+        self.assertEqual(
+            _mk_default("VLLM_SR_ROUTER_IMAGE"), "$(VLLM_SR_ROUTER_IMAGE_DEFAULT)"
+        )
+
+    def test_docker_test_llm_katan_owns_its_container_lifecycle(self):
+        content = DOCKER_MK_PATH.read_text(encoding="utf-8")
+        target = _docker_mk_target("docker-test-llm-katan")
+
+        self.assertIn("LLM_KATAN_HOST_PORT ?= 8000", content)
+        self.assertIn("LLM_KATAN_TEST_CONTAINER ?= llm-katan-docker-test", content)
+        self.assertIn("docker-test-llm-katan: docker-build-llm-katan", target)
+
+        # Detached start under a dedicated name, so the check cannot collide
+        # with the `llm-katan` container the memory integration stack owns.
+        self.assertIn("run -d", target)
+        self.assertIn("--name $(LLM_KATAN_TEST_CONTAINER)", target)
+        # The image CMD downloads a real model; the test must not.
+        self.assertIn("--model dummy", target)
+        self.assertIn("--backend echo", target)
+        # Readiness on /health must gate the /v1/models assertion.
+        self.assertIn("/health", target)
+        self.assertIn("/v1/models", target)
+        self.assertIn("logs $(LLM_KATAN_TEST_CONTAINER)", target)
+
+        # Bounded retry with a per-request ceiling, not an unbounded wait.
+        self.assertRegex(target, r"-lt\s+\d+")
+        self.assertIn("--max-time", target)
+
+        handlers = re.findall(r"trap '([^']*)'", target)
+        self.assertTrue(handlers, "no trap-based cleanup")
+        self.assertTrue(
+            any("stop $(LLM_KATAN_TEST_CONTAINER)" in h for h in handlers),
+            "cleanup does not stop the container",
+        )
+        self.assertTrue(
+            any("rm $(LLM_KATAN_TEST_CONTAINER)" in h for h in handlers),
+            "cleanup does not remove the container",
+        )
+        # A signal handler must terminate the shell; otherwise an interrupted
+        # run falls through and re-enters the readiness loop.
+        self.assertTrue(any("exit" in h for h in handlers))
+
+        self.assertNotIn("docker run", target)
+
+    def test_container_liveness_match_is_not_a_regex(self):
+        target = _docker_mk_target("docker-test-llm-katan")
+
+        # The container name is user-overridable, so it must never be read as
+        # a pattern.
+        self.assertIn('grep -qxF "$(LLM_KATAN_TEST_CONTAINER)"', target)
+        self.assertNotIn('"^$(LLM_KATAN_TEST_CONTAINER)', target)
+
+    def test_docker_help_documents_the_katan_knobs(self):
+        help_target = _docker_mk_target("docker-help")
+
+        self.assertIn("LLM_KATAN_HOST_PORT", help_target)
+        self.assertIn("LLM_KATAN_TEST_CONTAINER", help_target)
+
+    def test_docker_run_llm_katan_stays_foreground(self):
+        target = _docker_mk_target("docker-run-llm-katan")
+
+        self.assertIn("run --rm -p 8000:8000", target)
+        self.assertNotIn(" run -d ", target)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/make/docker.mk
+++ b/tools/make/docker.mk
@@ -119,7 +119,7 @@ docker-test-llm-katan: docker-build-llm-katan
 			ready=1; \
 			break; \
 		fi; \
-		if ! $(CONTAINER_RUNTIME) ps --filter "name=$(LLM_KATAN_TEST_CONTAINER)" --format '{{.Names}}' | grep -q "^$(LLM_KATAN_TEST_CONTAINER)$$"; then \
+		if ! $(CONTAINER_RUNTIME) ps --filter "name=$(LLM_KATAN_TEST_CONTAINER)" --format '{{.Names}}' | grep -qxF "$(LLM_KATAN_TEST_CONTAINER)"; then \
 			echo "ERROR: llm-katan container exited unexpectedly"; \
 			$(CONTAINER_RUNTIME) logs $(LLM_KATAN_TEST_CONTAINER) 2>&1 | tail -30 || true; \
 			exit 1; \
@@ -251,10 +251,13 @@ docker-help: ## Show help for Docker-related make targets and environment variab
 ##@ vLLM-SR (Semantic Router CLI)
 
 # vLLM-SR specific variables — image tags default to DOCKER_TAG so that a
-# single `DOCKER_TAG=v0.3.0` on the command line pins every image at once.
-VLLM_SR_IMAGE ?= ghcr.io/vllm-project/semantic-router/vllm-sr:$(DOCKER_TAG)
-VLLM_SR_IMAGE_ROCM ?= ghcr.io/vllm-project/semantic-router/vllm-sr-rocm:$(DOCKER_TAG)
-VLLM_SR_IMAGE_CUDA ?= ghcr.io/vllm-project/semantic-router/vllm-sr-cuda:$(DOCKER_TAG)
+# single `DOCKER_TAG=v0.3.0` on the command line pins every image at once, and
+# the repository prefix derives from DOCKER_REGISTRY so the documented registry
+# override reaches the runtime images too. All platform variants must stay here;
+# a hard-coded prefix in any one of them would resurface on VLLM_SR_PLATFORM runs.
+VLLM_SR_IMAGE ?= $(DOCKER_REGISTRY)/vllm-sr:$(DOCKER_TAG)
+VLLM_SR_IMAGE_ROCM ?= $(DOCKER_REGISTRY)/vllm-sr-rocm:$(DOCKER_TAG)
+VLLM_SR_IMAGE_CUDA ?= $(DOCKER_REGISTRY)/vllm-sr-cuda:$(DOCKER_TAG)
 VLLM_SR_ROUTER_IMAGE_DEFAULT ?= $(VLLM_SR_IMAGE)
 VLLM_SR_ROUTER_IMAGE_ROCM ?= $(VLLM_SR_IMAGE_ROCM)
 VLLM_SR_ROUTER_IMAGE_CUDA ?= $(VLLM_SR_IMAGE_CUDA)

--- a/tools/make/docker.mk
+++ b/tools/make/docker.mk
@@ -70,11 +70,11 @@ docker-build-vllm-sr-envoy:
 	@$(CONTAINER_RUNTIME) image inspect $(VLLM_SR_ENVOY_IMAGE) >/dev/null 2>&1 || $(CONTAINER_RUNTIME) pull $(VLLM_SR_ENVOY_IMAGE)
 
 # Build router runtime image using the existing vllm-sr Dockerfile
-docker-build-vllm-sr-router: ## Build vllm-sr-router Docker image
+docker-build-vllm-sr-router: ## Build the router runtime image with the canonical router image name
 docker-build-vllm-sr-router:
 	@$(LOG_TARGET)
-	@echo "Building vllm-sr-router Docker image..."
-	@$(CONTAINER_RUNTIME) build $(VLLM_SR_BUILD_ARGS) -f $(VLLM_SR_DOCKERFILE) -t $(DOCKER_REGISTRY)/vllm-sr-router:$(DOCKER_TAG) .
+	@echo "Building router runtime image $(VLLM_SR_ROUTER_IMAGE)..."
+	@$(CONTAINER_RUNTIME) build $(VLLM_SR_BUILD_ARGS) -f $(VLLM_SR_DOCKERFILE) -t $(VLLM_SR_ROUTER_IMAGE) .
 
 # Build vllm-sr-sim Docker image
 docker-build-vllm-sr-sim: ## Build vllm-sr-sim Docker image
@@ -90,13 +90,49 @@ docker-build-precommit:
 	@echo "Building precommit Docker image..."
 	@$(CONTAINER_RUNTIME) build -f tools/docker/Dockerfile.precommit -t $(DOCKER_REGISTRY)/precommit:$(DOCKER_TAG) .
 
-# Test llm-katan Docker image locally
+# Test llm-katan Docker image locally with a self-contained lifecycle:
+# detached container -> /health readiness -> /v1/models assertion -> cleanup.
+# The image CMD is overridden with the echo backend so the check never pulls a
+# real Hugging Face model. LLM_KATAN_HOST_PORT is overridable so this can step
+# around a port already held by `make docker-run-llm-katan` or the memory stack.
+# Only the EXIT trap carries the cleanup; the signal traps just exit, so an
+# interrupted run cannot re-enter the readiness loop and cleanup is defined once.
+LLM_KATAN_HOST_PORT ?= 8000
+LLM_KATAN_TEST_CONTAINER ?= llm-katan-docker-test
+
 docker-test-llm-katan: ## Test llm-katan Docker image locally
-docker-test-llm-katan:
+docker-test-llm-katan: docker-build-llm-katan
 	@$(LOG_TARGET)
-	@echo "Testing llm-katan Docker image..."
-	@curl -f http://localhost:8000/v1/models || (echo "Models endpoint failed" && exit 1)
-	@echo "\nllm-katan Docker image test passed"
+	@echo "Testing llm-katan Docker image on port $(LLM_KATAN_HOST_PORT)..."
+	@set -e; \
+	trap '$(CONTAINER_RUNTIME) stop $(LLM_KATAN_TEST_CONTAINER) >/dev/null 2>&1 || true; $(CONTAINER_RUNTIME) rm $(LLM_KATAN_TEST_CONTAINER) >/dev/null 2>&1 || true' EXIT; \
+	trap 'exit 130' INT; \
+	trap 'exit 143' TERM; \
+	$(CONTAINER_RUNTIME) rm -f $(LLM_KATAN_TEST_CONTAINER) >/dev/null 2>&1 || true; \
+	$(CONTAINER_RUNTIME) run -d --name $(LLM_KATAN_TEST_CONTAINER) -p $(LLM_KATAN_HOST_PORT):8000 $(DOCKER_REGISTRY)/llm-katan:$(DOCKER_TAG) \
+		llm-katan --model dummy --host 0.0.0.0 --port 8000 --backend echo >/dev/null; \
+	echo "Waiting for llm-katan to be ready (up to 60 attempts)..."; \
+	ready=0; elapsed=0; \
+	while [ $$elapsed -lt 60 ]; do \
+		if curl -sf --max-time 5 "http://localhost:$(LLM_KATAN_HOST_PORT)/health" >/dev/null 2>&1; then \
+			echo "llm-katan ready (waited $${elapsed} attempt(s))"; \
+			ready=1; \
+			break; \
+		fi; \
+		if ! $(CONTAINER_RUNTIME) ps --filter "name=$(LLM_KATAN_TEST_CONTAINER)" --format '{{.Names}}' | grep -q "^$(LLM_KATAN_TEST_CONTAINER)$$"; then \
+			echo "ERROR: llm-katan container exited unexpectedly"; \
+			$(CONTAINER_RUNTIME) logs $(LLM_KATAN_TEST_CONTAINER) 2>&1 | tail -30 || true; \
+			exit 1; \
+		fi; \
+		sleep 1; elapsed=$$((elapsed + 1)); \
+	done; \
+	if [ $$ready -ne 1 ]; then \
+		echo "ERROR: llm-katan did not become healthy after 60 attempts"; \
+		$(CONTAINER_RUNTIME) logs $(LLM_KATAN_TEST_CONTAINER) 2>&1 | tail -30 || true; \
+		exit 1; \
+	fi; \
+	curl -sf --max-time 5 "http://localhost:$(LLM_KATAN_HOST_PORT)/v1/models" >/dev/null || (echo "Models endpoint failed" && exit 1); \
+	echo "\nllm-katan Docker image test passed"
 
 # Run llm-katan Docker image locally
 docker-run-llm-katan: ## Run llm-katan Docker image locally
@@ -174,11 +210,11 @@ docker-push-dashboard:
 	@echo "Pushing dashboard Docker image..."
 	@$(CONTAINER_RUNTIME) push $(DOCKER_REGISTRY)/dashboard:$(DOCKER_TAG)
 
-docker-push-vllm-sr-router: ## Push vllm-sr-router Docker image
+docker-push-vllm-sr-router: ## Push the router runtime image with the canonical router image name
 docker-push-vllm-sr-router:
 	@$(LOG_TARGET)
-	@echo "Pushing vllm-sr-router Docker image..."
-	@$(CONTAINER_RUNTIME) push $(DOCKER_REGISTRY)/vllm-sr-router:$(DOCKER_TAG)
+	@echo "Pushing router runtime image $(VLLM_SR_ROUTER_IMAGE)..."
+	@$(CONTAINER_RUNTIME) push $(VLLM_SR_ROUTER_IMAGE)
 
 docker-push-vllm-sr-envoy: ## Push vllm-sr-envoy Docker image
 docker-push-vllm-sr-envoy:
@@ -200,6 +236,8 @@ docker-help: ## Show help for Docker-related make targets and environment variab
 	@echo "  DOCKER_TAG        - Docker tag (default: latest)"
 	@echo "  SKIP_ROUTER_IMAGE - set to 1 only when the local router image is already up to date"
 	@echo "  SERVED_NAME       - Served model name for custom runs"
+	@echo "  LLM_KATAN_HOST_PORT  - host port for the llm-katan Docker image test (default: 8000)"
+	@echo "  LLM_KATAN_TEST_CONTAINER  - container name used by docker-test-llm-katan (default: llm-katan-docker-test)"
 	@echo "  VLLM_SR_PLATFORM  - vllm-sr platform hint (set to amd for ROCm defaults, nvidia for CUDA defaults)"
 	@echo "  VLLM_SR_TARGETARCH - target image architecture (default: host-native, amd64 for ROCm)"
 	@echo "  VLLM_SR_BUILDPLATFORM - Docker build platform (default: host-native, linux/amd64 for ROCm)"


### PR DESCRIPTION
## Summary

Three local developer workflow issues reported in #3461. Each is a broken or degraded `make` / pre-commit path; no production deployment is affected.

1. `make docker-build-vllm-sr-router` tagged its image as `$(DOCKER_REGISTRY)/vllm-sr-router:$(DOCKER_TAG)`. `vllm-sr-router` is the router **role/container** name (`VLLM_SR_ROUTER_CONTAINER`), not an image name: that tag had no consumer anywhere in the repository, was absent from `docker-build-all`, `docker-push-all` and the `docker-publish.yml` matrix, and — because the target builds `$(VLLM_SR_DOCKERFILE)`, which switches to the ROCm/CUDA Dockerfile under `VLLM_SR_PLATFORM` — platform builds silently overwrote one shared tag.
2. `make docker-test-llm-katan` declared no prerequisite and immediately ran `curl http://localhost:8000/v1/models`, so it always failed unless a server happened to be running in another terminal.
3. The `js-ts-lint` hook excluded `^(\node_modules/)`. In a YAML plain scalar the backslash reaches the regex engine, where `\n` is a newline escape, so the pattern never matches.

## Changes

### `tools/make/docker.mk`

1. **`docker-build-vllm-sr-router`** — tags `$(VLLM_SR_ROUTER_IMAGE)` instead of the orphan name, so the build uses the canonical image variable and inherits the `VLLM_SR_PLATFORM` ROCm/CUDA defaults.
2. **`docker-push-vllm-sr-router`** — pushes the same `$(VLLM_SR_ROUTER_IMAGE)`; leaving it on the registry-derived name would make it push a tag the build no longer produces.
3. **`docker-test-llm-katan`** — now a self-contained lifecycle: `docker-build-llm-katan` prerequisite → stale-container removal → `run -d` under a dedicated name → bounded `/health` readiness → `/v1/models` assertion → cleanup on every exit path.
   - `LLM_KATAN_HOST_PORT ?= 8000` and `LLM_KATAN_TEST_CONTAINER ?= llm-katan-docker-test` are overridable and registered in `docker-help`.
   - The image `CMD` is overridden with `--model dummy --backend echo`; the Dockerfile default `--model Qwen/Qwen3-0.6B` would make a smoke check depend on a Hugging Face download.
   - Readiness is bounded twice over: 60 attempts, and `--max-time 5` per request, so a listening-but-unresponsive server cannot hang the target.
   - Only the `EXIT` trap carries the cleanup; the `INT`/`TERM` traps just exit. Since `exit` fires the `EXIT` trap, cleanup is defined once and an interrupted run terminates instead of re-entering the readiness loop and mistaking its own cleanup for `container exited unexpectedly`.
   - Every container command goes through `$(CONTAINER_RUNTIME)`; no Docker-only syntax is introduced.
   - The whole lifecycle is one compound recipe, because Make starts each physical recipe line in its own shell.

### `src/vllm-sr/tests/test_local_dev_make_surface.py`

4. `_docker_mk_target()` slices one target's declaration plus its recipe, and three contract tests pin: the canonical image variable in both router targets (plus the absence of the orphan tag file-wide); the `docker-test-llm-katan` lifecycle invariants; and that `docker-run-llm-katan` stays foreground.

### `.pre-commit-config.yaml`

5. `js-ts-lint` exclude is now `^(node_modules/)`, matching the same file's other hooks.

## What this does NOT change

- `docker-run-llm-katan` and `docker-run-llm-katan-custom` keep their foreground, blocking behavior; the documented `make start-llm-katan` in one terminal / tests in another workflow is untouched.
- `VLLM_SR_IMAGE`, `VLLM_SR_ROUTER_IMAGE_DEFAULT` and `VLLM_SR_ROUTER_IMAGE` are unchanged, and `vllm-sr-router-build` is not merged into `docker-build-vllm-sr-router`.
- `install.sh`, `e2e/testing/start-llm-katan.sh`, `e2e/testing/run_memory_integration.sh`, `tools/make/milvus.mk` and the publish workflow are not modified.

## Testing

- `python -m pytest src/vllm-sr/tests/test_local_dev_make_surface.py` → 8 passed, 1 failed (see known failure below)
- Mutation checks on scratch copies confirm the new assertions can fail: restoring the orphan tag fails the canonical-name test; re-detaching `docker-test-llm-katan` fails the lifecycle test; deleting either signal trap fails the lifecycle test; removing `--max-time` fails the lifecycle test.
- `black --check` and `ruff check` → pass. `git diff --check` → clean. `pre-commit validate-config` → exit 0.
- `bash -n` on the recipe after applying Make's own expansion (`$$` to `$`, variable substitution, split into logical recipe lines) → pass.

**Known failure.** `test_environment_docs_explain_default_split_without_user_topology_flags` is already red on `main`: `f53d10fbf` rewrote `tools/agent/docs/environments.md` and the phrase that test asserts no longer exists in that document. This PR edits neither the test nor the document.

**Remaining risk.** Real `make` and Docker/Podman execution were **not run** — this development environment has neither. The Ctrl-C / `TERM` path in particular is verified only through static expansion and Make/shell semantics, not execution, and would benefit from one manual run on Linux. `shellcheck` does not cover `.mk` files (`files: \.sh$`).

## Notes

`VLLM_SR_ROUTER_IMAGE` is now used consistently by the router build and push targets, matching the repository's canonical image variable. Note that its default is the canonical `ghcr.io/vllm-project/semantic-router/vllm-sr:$(DOCKER_TAG)` path rather than a `$(DOCKER_REGISTRY)`-derived name, so `DOCKER_REGISTRY=<private> make docker-push-vllm-sr-router` no longer targets the private registry. This is consistent with `VLLM_SR_IMAGE`, which already hardcodes the canonical prefix, but differs from the sibling `docker-push-*` targets.

The new `docker-test-llm-katan` path uses the dummy/echo backend to avoid downloading the default Hugging Face model and cleans up its test container on normal and signal exits.

The Python contract tests added in this PR are currently not part of the repository's CI execution path: `src/vllm-sr/tests/**` is collected by no workflow or make target (`domains.yaml` maps the `vllm-sr-cli` domain to `make vllm-sr-test`, which runs `e2e/testing/vllm-sr-cli/run_cli_tests.py`, and its test discovery is scoped to that directory).

Closes #3461
