### PR TITLE
[Feature] Simplify Provider discovery labels

### DIFF
--- a/dashboard/frontend/src/pages/ModelHubComponents.test.tsx
+++ b/dashboard/frontend/src/pages/ModelHubComponents.test.tsx
@@ -1,0 +1,29 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+
+import { HubHero } from './ModelHubComponents'
+
+describe('Model Hub hero', () => {
+  it('presents every provider without exposing internal mapping classes', () => {
+    const markup = renderToStaticMarkup(
+      <MemoryRouter>
+        <HubHero
+          stats={{
+            models: 101,
+            physicalModels: 90,
+            virtualModels: 11,
+            mappedProviders: 3,
+            providerContracts: 17,
+            creators: 24,
+            evaluatedModels: 80,
+            evaluations: 900,
+          }}
+        />
+      </MemoryRouter>,
+    )
+
+    expect(markup).toContain('<dd>17</dd><dt>providers</dt>')
+    expect(markup).not.toContain('mapped providers')
+  })
+})

--- a/dashboard/frontend/src/pages/ModelHubComponents.tsx
+++ b/dashboard/frontend/src/pages/ModelHubComponents.tsx
@@ -48,7 +48,7 @@ export const HubHero: React.FC<{ stats: ModelHubStats }> = ({ stats }) => (
     <dl className={styles.stats}>
       <Stat label="models" value={stats.models} />
       <Stat label="creators" value={stats.creators} />
-      <Stat label="mapped providers" value={stats.mappedProviders} />
+      <Stat label="providers" value={stats.providerContracts} />
       <Stat label="evaluations" value={stats.evaluations} />
     </dl>
     <Link className={styles.primaryAction} to="/config/models">

--- a/website/scripts/lib/model-hub-provider-operations.test.mjs
+++ b/website/scripts/lib/model-hub-provider-operations.test.mjs
@@ -91,3 +91,31 @@ test('provider cards render each supported operation instead of only a count', (
   assert.match(providerCard, /operation\.path/)
   assert.doesNotMatch(providerCard, /operationCount/)
 })
+
+test('provider discovery uses task-oriented choices instead of internal mapping classes', () => {
+  const providers = readFileSync(
+    resolve(repositoryRoot, 'website/src/components/model-hub/ModelHubProviders.tsx'),
+    'utf8',
+  )
+  const page = readFileSync(
+    resolve(repositoryRoot, 'website/src/pages/models.tsx'),
+    'utf8',
+  )
+  const detail = readFileSync(
+    resolve(repositoryRoot, 'website/src/components/model-hub/ModelHubDetail.tsx'),
+    'utf8',
+  )
+
+  assert.match(providers, /Every provider below can be connected to Semantic Router/)
+  assert.match(providers, /built-in .*choice/)
+  assert.match(providers, /Enter a model ID/)
+  assert.match(page, /catalog\.providers\.length/)
+  assert.match(page, /available providers/)
+  assert.match(detail, /No built-in provider choice/)
+  assert.doesNotMatch(providers, /ProviderScope/)
+  assert.doesNotMatch(providers, /Contract only/)
+  assert.doesNotMatch(providers, />Mapped /)
+  assert.doesNotMatch(page, /mapped providers/)
+  assert.doesNotMatch(page, /runtime contracts/)
+  assert.doesNotMatch(detail, /mapped provider/)
+})

--- a/website/src/components/model-hub/ModelHubDetail.tsx
+++ b/website/src/components/model-hub/ModelHubDetail.tsx
@@ -233,7 +233,7 @@ export function ModelHubDetail({
                         ))}
                       </div>
                     )
-                  : <p>No mapped provider.</p>}
+                  : <p>No built-in provider choice. Connect a compatible provider and enter its model ID.</p>}
               </DetailSection>
             )}
         <DetailSection title={`Evidence · ${evaluations.length}`}>

--- a/website/src/components/model-hub/ModelHubProviders.tsx
+++ b/website/src/components/model-hub/ModelHubProviders.tsx
@@ -1,10 +1,6 @@
 import React, { useMemo, useState } from 'react'
 
-import type {
-  CatalogProtocol,
-  CatalogProvider,
-  ProviderScope,
-} from '../../data/modelHubCatalogTypes'
+import type { CatalogProtocol, CatalogProvider } from '../../data/modelHubCatalogTypes'
 import { providerProtocolOperations } from '../../data/modelHubProviderOperations'
 import { CatalogMark } from './ModelHubMark'
 import { EmptyState, Pagination, readable, srOnlyClass } from './ModelHubPrimitives'
@@ -28,7 +24,7 @@ function ProviderCard({
         }))
       : []
   })
-  const mapped = Boolean(provider.models?.length)
+  const builtInModelCount = provider.models?.length ?? 0
 
   return (
     <article className={styles.providerCard}>
@@ -47,7 +43,6 @@ function ProviderCard({
             {provider.conformance.verified_at ? ` · ${provider.conformance.verified_at}` : ''}
           </span>
           <span>{readable(provider.support_tier)}</span>
-          <span>{mapped ? 'Mapped' : 'Contract only'}</span>
         </div>
       </div>
       <div className={styles.summary}>
@@ -56,7 +51,11 @@ function ProviderCard({
         <dl className={styles.providerFacts}>
           <div>
             <dt>Models</dt>
-            <dd>{provider.models?.length || 'Custom'}</dd>
+            <dd>
+              {builtInModelCount
+                ? `${builtInModelCount} built-in ${builtInModelCount === 1 ? 'choice' : 'choices'}`
+                : 'Enter a model ID'}
+            </dd>
           </div>
           <div>
             <dt>Protocols</dt>
@@ -118,29 +117,24 @@ export function ModelHubProviders({
   protocols: CatalogProtocol[]
 }) {
   const [query, setQuery] = useState('')
-  const [scope, setScope] = useState<ProviderScope>('mapped')
   const [page, setPage] = useState(1)
   const protocolMap = useMemo(() => new Map(protocols.map(item => [item.id, item])), [protocols])
-  const mappedCount = providers.filter(provider => provider.models?.length).length
-  const contractOnlyCount = providers.length - mappedCount
   const filtered = providers.filter((provider) => {
-    const mapped = Boolean(provider.models?.length)
-    const scopeMatches = scope === 'all' || (scope === 'mapped' ? mapped : !mapped)
     const haystack = `${provider.display_name} ${provider.id} ${provider.description} ${provider.protocols.join(' ')}`.toLocaleLowerCase()
-    return scopeMatches && (!query.trim() || haystack.includes(query.trim().toLocaleLowerCase()))
+    return !query.trim() || haystack.includes(query.trim().toLocaleLowerCase())
   })
   const pageCount = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE))
   const pageProviders = filtered.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE)
-  const updateScope = (next: ProviderScope) => {
-    setScope(next)
-    setPage(1)
-  }
 
   return (
     <div className={styles.providers}>
+      <p className={styles.providerGuide}>
+        Every provider below can be connected to Semantic Router. Choose a built-in model when one
+        is listed, or enter any model ID that the provider serves.
+      </p>
       <div className={styles.toolbar}>
         <label>
-          <span className={srOnlyClass}>Search provider contracts</span>
+          <span className={srOnlyClass}>Search providers</span>
           <svg viewBox="0 0 20 20" aria-hidden="true">
             <circle cx="8.5" cy="8.5" r="5.5" />
             <path d="m12.5 12.5 4 4" />
@@ -155,15 +149,6 @@ export function ModelHubProviders({
             placeholder="Search providers"
           />
         </label>
-        <div role="group" aria-label="Provider scope">
-          {([
-            ['mapped', `Mapped ${mappedCount}`],
-            ['contract_only', `Contract only ${contractOnlyCount}`],
-            ['all', `All ${providers.length}`],
-          ] as Array<[ProviderScope, string]>).map(([value, label]) => (
-            <button key={value} type="button" aria-pressed={scope === value} onClick={() => updateScope(value)}>{label}</button>
-          ))}
-        </div>
       </div>
       <div className={styles.resultCount}>
         {filtered.length}

--- a/website/src/components/model-hub/modelHubProviders.module.css
+++ b/website/src/components/model-hub/modelHubProviders.module.css
@@ -2,11 +2,17 @@
   display: grid;
 }
 
+.providerGuide {
+  max-width: 52rem;
+  margin: 0 0 var(--space-3);
+  color: var(--site-muted);
+  font-size: var(--text-sm);
+  line-height: 1.5;
+}
+
 .toolbar {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: var(--space-3);
   margin-bottom: var(--space-3);
 }
 
@@ -43,38 +49,6 @@
 .toolbar input:focus {
   border-color: var(--site-accent);
   box-shadow: 0 0 0 3px var(--site-accent-soft);
-}
-
-.toolbar > div {
-  display: flex;
-  gap: 2px;
-  padding: 0.18rem;
-  border: 1px solid var(--site-border);
-  border-radius: var(--radius-md);
-  background: var(--site-bg);
-}
-
-.toolbar button {
-  min-height: 2.15rem;
-  padding: 0.3rem 0.65rem;
-  border: 0;
-  border-radius: var(--radius-sm);
-  background: transparent;
-  color: var(--site-muted);
-  cursor: pointer;
-  font: inherit;
-  font-size: var(--text-sm);
-}
-
-.toolbar button[aria-pressed='true'] {
-  background: var(--site-accent-soft);
-  color: var(--site-accent-strong);
-  font-weight: var(--site-font-weight-medium);
-}
-
-.toolbar button:hover:not([aria-pressed='true']) {
-  background: var(--site-hover-chrome-bg);
-  color: var(--site-hover-text);
 }
 
 .resultCount {
@@ -308,14 +282,6 @@
 
   .toolbar > label {
     width: 100%;
-  }
-
-  .toolbar > div {
-    overflow-x: auto;
-  }
-
-  .toolbar button {
-    flex: 1 0 auto;
   }
 
   .providerCard {

--- a/website/src/data/modelHubCatalogTypes.ts
+++ b/website/src/data/modelHubCatalogTypes.ts
@@ -161,5 +161,3 @@ export interface BenchmarkRow {
   model: CatalogModel
   value: number
 }
-
-export type ProviderScope = 'mapped' | 'contract_only' | 'all'

--- a/website/src/pages/models.tsx
+++ b/website/src/pages/models.tsx
@@ -295,7 +295,6 @@ export default function ModelsPage() {
   const creators = new Set(
     catalog.models.filter(model => model.kind === 'physical').map(model => model.publisher),
   ).size
-  const mappedProviders = catalog.providers.filter(provider => provider.models?.length).length
   const evaluations = modelHubPublicEvaluations(catalog.evaluations).length
 
   return (
@@ -328,8 +327,8 @@ export default function ModelsPage() {
                 <dt>creators</dt>
               </div>
               <div>
-                <dd>{mappedProviders}</dd>
-                <dt>mapped providers</dt>
+                <dd>{catalog.providers.length}</dd>
+                <dt>providers</dt>
               </div>
               <div>
                 <dd>{evaluations}</dd>
@@ -370,13 +369,9 @@ export default function ModelsPage() {
             <header className={styles.sectionHeading}>
               <h2 id="providers-heading">Providers</h2>
               <span>
-                {mappedProviders}
-                {' '}
-                mapped ·
-                {' '}
                 {catalog.providers.length}
                 {' '}
-                runtime contracts
+                available providers
               </span>
             </header>
             <ModelHubProviders providers={catalog.providers} protocols={catalog.protocols} />


### PR DESCRIPTION
Related #2358

## Purpose

Make Provider discovery task-oriented instead of exposing internal catalog mapping classes.

- show every Provider by default
- remove the user-facing **Mapped** and **Contract only** filters and badges
- explain built-in model choices versus entering a served model ID
- report all Provider contracts in the Dashboard Model Hub summary

Internal model-to-Provider mappings remain unchanged for routing and compatibility checks.

## Test Plan

- `make check BASE_REF=upstream/main`
- `cd website && node --test scripts/lib/model-hub-provider-operations.test.mjs`
- `cd website && ./node_modules/.bin/docusaurus build --locale en`

## Test Result

All listed checks passed locally on current `upstream/main`; the dashboard gate covered 185 test files and 859 tests.