### PR TITLE
[Community] Update community meeting schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,17 +97,14 @@ Track contributors, workgroups, and weekly activity at [community.vllm-sr.ai](ht
 
 ### Community Meetings
 
-We host community meetings on the first and third Tuesday of each month to sync with contributors across different time zones:
+We host two monthly community meetings across APAC and the Americas:
 
-- **First Tuesday of the month**: 9:00-10:00 AM EST (accommodates US EST, EU, and Asia Pacific contributors)
-  - [Zoom Link](https://us05web.zoom.us/j/84122485631?pwd=BB88v03mMNLVHn60YzVk4PihuqBV9d.1)
-  - [Google Calendar Invite](https://us05web.zoom.us/meeting/tZAsdeuspj4sGdVraOOR4UaXSstrH2jjPYFq/calendar/google/add?meetingMasterEventId=4jjzUKSLSLiBHtIKZpGc3g)
-  - [ics file](https://drive.google.com/file/d/15wO8cg0ZjNxdr8OtGiZyAgkSS8_Wry0J/view?usp=sharing)
-- **Third Tuesday of the month**: 1:00-2:00 PM EST (accommodates US EST and California contributors)
-  - [Zoom Link](https://us06web.zoom.us/j/86871492845?pwd=LcTtXm9gtGu23JeWqXxbnLLCCvbumB.1)
-  - [Google Calendar Invite](https://us05web.zoom.us/meeting/tZIlcOispzkiHtH2dlkWlLym68bEqvuf3MU5/calendar/google/add?meetingMasterEventId=PqWz2vk7TOCszPXqconGAA)
-  - [ics file](https://drive.google.com/file/d/1T54mwYpXXoV9QfR76I56BFBPNbykSsTw/view?usp=sharing)
-- Meeting recordings: [YouTube](https://www.youtube.com/@vLLMSemanticRouter/videos)
+- **APAC-friendly meeting — second Wednesday of the month**: 9:00-10:00 AM Singapore time (UTC+8; the same local time in Beijing)
+  - [Google Meet](https://meet.google.com/sed-jmht-ddm)
+  - [Google Calendar Invite](https://calendar.app.google/w3r6mfKf4X4xCMAm9)
+- **Americas-friendly meeting — fourth Wednesday of the month**: 8:00-9:00 PM Eastern Time (`America/New_York`) / 5:00-6:00 PM Pacific Time
+  - [Google Meet](https://meet.google.com/wvm-vbfy-xzj)
+  - [Google Calendar Invite](https://calendar.app.google/xHPHx8xhD1wHQfhH6)
 
 ## Contributing
 


### PR DESCRIPTION
Closes #1874

## Purpose

Replace the outdated first- and third-Tuesday Zoom schedule in `README.md` with two recurring public Google Meet sessions:

- APAC-friendly: second Wednesday, 9:00-10:00 AM Singapore/Beijing time (UTC+8).
- Americas-friendly: fourth Wednesday, 8:00-9:00 PM Eastern Time / 5:00-6:00 PM Pacific Time.

The change also adds the corresponding public Google Calendar invitations and removes the previous Zoom, ICS, and meeting-recordings links. This is community governance work owned by `owner/maintainers`.

## Test Plan

- Run `make check CHANGED_FILES="README.md"`.
- Verify both public Google Calendar invitations resolve to the expected event time and Google Meet.

## Test Result

- After rebasing onto the latest `main`, `make check CHANGED_FILES="README.md"` passed, including Markdown formatting, spelling, structure, architecture dependency, and translation coverage checks.
- Both public Calendar invitations resolved to the expected Google Meet sessions and first occurrence times.
- Documentation-only change; no remote AMD validation was required.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category.
- [x] The title uses a single category prefix.
- [x] The PR links accepted issue #1874 with the single `owner/maintainers` owner.
- [x] The commit is signed off with `git commit -s`.
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope and validation.

</details>
