### PR TITLE
[Test] Conformance coverage for image cancellation, usage/artifact, and replay round-trips (#3183)

### DIFF
--- a/src/semantic-router/pkg/protocolcodec/image_generation_test.go
+++ b/src/semantic-router/pkg/protocolcodec/image_generation_test.go
@@ -1,6 +1,7 @@
 package protocolcodec
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"os"
@@ -222,6 +223,31 @@ func TestImageGenerationStreamLifecycleAcceptsCompleteOrderedSequence(t *testing
 func TestDecodeResponsesImageGenerationStreamAccumulatesTerminalImage(t *testing.T) {
 	response := decodeImageGenerationStreamFixture(t)
 	assertCompletedGeneratedImageResponse(t, response)
+}
+
+// A client cancellation while image generation is mid-stream must not be
+// released as a successful completion: the Responses wire must not gain a
+// `response.completed` terminal. The same invariance corner_cases_test.go
+// asserts for the streaming text formats.
+func TestImageGenerationStreamCancellationSuppressesDeferredCompletion(t *testing.T) {
+	encoder := newStartedImageGenerationEncoder(t)
+	zero, one := int64(0), int64(1)
+	for _, image := range []*llmprotocol.GeneratedImage{
+		{Status: llmprotocol.ImageGenerationGenerating},
+		{Status: llmprotocol.ImageGenerationGenerating, PartialIndex: &zero, PartialImage: "YQ=="},
+		{Status: llmprotocol.ImageGenerationGenerating, PartialIndex: &one, PartialImage: "Yg=="},
+	} {
+		pushImageGenerationProgress(t, encoder, image)
+	}
+	frames, _, err := encoder.Finalize(context.Canceled)
+	if err != nil {
+		t.Fatalf("finalize after cancellation: %v", err)
+	}
+	wire := bytes.Join(frames, nil)
+	assertNoSuccessfulStreamTerminal(t, llmprotocol.OpenAIResponsesV1, wire)
+	if !bytes.Contains(wire, []byte("stream_canceled")) {
+		t.Fatalf("cancellation has no public cancel terminal: %s", wire)
+	}
 }
 
 func decodeImageGenerationStreamFixture(t *testing.T) llmprotocol.Response {

--- a/src/semantic-router/pkg/protocolcodec/images_codec_test.go
+++ b/src/semantic-router/pkg/protocolcodec/images_codec_test.go
@@ -273,6 +273,12 @@ func TestImagesCodecDecodeResponseToGeneratedImage(t *testing.T) {
 	if block.GeneratedImage.Result == nil || *block.GeneratedImage.Result != payload {
 		t.Fatalf("result = %v, want %q", block.GeneratedImage.Result, payload)
 	}
+	// The images dialect does not carry token usage; the neutral response must
+	// keep usage explicitly unavailable so downstream accounting never
+	// misreads an image artifact as token-bearing text.
+	if response.Usage.State != llmprotocol.UsageUnavailable {
+		t.Fatalf("usage state = %v, want unavailable", response.Usage.State)
+	}
 }
 
 func TestImagesCodecDecodeResponseEmptyData(t *testing.T) {

--- a/src/semantic-router/pkg/routerreplay/recorder_image_roundtrip_test.go
+++ b/src/semantic-router/pkg/routerreplay/recorder_image_roundtrip_test.go
@@ -1,0 +1,58 @@
+package routerreplay
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/routerreplay/store"
+)
+
+// Replay is body-agnostic (it stores bytes), but the image vertical adds one
+// requirement: a generated-image payload is a base64-encoded binary artifact,
+// often larger than text bodies. This test pins that a real images-dialect
+// request/response pair round-trips capture -> read -> restore byte-for-byte,
+// including the artifact payloads, so a replayed image request rebuilds the
+// exact bytes the client sent and the backing backend returned.
+func TestRecorderImageRequestResponseRoundTripPreservesPayloads(t *testing.T) {
+	// 1x1 red PNG, base64 — realistic generated-image artifact.
+	png, err := base64.StdEncoding.DecodeString("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==")
+	if err != nil {
+		t.Fatalf("decode fixture png: %v", err)
+	}
+	artifact := base64.StdEncoding.EncodeToString(png)
+
+	requestBody := `{"model":"image-backend","input":"draw a red fox","tools":[{"type":"image_generation","model":"gpt-image-1"}],"tool_choice":{"type":"image_generation"}}`
+	responseBody := `{"created":1701234567,"data":[{"b64_json":"` + artifact + `"},{"b64_json":"` + artifact + `"}]}`
+
+	collect := store.NewMemoryStore(10, 0)
+	recorder := NewRecorder(collect)
+	recorder.SetCapturePolicy(true, true, 10<<20) // 10 MiB — artifact far under
+
+	id, err := recorder.AddRecord(RoutingRecord{
+		RequestID:     "req-image-roundtrip",
+		OriginalModel: "default-backend",
+		SelectedModel: "image-backend",
+		RequestBody:   requestBody,
+		ResponseBody:  responseBody,
+	})
+	if err != nil {
+		t.Fatalf("AddRecord: %v", err)
+	}
+
+	rec, found := recorder.GetRecord(id)
+	if !found {
+		t.Fatal("record not found after capture")
+	}
+	if rec.RequestBody != requestBody {
+		t.Fatalf("request body changed across replay round-trip\n got %q\nwant %q", rec.RequestBody, requestBody)
+	}
+	if rec.ResponseBody != responseBody {
+		t.Fatalf("response body changed across replay round-trip\n got %q\nwant %q", rec.ResponseBody, responseBody)
+	}
+	if rec.RequestBodyTruncated || rec.ResponseBodyTruncated {
+		t.Fatalf("image bodies truncated: req=%v resp=%v", rec.RequestBodyTruncated, rec.ResponseBodyTruncated)
+	}
+	if rec.SelectedModel != "image-backend" {
+		t.Fatalf("replay record lost final dispatch model: %q", rec.SelectedModel)
+	}
+}


### PR DESCRIPTION
## Summary

Deterministic conformance coverage for the capability-driven image-generation
vertical, closing the gaps #3313 left untested. This is a **test-only** PR — no
production code changes.

- **Mid-stream cancellation** (`image_generation_test.go`): when a client cancels
  while image generation is in progress, the Responses stream must not release a
  deferred `response.completed`; it emits a `stream_canceled` failure terminal
  instead. Mirrors the same invariance `corner_cases_test.go` asserts for the
  streaming text formats.
- **Usage/artifact semantics** (`images_codec_test.go`): pins that an images
  response decodes with `Usage.State == UsageUnavailable` — the images dialect
  carries no token usage, and the neutral response must keep it explicitly
  unavailable so downstream accounting never misreads a generated image as
  token-bearing text.
- **Replay round-trip** (`routerreplay/recorder_image_roundtrip_test.go`, new):
  a realistic images-dialect request/response pair (two base64 PNG artifacts)
  round-trips capture → read → restore byte-for-byte without truncation, and the
  replay record keeps the final dispatch model.

## Notes / Out of scope

The four-dimension conformance matrix is largely already in place from #3313:
response and stream golden matrices, fail-closed streaming (`unsupported_capability`
on non-Responses targets), and rejection/error cases (golden rejection 234–237).
This PR adds exactly the coverage that was missing. Streaming fail-closed,
rejection matrices, and maintained E2E (real backend) are intentionally not
repeated here.

Related #3183
