### PR TITLE
[Feature] Remove benchmark header source links

### DIFF
--- a/dashboard/frontend/src/pages/ModelHubViews.test.tsx
+++ b/dashboard/frontend/src/pages/ModelHubViews.test.tsx
@@ -61,6 +61,7 @@ describe('model hub views', () => {
     expect(markup).toContain('aria-label="Filter benchmarks"')
     expect(markup).toContain('aria-pressed="true"')
     expect(markup).not.toContain('<select')
+    expect(markup).not.toContain('Source ↗')
     expect(markup.indexOf('Core <span>6</span>')).toBeGreaterThan(markup.indexOf('All <span>'))
     expect(markup).toMatch(/\d+\.\d%/)
     const modelIDs = new Set(rows.map((row) => row.model.id))

--- a/dashboard/frontend/src/pages/ModelHubViews.tsx
+++ b/dashboard/frontend/src/pages/ModelHubViews.tsx
@@ -218,11 +218,6 @@ export const BenchmarkExplorer: React.FC<{
                       {readable(chart.selection.profile)} · {readable(chart.selection.metric)}
                     </span>
                   </div>
-                  {chart.benchmark?.source ? (
-                    <a href={chart.benchmark.source} target="_blank" rel="noreferrer">
-                      Source ↗
-                    </a>
-                  ) : null}
                 </header>
                 <div className={styles.chartMeta}>
                   <span>{chart.points.length} results</span>

--- a/website/scripts/lib/model-hub-benchmark-support.test.mjs
+++ b/website/scripts/lib/model-hub-benchmark-support.test.mjs
@@ -262,6 +262,8 @@ test('website benchmark renders every filtered result in one comparison surface'
   assert.match(component, /charts\.map\(\(?chart\)? =>/)
   assert.doesNotMatch(component, /<Pagination/)
   assert.doesNotMatch(component, /pageRows/)
+  assert.doesNotMatch(component, /Source ↗/)
+  assert.doesNotMatch(component, /chart\.benchmark\.source/)
 })
 
 test('website benchmark bar height follows metric direction', () => {

--- a/website/src/components/model-hub/ModelHubBenchmark.tsx
+++ b/website/src/components/model-hub/ModelHubBenchmark.tsx
@@ -105,13 +105,6 @@ function BenchmarkPanel({
           <strong>{chart.benchmark.display_name}</strong>
           <small>{profile?.description ?? readable(chart.profile)}</small>
         </span>
-        {chart.benchmark.source
-          ? (
-              <a href={chart.benchmark.source} target="_blank" rel="noreferrer">
-                Source ↗
-              </a>
-            )
-          : null}
       </header>
       <div className={styles.chartMeta}>
         <span>


### PR DESCRIPTION
Related #2358

## Purpose

Remove the repeated benchmark-definition **Source ↗** links from comparison chart headers in the Dashboard and website.

Per-evaluation evidence and provenance links remain available in model details; this only removes the redundant chart-level links.

## Test Plan

- `make check BASE_REF=upstream/main`
- `cd website && node --test scripts/lib/model-hub-benchmark-support.test.mjs`
- `cd website && ./node_modules/.bin/docusaurus build --locale en`

## Test Result

All listed checks passed locally on current `upstream/main`; the dashboard gate covered 184 test files and 858 tests.