### PR TITLE
[Model Hub] Enrich GPT-6 Astra evaluations and shareable URLs

### DIFF
--- a/config/catalog/resources/evaluations/single/openai.yaml
+++ b/config/catalog/resources/evaluations/single/openai.yaml
@@ -4912,6 +4912,416 @@
     verification: claimed
     source: https://cdn.openai.com/pdf/419b6906-9da6-406c-a19d-1bb078ac7637/oai_gpt-oss_model_card.pdf
     redistributable: true
+- id: independent/gpt-6-astra-low-humanitys-last-exam@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: cais/humanitys-last-exam@1.0.0
+  benchmark_profile: independent-standard
+  reasoning_effort: low
+  subject:
+    source_model: GPT-6 Astra (low)
+    source_model_slug: gpt-6-astra-low
+    run_kind: independent
+    tool_policy: no_tools
+    sample_count: 2158
+  metrics:
+    accuracy: 0.492122335495829
+  status: available
+  observed_at: 2026-09-08
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/humanitys-last-exam
+    redistributable: true
+- id: independent/gpt-6-astra-low-terminalbench-v2-1@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: harbor/terminal-bench@2.1.0
+  benchmark_profile: independent-agent
+  reasoning_effort: low
+  subject:
+    source_model: GPT-6 Astra (low)
+    source_model_slug: gpt-6-astra-low
+    run_kind: independent
+    agent_harness: Terminus 2
+    sandbox: E2B
+    task_count: 89
+    repeats: 3
+  metrics:
+    resolved: 0.880149812734082
+  status: available
+  observed_at: 2026-09-08
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/terminalbench-v2-1
+    redistributable: true
+- id: independent/gpt-6-astra-low-gpqa-diamond@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: idavidrein/gpqa-diamond@1.0.0
+  benchmark_profile: independent-standard
+  reasoning_effort: low
+  subject:
+    source_model: GPT-6 Astra (low)
+    source_model_slug: gpt-6-astra-low
+    run_kind: independent
+    sample_count: 198
+  metrics:
+    accuracy: 0.931313131313131
+  status: available
+  observed_at: 2026-09-08
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/gpqa-diamond
+    redistributable: true
+- id: independent/gpt-6-astra-low-scicode@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: scicode-bench/scicode@1.0.0
+  benchmark_profile: independent-test-288
+  reasoning_effort: low
+  subject:
+    source_model: GPT-6 Astra (low)
+    source_model_slug: gpt-6-astra-low
+    run_kind: independent
+    tool_policy: no_tools
+    sample_count: 288
+    repeats: 3
+  metrics:
+    score: 0.540509259259259
+  status: available
+  observed_at: 2026-09-08
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/scicode
+    redistributable: true
+- id: independent/gpt-6-astra-medium-humanitys-last-exam@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: cais/humanitys-last-exam@1.0.0
+  benchmark_profile: independent-standard
+  reasoning_effort: medium
+  subject:
+    source_model: GPT-6 Astra (medium)
+    source_model_slug: gpt-6-astra-medium
+    run_kind: independent
+    tool_policy: no_tools
+    sample_count: 2158
+  metrics:
+    accuracy: 0.527340129749768
+  status: available
+  observed_at: 2026-09-08
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/humanitys-last-exam
+    redistributable: true
+- id: independent/gpt-6-astra-medium-terminalbench-v2-1@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: harbor/terminal-bench@2.1.0
+  benchmark_profile: independent-agent
+  reasoning_effort: medium
+  subject:
+    source_model: GPT-6 Astra (medium)
+    source_model_slug: gpt-6-astra-medium
+    run_kind: independent
+    agent_harness: Terminus 2
+    sandbox: E2B
+    task_count: 89
+    repeats: 3
+  metrics:
+    resolved: 0.895131086142322
+  status: available
+  observed_at: 2026-09-08
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/terminalbench-v2-1
+    redistributable: true
+- id: independent/gpt-6-astra-medium-gpqa-diamond@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: idavidrein/gpqa-diamond@1.0.0
+  benchmark_profile: independent-standard
+  reasoning_effort: medium
+  subject:
+    source_model: GPT-6 Astra (medium)
+    source_model_slug: gpt-6-astra-medium
+    run_kind: independent
+    sample_count: 198
+  metrics:
+    accuracy: 0.939393939393939
+  status: available
+  observed_at: 2026-09-08
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/gpqa-diamond
+    redistributable: true
+- id: independent/gpt-6-astra-medium-scicode@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: scicode-bench/scicode@1.0.0
+  benchmark_profile: independent-test-288
+  reasoning_effort: medium
+  subject:
+    source_model: GPT-6 Astra (medium)
+    source_model_slug: gpt-6-astra-medium
+    run_kind: independent
+    tool_policy: no_tools
+    sample_count: 288
+    repeats: 3
+  metrics:
+    score: 0.541666666666667
+  status: available
+  observed_at: 2026-09-08
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/scicode
+    redistributable: true
+- id: independent/gpt-6-astra-high-humanitys-last-exam@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: cais/humanitys-last-exam@1.0.0
+  benchmark_profile: independent-standard
+  reasoning_effort: high
+  subject:
+    source_model: GPT-6 Astra (high)
+    source_model_slug: gpt-6-astra-high
+    run_kind: independent
+    tool_policy: no_tools
+    sample_count: 2158
+  metrics:
+    accuracy: 0.530583873957368
+  status: available
+  observed_at: 2026-09-08
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/humanitys-last-exam
+    redistributable: true
+- id: independent/gpt-6-astra-high-terminalbench-v2-1@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: harbor/terminal-bench@2.1.0
+  benchmark_profile: independent-agent
+  reasoning_effort: high
+  subject:
+    source_model: GPT-6 Astra (high)
+    source_model_slug: gpt-6-astra-high
+    run_kind: independent
+    agent_harness: Terminus 2
+    sandbox: E2B
+    task_count: 89
+    repeats: 3
+  metrics:
+    resolved: 0.898876404494382
+  status: available
+  observed_at: 2026-09-08
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/terminalbench-v2-1
+    redistributable: true
+- id: independent/gpt-6-astra-high-gpqa-diamond@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: idavidrein/gpqa-diamond@1.0.0
+  benchmark_profile: independent-standard
+  reasoning_effort: high
+  subject:
+    source_model: GPT-6 Astra (high)
+    source_model_slug: gpt-6-astra-high
+    run_kind: independent
+    sample_count: 198
+  metrics:
+    accuracy: 0.94949494949495
+  status: available
+  observed_at: 2026-09-08
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/gpqa-diamond
+    redistributable: true
+- id: independent/gpt-6-astra-high-scicode@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: scicode-bench/scicode@1.0.0
+  benchmark_profile: independent-test-288
+  reasoning_effort: high
+  subject:
+    source_model: GPT-6 Astra (high)
+    source_model_slug: gpt-6-astra-high
+    run_kind: independent
+    tool_policy: no_tools
+    sample_count: 288
+    repeats: 3
+  metrics:
+    score: 0.554398148148148
+  status: available
+  observed_at: 2026-09-08
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/scicode
+    redistributable: true
+- id: independent/gpt-6-astra-xhigh-humanitys-last-exam@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: cais/humanitys-last-exam@1.0.0
+  benchmark_profile: independent-standard
+  reasoning_effort: xhigh
+  subject:
+    source_model: GPT-6 Astra (xhigh)
+    source_model_slug: gpt-6-astra-xhigh
+    run_kind: independent
+    tool_policy: no_tools
+    sample_count: 2158
+  metrics:
+    accuracy: 0.545875810936052
+  status: available
+  observed_at: 2026-09-08
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/humanitys-last-exam
+    redistributable: true
+- id: independent/gpt-6-astra-xhigh-terminalbench-v2-1@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: harbor/terminal-bench@2.1.0
+  benchmark_profile: independent-agent
+  reasoning_effort: xhigh
+  subject:
+    source_model: GPT-6 Astra (xhigh)
+    source_model_slug: gpt-6-astra-xhigh
+    run_kind: independent
+    agent_harness: Terminus 2
+    sandbox: E2B
+    task_count: 89
+    repeats: 3
+  metrics:
+    resolved: 0.891385767790262
+  status: available
+  observed_at: 2026-09-08
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/terminalbench-v2-1
+    redistributable: true
+- id: independent/gpt-6-astra-xhigh-gpqa-diamond@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: idavidrein/gpqa-diamond@1.0.0
+  benchmark_profile: independent-standard
+  reasoning_effort: xhigh
+  subject:
+    source_model: GPT-6 Astra (xhigh)
+    source_model_slug: gpt-6-astra-xhigh
+    run_kind: independent
+    sample_count: 198
+  metrics:
+    accuracy: 0.962626262626263
+  status: available
+  observed_at: 2026-09-08
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/gpqa-diamond
+    redistributable: true
+- id: independent/gpt-6-astra-xhigh-scicode@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: scicode-bench/scicode@1.0.0
+  benchmark_profile: independent-test-288
+  reasoning_effort: xhigh
+  subject:
+    source_model: GPT-6 Astra (xhigh)
+    source_model_slug: gpt-6-astra-xhigh
+    run_kind: independent
+    tool_policy: no_tools
+    sample_count: 288
+    repeats: 3
+  metrics:
+    score: 0.556712962962963
+  status: available
+  observed_at: 2026-09-08
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/scicode
+    redistributable: true
+- id: independent/gpt-6-astra-max-humanitys-last-exam@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: cais/humanitys-last-exam@1.0.0
+  benchmark_profile: independent-standard
+  reasoning_effort: max
+  subject:
+    source_model: GPT-6 Astra (max)
+    source_model_slug: gpt-6-astra
+    run_kind: independent
+    tool_policy: no_tools
+    sample_count: 2158
+  metrics:
+    accuracy: 0.546802594995366
+  status: available
+  observed_at: 2026-09-08
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/humanitys-last-exam
+    redistributable: true
+- id: independent/gpt-6-astra-max-terminalbench-v2-1@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: harbor/terminal-bench@2.1.0
+  benchmark_profile: independent-agent
+  reasoning_effort: max
+  subject:
+    source_model: GPT-6 Astra (max)
+    source_model_slug: gpt-6-astra
+    run_kind: independent
+    agent_harness: Terminus 2
+    sandbox: E2B
+    task_count: 89
+    repeats: 3
+  metrics:
+    resolved: 0.883895131086142
+  status: available
+  observed_at: 2026-09-08
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/terminalbench-v2-1
+    redistributable: true
+- id: independent/gpt-6-astra-max-gpqa-diamond@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: idavidrein/gpqa-diamond@1.0.0
+  benchmark_profile: independent-standard
+  reasoning_effort: max
+  subject:
+    source_model: GPT-6 Astra (max)
+    source_model_slug: gpt-6-astra
+    run_kind: independent
+    sample_count: 198
+  metrics:
+    accuracy: 0.960606060606061
+  status: available
+  observed_at: 2026-09-08
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/gpqa-diamond
+    redistributable: true
+- id: independent/gpt-6-astra-max-scicode@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: scicode-bench/scicode@1.0.0
+  benchmark_profile: independent-test-288
+  reasoning_effort: max
+  subject:
+    source_model: GPT-6 Astra (max)
+    source_model_slug: gpt-6-astra
+    run_kind: independent
+    tool_policy: no_tools
+    sample_count: 288
+    repeats: 3
+  metrics:
+    score: 0.564814814814815
+  status: available
+  observed_at: 2026-09-08
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/scicode
+    redistributable: true
 - id: openai/gpt-6-astra-launch-gpqa-diamond@1.0.0
   model: openai/gpt-6-astra
   benchmark: idavidrein/gpqa-diamond@1.0.0

--- a/config/recipes/built-in/latest/catalog.yaml
+++ b/config/recipes/built-in/latest/catalog.yaml
@@ -27323,6 +27323,416 @@ evaluations:
     verification: claimed
     source: https://cdn.openai.com/pdf/419b6906-9da6-406c-a19d-1bb078ac7637/oai_gpt-oss_model_card.pdf
     redistributable: true
+- id: independent/gpt-6-astra-low-humanitys-last-exam@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: cais/humanitys-last-exam@1.0.0
+  benchmark_profile: independent-standard
+  reasoning_effort: low
+  subject:
+    source_model: GPT-6 Astra (low)
+    source_model_slug: gpt-6-astra-low
+    run_kind: independent
+    tool_policy: no_tools
+    sample_count: 2158
+  metrics:
+    accuracy: 0.492122335495829
+  status: available
+  observed_at: '2026-09-08'
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/humanitys-last-exam
+    redistributable: true
+- id: independent/gpt-6-astra-low-terminalbench-v2-1@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: harbor/terminal-bench@2.1.0
+  benchmark_profile: independent-agent
+  reasoning_effort: low
+  subject:
+    source_model: GPT-6 Astra (low)
+    source_model_slug: gpt-6-astra-low
+    run_kind: independent
+    agent_harness: Terminus 2
+    sandbox: E2B
+    task_count: 89
+    repeats: 3
+  metrics:
+    resolved: 0.880149812734082
+  status: available
+  observed_at: '2026-09-08'
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/terminalbench-v2-1
+    redistributable: true
+- id: independent/gpt-6-astra-low-gpqa-diamond@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: idavidrein/gpqa-diamond@1.0.0
+  benchmark_profile: independent-standard
+  reasoning_effort: low
+  subject:
+    source_model: GPT-6 Astra (low)
+    source_model_slug: gpt-6-astra-low
+    run_kind: independent
+    sample_count: 198
+  metrics:
+    accuracy: 0.931313131313131
+  status: available
+  observed_at: '2026-09-08'
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/gpqa-diamond
+    redistributable: true
+- id: independent/gpt-6-astra-low-scicode@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: scicode-bench/scicode@1.0.0
+  benchmark_profile: independent-test-288
+  reasoning_effort: low
+  subject:
+    source_model: GPT-6 Astra (low)
+    source_model_slug: gpt-6-astra-low
+    run_kind: independent
+    tool_policy: no_tools
+    sample_count: 288
+    repeats: 3
+  metrics:
+    score: 0.540509259259259
+  status: available
+  observed_at: '2026-09-08'
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/scicode
+    redistributable: true
+- id: independent/gpt-6-astra-medium-humanitys-last-exam@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: cais/humanitys-last-exam@1.0.0
+  benchmark_profile: independent-standard
+  reasoning_effort: medium
+  subject:
+    source_model: GPT-6 Astra (medium)
+    source_model_slug: gpt-6-astra-medium
+    run_kind: independent
+    tool_policy: no_tools
+    sample_count: 2158
+  metrics:
+    accuracy: 0.527340129749768
+  status: available
+  observed_at: '2026-09-08'
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/humanitys-last-exam
+    redistributable: true
+- id: independent/gpt-6-astra-medium-terminalbench-v2-1@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: harbor/terminal-bench@2.1.0
+  benchmark_profile: independent-agent
+  reasoning_effort: medium
+  subject:
+    source_model: GPT-6 Astra (medium)
+    source_model_slug: gpt-6-astra-medium
+    run_kind: independent
+    agent_harness: Terminus 2
+    sandbox: E2B
+    task_count: 89
+    repeats: 3
+  metrics:
+    resolved: 0.895131086142322
+  status: available
+  observed_at: '2026-09-08'
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/terminalbench-v2-1
+    redistributable: true
+- id: independent/gpt-6-astra-medium-gpqa-diamond@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: idavidrein/gpqa-diamond@1.0.0
+  benchmark_profile: independent-standard
+  reasoning_effort: medium
+  subject:
+    source_model: GPT-6 Astra (medium)
+    source_model_slug: gpt-6-astra-medium
+    run_kind: independent
+    sample_count: 198
+  metrics:
+    accuracy: 0.939393939393939
+  status: available
+  observed_at: '2026-09-08'
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/gpqa-diamond
+    redistributable: true
+- id: independent/gpt-6-astra-medium-scicode@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: scicode-bench/scicode@1.0.0
+  benchmark_profile: independent-test-288
+  reasoning_effort: medium
+  subject:
+    source_model: GPT-6 Astra (medium)
+    source_model_slug: gpt-6-astra-medium
+    run_kind: independent
+    tool_policy: no_tools
+    sample_count: 288
+    repeats: 3
+  metrics:
+    score: 0.541666666666667
+  status: available
+  observed_at: '2026-09-08'
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/scicode
+    redistributable: true
+- id: independent/gpt-6-astra-high-humanitys-last-exam@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: cais/humanitys-last-exam@1.0.0
+  benchmark_profile: independent-standard
+  reasoning_effort: high
+  subject:
+    source_model: GPT-6 Astra (high)
+    source_model_slug: gpt-6-astra-high
+    run_kind: independent
+    tool_policy: no_tools
+    sample_count: 2158
+  metrics:
+    accuracy: 0.530583873957368
+  status: available
+  observed_at: '2026-09-08'
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/humanitys-last-exam
+    redistributable: true
+- id: independent/gpt-6-astra-high-terminalbench-v2-1@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: harbor/terminal-bench@2.1.0
+  benchmark_profile: independent-agent
+  reasoning_effort: high
+  subject:
+    source_model: GPT-6 Astra (high)
+    source_model_slug: gpt-6-astra-high
+    run_kind: independent
+    agent_harness: Terminus 2
+    sandbox: E2B
+    task_count: 89
+    repeats: 3
+  metrics:
+    resolved: 0.898876404494382
+  status: available
+  observed_at: '2026-09-08'
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/terminalbench-v2-1
+    redistributable: true
+- id: independent/gpt-6-astra-high-gpqa-diamond@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: idavidrein/gpqa-diamond@1.0.0
+  benchmark_profile: independent-standard
+  reasoning_effort: high
+  subject:
+    source_model: GPT-6 Astra (high)
+    source_model_slug: gpt-6-astra-high
+    run_kind: independent
+    sample_count: 198
+  metrics:
+    accuracy: 0.94949494949495
+  status: available
+  observed_at: '2026-09-08'
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/gpqa-diamond
+    redistributable: true
+- id: independent/gpt-6-astra-high-scicode@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: scicode-bench/scicode@1.0.0
+  benchmark_profile: independent-test-288
+  reasoning_effort: high
+  subject:
+    source_model: GPT-6 Astra (high)
+    source_model_slug: gpt-6-astra-high
+    run_kind: independent
+    tool_policy: no_tools
+    sample_count: 288
+    repeats: 3
+  metrics:
+    score: 0.554398148148148
+  status: available
+  observed_at: '2026-09-08'
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/scicode
+    redistributable: true
+- id: independent/gpt-6-astra-xhigh-humanitys-last-exam@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: cais/humanitys-last-exam@1.0.0
+  benchmark_profile: independent-standard
+  reasoning_effort: xhigh
+  subject:
+    source_model: GPT-6 Astra (xhigh)
+    source_model_slug: gpt-6-astra-xhigh
+    run_kind: independent
+    tool_policy: no_tools
+    sample_count: 2158
+  metrics:
+    accuracy: 0.545875810936052
+  status: available
+  observed_at: '2026-09-08'
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/humanitys-last-exam
+    redistributable: true
+- id: independent/gpt-6-astra-xhigh-terminalbench-v2-1@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: harbor/terminal-bench@2.1.0
+  benchmark_profile: independent-agent
+  reasoning_effort: xhigh
+  subject:
+    source_model: GPT-6 Astra (xhigh)
+    source_model_slug: gpt-6-astra-xhigh
+    run_kind: independent
+    agent_harness: Terminus 2
+    sandbox: E2B
+    task_count: 89
+    repeats: 3
+  metrics:
+    resolved: 0.891385767790262
+  status: available
+  observed_at: '2026-09-08'
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/terminalbench-v2-1
+    redistributable: true
+- id: independent/gpt-6-astra-xhigh-gpqa-diamond@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: idavidrein/gpqa-diamond@1.0.0
+  benchmark_profile: independent-standard
+  reasoning_effort: xhigh
+  subject:
+    source_model: GPT-6 Astra (xhigh)
+    source_model_slug: gpt-6-astra-xhigh
+    run_kind: independent
+    sample_count: 198
+  metrics:
+    accuracy: 0.962626262626263
+  status: available
+  observed_at: '2026-09-08'
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/gpqa-diamond
+    redistributable: true
+- id: independent/gpt-6-astra-xhigh-scicode@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: scicode-bench/scicode@1.0.0
+  benchmark_profile: independent-test-288
+  reasoning_effort: xhigh
+  subject:
+    source_model: GPT-6 Astra (xhigh)
+    source_model_slug: gpt-6-astra-xhigh
+    run_kind: independent
+    tool_policy: no_tools
+    sample_count: 288
+    repeats: 3
+  metrics:
+    score: 0.556712962962963
+  status: available
+  observed_at: '2026-09-08'
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/scicode
+    redistributable: true
+- id: independent/gpt-6-astra-max-humanitys-last-exam@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: cais/humanitys-last-exam@1.0.0
+  benchmark_profile: independent-standard
+  reasoning_effort: max
+  subject:
+    source_model: GPT-6 Astra (max)
+    source_model_slug: gpt-6-astra
+    run_kind: independent
+    tool_policy: no_tools
+    sample_count: 2158
+  metrics:
+    accuracy: 0.546802594995366
+  status: available
+  observed_at: '2026-09-08'
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/humanitys-last-exam
+    redistributable: true
+- id: independent/gpt-6-astra-max-terminalbench-v2-1@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: harbor/terminal-bench@2.1.0
+  benchmark_profile: independent-agent
+  reasoning_effort: max
+  subject:
+    source_model: GPT-6 Astra (max)
+    source_model_slug: gpt-6-astra
+    run_kind: independent
+    agent_harness: Terminus 2
+    sandbox: E2B
+    task_count: 89
+    repeats: 3
+  metrics:
+    resolved: 0.883895131086142
+  status: available
+  observed_at: '2026-09-08'
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/terminalbench-v2-1
+    redistributable: true
+- id: independent/gpt-6-astra-max-gpqa-diamond@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: idavidrein/gpqa-diamond@1.0.0
+  benchmark_profile: independent-standard
+  reasoning_effort: max
+  subject:
+    source_model: GPT-6 Astra (max)
+    source_model_slug: gpt-6-astra
+    run_kind: independent
+    sample_count: 198
+  metrics:
+    accuracy: 0.960606060606061
+  status: available
+  observed_at: '2026-09-08'
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/gpqa-diamond
+    redistributable: true
+- id: independent/gpt-6-astra-max-scicode@1.0.0
+  model: openai/gpt-6-astra
+  benchmark: scicode-bench/scicode@1.0.0
+  benchmark_profile: independent-test-288
+  reasoning_effort: max
+  subject:
+    source_model: GPT-6 Astra (max)
+    source_model_slug: gpt-6-astra
+    run_kind: independent
+    tool_policy: no_tools
+    sample_count: 288
+    repeats: 3
+  metrics:
+    score: 0.564814814814815
+  status: available
+  observed_at: '2026-09-08'
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/scicode
+    redistributable: true
 - id: openai/gpt-6-astra-launch-gpqa-diamond@1.0.0
   model: openai/gpt-6-astra
   benchmark: idavidrein/gpqa-diamond@1.0.0

--- a/src/semantic-router/pkg/catalog/zz_generated_catalog.go
+++ b/src/semantic-router/pkg/catalog/zz_generated_catalog.go
@@ -2,7 +2,7 @@
 
 package catalog
 
-const builtInCatalogDigest = "sha256:b0ffa7072ac6a77e8d40f3a6fc1bf8b0be230ffd643651cb013a0124bcafc432"
+const builtInCatalogDigest = "sha256:023210b43682c690f9285426614e45140e3064cbee521d9bf5650a654edd3e16"
 
 const builtInCatalogJSON = `{
   "benchmarks": [
@@ -25059,6 +25059,516 @@ const builtInCatalogJSON = `{
         "reasoning_effort": "medium",
         "source_kind": "official_model_card",
         "variant": "gpt-oss-20b"
+      }
+    },
+    {
+      "benchmark": "cais/humanitys-last-exam@1.0.0",
+      "benchmark_profile": "independent-standard",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/humanitys-last-exam",
+        "verification": "imported"
+      },
+      "id": "independent/gpt-6-astra-low-humanitys-last-exam@1.0.0",
+      "metrics": {
+        "accuracy": 0.492122335495829
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-08",
+      "reasoning_effort": "low",
+      "status": "available",
+      "subject": {
+        "run_kind": "independent",
+        "sample_count": 2158,
+        "source_model": "GPT-6 Astra (low)",
+        "source_model_slug": "gpt-6-astra-low",
+        "tool_policy": "no_tools"
+      }
+    },
+    {
+      "benchmark": "harbor/terminal-bench@2.1.0",
+      "benchmark_profile": "independent-agent",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/terminalbench-v2-1",
+        "verification": "imported"
+      },
+      "id": "independent/gpt-6-astra-low-terminalbench-v2-1@1.0.0",
+      "metrics": {
+        "resolved": 0.880149812734082
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-08",
+      "reasoning_effort": "low",
+      "status": "available",
+      "subject": {
+        "agent_harness": "Terminus 2",
+        "repeats": 3,
+        "run_kind": "independent",
+        "sandbox": "E2B",
+        "source_model": "GPT-6 Astra (low)",
+        "source_model_slug": "gpt-6-astra-low",
+        "task_count": 89
+      }
+    },
+    {
+      "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+      "benchmark_profile": "independent-standard",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/gpqa-diamond",
+        "verification": "imported"
+      },
+      "id": "independent/gpt-6-astra-low-gpqa-diamond@1.0.0",
+      "metrics": {
+        "accuracy": 0.931313131313131
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-08",
+      "reasoning_effort": "low",
+      "status": "available",
+      "subject": {
+        "run_kind": "independent",
+        "sample_count": 198,
+        "source_model": "GPT-6 Astra (low)",
+        "source_model_slug": "gpt-6-astra-low"
+      }
+    },
+    {
+      "benchmark": "scicode-bench/scicode@1.0.0",
+      "benchmark_profile": "independent-test-288",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/scicode",
+        "verification": "imported"
+      },
+      "id": "independent/gpt-6-astra-low-scicode@1.0.0",
+      "metrics": {
+        "score": 0.540509259259259
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-08",
+      "reasoning_effort": "low",
+      "status": "available",
+      "subject": {
+        "repeats": 3,
+        "run_kind": "independent",
+        "sample_count": 288,
+        "source_model": "GPT-6 Astra (low)",
+        "source_model_slug": "gpt-6-astra-low",
+        "tool_policy": "no_tools"
+      }
+    },
+    {
+      "benchmark": "cais/humanitys-last-exam@1.0.0",
+      "benchmark_profile": "independent-standard",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/humanitys-last-exam",
+        "verification": "imported"
+      },
+      "id": "independent/gpt-6-astra-medium-humanitys-last-exam@1.0.0",
+      "metrics": {
+        "accuracy": 0.527340129749768
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-08",
+      "reasoning_effort": "medium",
+      "status": "available",
+      "subject": {
+        "run_kind": "independent",
+        "sample_count": 2158,
+        "source_model": "GPT-6 Astra (medium)",
+        "source_model_slug": "gpt-6-astra-medium",
+        "tool_policy": "no_tools"
+      }
+    },
+    {
+      "benchmark": "harbor/terminal-bench@2.1.0",
+      "benchmark_profile": "independent-agent",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/terminalbench-v2-1",
+        "verification": "imported"
+      },
+      "id": "independent/gpt-6-astra-medium-terminalbench-v2-1@1.0.0",
+      "metrics": {
+        "resolved": 0.895131086142322
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-08",
+      "reasoning_effort": "medium",
+      "status": "available",
+      "subject": {
+        "agent_harness": "Terminus 2",
+        "repeats": 3,
+        "run_kind": "independent",
+        "sandbox": "E2B",
+        "source_model": "GPT-6 Astra (medium)",
+        "source_model_slug": "gpt-6-astra-medium",
+        "task_count": 89
+      }
+    },
+    {
+      "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+      "benchmark_profile": "independent-standard",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/gpqa-diamond",
+        "verification": "imported"
+      },
+      "id": "independent/gpt-6-astra-medium-gpqa-diamond@1.0.0",
+      "metrics": {
+        "accuracy": 0.939393939393939
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-08",
+      "reasoning_effort": "medium",
+      "status": "available",
+      "subject": {
+        "run_kind": "independent",
+        "sample_count": 198,
+        "source_model": "GPT-6 Astra (medium)",
+        "source_model_slug": "gpt-6-astra-medium"
+      }
+    },
+    {
+      "benchmark": "scicode-bench/scicode@1.0.0",
+      "benchmark_profile": "independent-test-288",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/scicode",
+        "verification": "imported"
+      },
+      "id": "independent/gpt-6-astra-medium-scicode@1.0.0",
+      "metrics": {
+        "score": 0.541666666666667
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-08",
+      "reasoning_effort": "medium",
+      "status": "available",
+      "subject": {
+        "repeats": 3,
+        "run_kind": "independent",
+        "sample_count": 288,
+        "source_model": "GPT-6 Astra (medium)",
+        "source_model_slug": "gpt-6-astra-medium",
+        "tool_policy": "no_tools"
+      }
+    },
+    {
+      "benchmark": "cais/humanitys-last-exam@1.0.0",
+      "benchmark_profile": "independent-standard",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/humanitys-last-exam",
+        "verification": "imported"
+      },
+      "id": "independent/gpt-6-astra-high-humanitys-last-exam@1.0.0",
+      "metrics": {
+        "accuracy": 0.530583873957368
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-08",
+      "reasoning_effort": "high",
+      "status": "available",
+      "subject": {
+        "run_kind": "independent",
+        "sample_count": 2158,
+        "source_model": "GPT-6 Astra (high)",
+        "source_model_slug": "gpt-6-astra-high",
+        "tool_policy": "no_tools"
+      }
+    },
+    {
+      "benchmark": "harbor/terminal-bench@2.1.0",
+      "benchmark_profile": "independent-agent",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/terminalbench-v2-1",
+        "verification": "imported"
+      },
+      "id": "independent/gpt-6-astra-high-terminalbench-v2-1@1.0.0",
+      "metrics": {
+        "resolved": 0.898876404494382
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-08",
+      "reasoning_effort": "high",
+      "status": "available",
+      "subject": {
+        "agent_harness": "Terminus 2",
+        "repeats": 3,
+        "run_kind": "independent",
+        "sandbox": "E2B",
+        "source_model": "GPT-6 Astra (high)",
+        "source_model_slug": "gpt-6-astra-high",
+        "task_count": 89
+      }
+    },
+    {
+      "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+      "benchmark_profile": "independent-standard",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/gpqa-diamond",
+        "verification": "imported"
+      },
+      "id": "independent/gpt-6-astra-high-gpqa-diamond@1.0.0",
+      "metrics": {
+        "accuracy": 0.94949494949495
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-08",
+      "reasoning_effort": "high",
+      "status": "available",
+      "subject": {
+        "run_kind": "independent",
+        "sample_count": 198,
+        "source_model": "GPT-6 Astra (high)",
+        "source_model_slug": "gpt-6-astra-high"
+      }
+    },
+    {
+      "benchmark": "scicode-bench/scicode@1.0.0",
+      "benchmark_profile": "independent-test-288",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/scicode",
+        "verification": "imported"
+      },
+      "id": "independent/gpt-6-astra-high-scicode@1.0.0",
+      "metrics": {
+        "score": 0.554398148148148
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-08",
+      "reasoning_effort": "high",
+      "status": "available",
+      "subject": {
+        "repeats": 3,
+        "run_kind": "independent",
+        "sample_count": 288,
+        "source_model": "GPT-6 Astra (high)",
+        "source_model_slug": "gpt-6-astra-high",
+        "tool_policy": "no_tools"
+      }
+    },
+    {
+      "benchmark": "cais/humanitys-last-exam@1.0.0",
+      "benchmark_profile": "independent-standard",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/humanitys-last-exam",
+        "verification": "imported"
+      },
+      "id": "independent/gpt-6-astra-xhigh-humanitys-last-exam@1.0.0",
+      "metrics": {
+        "accuracy": 0.545875810936052
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-08",
+      "reasoning_effort": "xhigh",
+      "status": "available",
+      "subject": {
+        "run_kind": "independent",
+        "sample_count": 2158,
+        "source_model": "GPT-6 Astra (xhigh)",
+        "source_model_slug": "gpt-6-astra-xhigh",
+        "tool_policy": "no_tools"
+      }
+    },
+    {
+      "benchmark": "harbor/terminal-bench@2.1.0",
+      "benchmark_profile": "independent-agent",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/terminalbench-v2-1",
+        "verification": "imported"
+      },
+      "id": "independent/gpt-6-astra-xhigh-terminalbench-v2-1@1.0.0",
+      "metrics": {
+        "resolved": 0.891385767790262
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-08",
+      "reasoning_effort": "xhigh",
+      "status": "available",
+      "subject": {
+        "agent_harness": "Terminus 2",
+        "repeats": 3,
+        "run_kind": "independent",
+        "sandbox": "E2B",
+        "source_model": "GPT-6 Astra (xhigh)",
+        "source_model_slug": "gpt-6-astra-xhigh",
+        "task_count": 89
+      }
+    },
+    {
+      "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+      "benchmark_profile": "independent-standard",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/gpqa-diamond",
+        "verification": "imported"
+      },
+      "id": "independent/gpt-6-astra-xhigh-gpqa-diamond@1.0.0",
+      "metrics": {
+        "accuracy": 0.962626262626263
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-08",
+      "reasoning_effort": "xhigh",
+      "status": "available",
+      "subject": {
+        "run_kind": "independent",
+        "sample_count": 198,
+        "source_model": "GPT-6 Astra (xhigh)",
+        "source_model_slug": "gpt-6-astra-xhigh"
+      }
+    },
+    {
+      "benchmark": "scicode-bench/scicode@1.0.0",
+      "benchmark_profile": "independent-test-288",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/scicode",
+        "verification": "imported"
+      },
+      "id": "independent/gpt-6-astra-xhigh-scicode@1.0.0",
+      "metrics": {
+        "score": 0.556712962962963
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-08",
+      "reasoning_effort": "xhigh",
+      "status": "available",
+      "subject": {
+        "repeats": 3,
+        "run_kind": "independent",
+        "sample_count": 288,
+        "source_model": "GPT-6 Astra (xhigh)",
+        "source_model_slug": "gpt-6-astra-xhigh",
+        "tool_policy": "no_tools"
+      }
+    },
+    {
+      "benchmark": "cais/humanitys-last-exam@1.0.0",
+      "benchmark_profile": "independent-standard",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/humanitys-last-exam",
+        "verification": "imported"
+      },
+      "id": "independent/gpt-6-astra-max-humanitys-last-exam@1.0.0",
+      "metrics": {
+        "accuracy": 0.546802594995366
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-08",
+      "reasoning_effort": "max",
+      "status": "available",
+      "subject": {
+        "run_kind": "independent",
+        "sample_count": 2158,
+        "source_model": "GPT-6 Astra (max)",
+        "source_model_slug": "gpt-6-astra",
+        "tool_policy": "no_tools"
+      }
+    },
+    {
+      "benchmark": "harbor/terminal-bench@2.1.0",
+      "benchmark_profile": "independent-agent",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/terminalbench-v2-1",
+        "verification": "imported"
+      },
+      "id": "independent/gpt-6-astra-max-terminalbench-v2-1@1.0.0",
+      "metrics": {
+        "resolved": 0.883895131086142
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-08",
+      "reasoning_effort": "max",
+      "status": "available",
+      "subject": {
+        "agent_harness": "Terminus 2",
+        "repeats": 3,
+        "run_kind": "independent",
+        "sandbox": "E2B",
+        "source_model": "GPT-6 Astra (max)",
+        "source_model_slug": "gpt-6-astra",
+        "task_count": 89
+      }
+    },
+    {
+      "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+      "benchmark_profile": "independent-standard",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/gpqa-diamond",
+        "verification": "imported"
+      },
+      "id": "independent/gpt-6-astra-max-gpqa-diamond@1.0.0",
+      "metrics": {
+        "accuracy": 0.960606060606061
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-08",
+      "reasoning_effort": "max",
+      "status": "available",
+      "subject": {
+        "run_kind": "independent",
+        "sample_count": 198,
+        "source_model": "GPT-6 Astra (max)",
+        "source_model_slug": "gpt-6-astra"
+      }
+    },
+    {
+      "benchmark": "scicode-bench/scicode@1.0.0",
+      "benchmark_profile": "independent-test-288",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/scicode",
+        "verification": "imported"
+      },
+      "id": "independent/gpt-6-astra-max-scicode@1.0.0",
+      "metrics": {
+        "score": 0.564814814814815
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-08",
+      "reasoning_effort": "max",
+      "status": "available",
+      "subject": {
+        "repeats": 3,
+        "run_kind": "independent",
+        "sample_count": 288,
+        "source_model": "GPT-6 Astra (max)",
+        "source_model_slug": "gpt-6-astra",
+        "tool_policy": "no_tools"
       }
     },
     {

--- a/tools/catalog/tests/test_generate_model_catalog.py
+++ b/tools/catalog/tests/test_generate_model_catalog.py
@@ -291,9 +291,14 @@ class ModelCatalogCompilerTests(unittest.TestCase):
             for item in resources["evaluations"]
             if item["model"] == "openai/gpt-6-astra"
         ]
-        self.assertEqual(len(evaluations), 5)
+        launch_evaluations = [
+            item
+            for item in evaluations
+            if item["id"].startswith("openai/gpt-6-astra-launch-")
+        ]
+        self.assertEqual(len(launch_evaluations), 5)
         self.assertEqual(
-            {item["benchmark"] for item in evaluations},
+            {item["benchmark"] for item in launch_evaluations},
             {
                 "idavidrein/gpqa-diamond@1.0.0",
                 "cais/humanitys-last-exam@1.0.0",
@@ -303,19 +308,54 @@ class ModelCatalogCompilerTests(unittest.TestCase):
             },
         )
         self.assertTrue(
-            all(item["reasoning_effort"] == "unspecified" for item in evaluations)
+            all(
+                item["reasoning_effort"] == "unspecified" for item in launch_evaluations
+            )
         )
         self.assertTrue(
             all(
                 item["subject"]["result_selection"]
                 == "maximum_across_supported_efforts"
-                for item in evaluations
+                for item in launch_evaluations
             )
         )
         self.assertTrue(
             all(
                 item["evidence"]["provenance"] == "vendor_claimed"
-                for item in evaluations
+                for item in launch_evaluations
+            )
+        )
+
+        independent_evaluations = [
+            item
+            for item in evaluations
+            if item["id"].startswith("independent/gpt-6-astra-")
+        ]
+        independent_efforts = {"low", "medium", "high", "xhigh", "max"}
+        independent_benchmarks = {
+            "idavidrein/gpqa-diamond@1.0.0",
+            "cais/humanitys-last-exam@1.0.0",
+            "harbor/terminal-bench@2.1.0",
+            "scicode-bench/scicode@1.0.0",
+        }
+        self.assertEqual(len(independent_evaluations), 20)
+        self.assertEqual(
+            {
+                (item["reasoning_effort"], item["benchmark"])
+                for item in independent_evaluations
+            },
+            {
+                (effort, benchmark)
+                for effort in independent_efforts
+                for benchmark in independent_benchmarks
+            },
+        )
+        self.assertTrue(
+            all(
+                item["evidence"]["provenance"] == "third_party"
+                and item["evidence"]["verification"] == "imported"
+                and item["subject"]["run_kind"] == "independent"
+                for item in independent_evaluations
             )
         )
 

--- a/website/scripts/lib/model-hub-url-state.test.mjs
+++ b/website/scripts/lib/model-hub-url-state.test.mjs
@@ -1,0 +1,106 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+import ts from 'typescript'
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..')
+const directoryHelperPath = resolve(
+  repositoryRoot,
+  'website/src/data/modelHubDirectorySupport.ts',
+)
+const urlHelperPath = resolve(repositoryRoot, 'website/src/data/modelHubUrlState.ts')
+const directoryHelperUrl = `data:text/javascript;base64,${Buffer.from(
+  ts.transpileModule(readFileSync(directoryHelperPath, 'utf8'), {
+    compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2020 },
+    fileName: directoryHelperPath,
+  }).outputText,
+).toString('base64')}`
+const urlHelperJavaScript = ts
+  .transpileModule(readFileSync(urlHelperPath, 'utf8'), {
+    compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2020 },
+    fileName: urlHelperPath,
+  })
+  .outputText.replace('./modelHubDirectorySupport', directoryHelperUrl)
+const support = await import(
+  `data:text/javascript;base64,${Buffer.from(urlHelperJavaScript).toString('base64')}`,
+)
+
+test('model hub URL state defaults are compact and stable', () => {
+  const state = support.parseModelHubUrlState('')
+
+  assert.deepEqual(state, {
+    filters: {
+      search: '',
+      kind: 'all',
+      distribution: 'all',
+      publisher: 'all',
+      provider: 'all',
+      capability: 'all',
+      lifecycle: 'supported',
+      sort: 'newest',
+    },
+    view: 'list',
+    page: 1,
+    benchmark: { filter: 'all', query: '', publisher: 'all' },
+    selectedModelID: null,
+  })
+  assert.equal(support.serializeModelHubUrlState(state), '')
+})
+
+test('every model hub control round-trips through the URL', () => {
+  const search = '?q=mixture+router&kind=virtual&distribution=router_recipe'
+    + '&creator=vLLM&provider=openai&capability=tools&lifecycle=all&sort=context'
+    + '&view=table&page=3&benchmark=tag%3Acore&benchmark_q=astra'
+    + '&benchmark_creator=OpenAI&model=openai%2Fgpt-6-astra'
+  const state = support.parseModelHubUrlState(search)
+
+  assert.deepEqual(state.filters, {
+    search: 'mixture router',
+    kind: 'virtual',
+    distribution: 'router_recipe',
+    publisher: 'vLLM',
+    provider: 'openai',
+    capability: 'tools',
+    lifecycle: 'all',
+    sort: 'context',
+  })
+  assert.equal(state.view, 'table')
+  assert.equal(state.page, 3)
+  assert.deepEqual(state.benchmark, {
+    filter: 'tag:core',
+    query: 'astra',
+    publisher: 'OpenAI',
+  })
+  assert.equal(state.selectedModelID, 'openai/gpt-6-astra')
+  assert.deepEqual(
+    support.parseModelHubUrlState(support.serializeModelHubUrlState(state)),
+    state,
+  )
+})
+
+test('invalid enum and page values fall back safely', () => {
+  const state = support.parseModelHubUrlState(
+    '?kind=mixture&distribution=download&lifecycle=retired&sort=rank&view=cards&page=-2',
+  )
+
+  assert.equal(state.filters.kind, 'all')
+  assert.equal(state.filters.distribution, 'all')
+  assert.equal(state.filters.lifecycle, 'supported')
+  assert.equal(state.filters.sort, 'newest')
+  assert.equal(state.view, 'list')
+  assert.equal(state.page, 1)
+})
+
+test('serialization preserves unrelated campaign parameters', () => {
+  const state = support.parseModelHubUrlState('?utm_source=weekly')
+  state.filters.kind = 'virtual'
+  state.selectedModelID = 'virtual/team/router'
+
+  const search = support.serializeModelHubUrlState(state, '?utm_source=weekly&kind=physical')
+  const parameters = new URLSearchParams(search)
+  assert.equal(parameters.get('utm_source'), 'weekly')
+  assert.equal(parameters.get('kind'), 'virtual')
+  assert.equal(parameters.get('model'), 'virtual/team/router')
+})

--- a/website/src/components/model-hub/ModelHubPrimitives.tsx
+++ b/website/src/components/model-hub/ModelHubPrimitives.tsx
@@ -160,7 +160,9 @@ export function SelectControl({
       >
         <span id={labelId} className={styles.selectPrefix}>{label}</span>
         <span id={`${labelId}-value`} className={styles.selectValue}>{selected}</span>
-        <i aria-hidden="true">⌄</i>
+        <svg className={styles.selectChevron} viewBox="0 0 16 16" aria-hidden="true">
+          <path d="m4 6 4 4 4-4" />
+        </svg>
       </button>
       {isBrowser && open
         ? createPortal(
@@ -184,7 +186,14 @@ export function SelectControl({
                       buttonRef.current?.focus()
                     }}
                   >
-                    {optionLabel}
+                    <span>{optionLabel}</span>
+                    {optionValue === value
+                      ? (
+                          <svg className={styles.selectCheck} viewBox="0 0 16 16" aria-hidden="true">
+                            <path d="m3.5 8.25 2.75 2.75 6.25-6.25" />
+                          </svg>
+                        )
+                      : null}
                   </button>
                 </li>
               ))}

--- a/website/src/components/model-hub/modelHubDetail.module.css
+++ b/website/src/components/model-hub/modelHubDetail.module.css
@@ -189,7 +189,7 @@
 }
 
 .roleGrid {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: minmax(0, 1fr);
 }
 
 .roleCard,
@@ -340,7 +340,6 @@
   }
 
   .facts,
-  .roleGrid,
   .recipeSummary {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -357,7 +356,6 @@
 
 @media (max-width: 420px) {
   .facts,
-  .roleGrid,
   .recipeSummary {
     grid-template-columns: 1fr;
   }

--- a/website/src/components/model-hub/modelHubDirectory.module.css
+++ b/website/src/components/model-hub/modelHubDirectory.module.css
@@ -336,6 +336,8 @@
 }
 
 .tableFrame {
+  width: 100%;
+  max-width: 100%;
   overflow-x: auto;
 }
 
@@ -346,6 +348,22 @@
   border-collapse: collapse;
   border: 0;
   font-size: var(--text-sm);
+  table-layout: fixed;
+}
+
+.tableFrame th:first-child {
+  width: 34%;
+}
+
+.tableFrame th:nth-child(2) {
+  width: 16%;
+}
+
+.tableFrame th:nth-child(3),
+.tableFrame th:nth-child(4),
+.tableFrame th:nth-child(5),
+.tableFrame th:nth-child(6) {
+  width: 12.5%;
 }
 
 .tableFrame th,
@@ -380,7 +398,8 @@
 
 .tableModel {
   display: flex;
-  min-width: 18rem;
+  min-width: 0;
+  width: 100%;
   align-items: center;
   gap: var(--space-3);
   padding: 0;
@@ -401,6 +420,13 @@
   overflow: hidden;
   color: var(--site-muted);
   font-size: var(--text-xs);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tableModel strong {
+  overflow: hidden;
+  color: var(--site-text-strong);
   text-overflow: ellipsis;
   white-space: nowrap;
 }

--- a/website/src/components/model-hub/modelHubShared.module.css
+++ b/website/src/components/model-hub/modelHubShared.module.css
@@ -110,8 +110,8 @@ html[data-theme='dark'],
   width: 100%;
   min-height: 2.25rem;
   align-items: center;
-  gap: var(--space-2);
-  padding: 0.35rem 0.55rem 0.35rem 0.7rem;
+  gap: 0;
+  padding: 0.35rem 0.65rem 0.35rem 0.75rem;
   border: 1px solid var(--site-border);
   border-radius: var(--radius-md);
   background: var(--site-bg);
@@ -125,6 +125,9 @@ html[data-theme='dark'],
 
 .selectPrefix {
   flex: 0 0 auto;
+  margin-right: var(--space-2);
+  padding-right: var(--space-2);
+  border-right: 1px solid var(--site-border);
   color: var(--site-muted);
   font-size: var(--text-xs);
   font-weight: var(--site-font-weight-medium);
@@ -135,14 +138,23 @@ html[data-theme='dark'],
   min-width: 0;
   flex: 1 1 auto;
   color: var(--site-text);
+  font-weight: var(--site-font-weight-medium);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.selectTrigger i {
+.selectChevron {
   flex: 0 0 auto;
+  width: 0.9rem;
+  height: 0.9rem;
+  margin-left: var(--space-2);
   color: var(--site-muted);
-  font-style: normal;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.6;
+  transition: transform var(--site-transition-fast);
 }
 
 .selectTrigger:hover {
@@ -156,9 +168,18 @@ html[data-theme='dark'],
   box-shadow: 0 0 0 3px var(--site-accent-soft);
 }
 
+.selectTrigger[aria-expanded='true'] .selectChevron {
+  transform: rotate(180deg);
+}
+
+.selectTrigger:focus-visible {
+  outline: 2px solid var(--site-accent);
+  outline-offset: 2px;
+}
+
 .selectMenu {
   margin: 0;
-  padding: 0.35rem;
+  padding: 0.4rem;
   overflow: auto;
   border: 1px solid var(--site-border);
   border-radius: var(--radius-lg);
@@ -173,8 +194,12 @@ html[data-theme='dark'],
 }
 
 .selectMenu button {
-  display: block;
+  display: flex;
   width: 100%;
+  min-height: 2.2rem;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
   padding: 0.5rem 0.7rem;
   border: 0;
   border-radius: var(--radius-md);
@@ -195,6 +220,18 @@ html[data-theme='dark'],
 .selectMenu button[aria-selected='true'] {
   background: var(--site-accent-soft);
   color: var(--site-accent-strong);
+  font-weight: var(--site-font-weight-medium);
+}
+
+.selectCheck {
+  flex: 0 0 auto;
+  width: 0.9rem;
+  height: 0.9rem;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.8;
 }
 
 .pagination {

--- a/website/src/data/modelHubUrlState.ts
+++ b/website/src/data/modelHubUrlState.ts
@@ -1,0 +1,144 @@
+import type { ModelView } from './modelHubCatalogTypes'
+import {
+  modelHubDirectoryDefaults,
+  type ModelHubDirectoryFilters,
+} from './modelHubDirectorySupport'
+
+export interface ModelHubBenchmarkUrlState {
+  filter: string
+  query: string
+  publisher: string
+}
+
+export interface ModelHubUrlState {
+  filters: ModelHubDirectoryFilters
+  view: ModelView
+  page: number
+  benchmark: ModelHubBenchmarkUrlState
+  selectedModelID: string | null
+}
+
+const DEFAULT_VIEW: ModelView = 'list'
+const DEFAULT_PAGE = 1
+const DEFAULT_BENCHMARK: ModelHubBenchmarkUrlState = {
+  filter: 'all',
+  query: '',
+  publisher: 'all',
+}
+
+const filterParameters: Record<keyof ModelHubDirectoryFilters, string> = {
+  search: 'q',
+  kind: 'kind',
+  distribution: 'distribution',
+  publisher: 'creator',
+  provider: 'provider',
+  capability: 'capability',
+  lifecycle: 'lifecycle',
+  sort: 'sort',
+}
+
+const knownParameters = [
+  ...Object.values(filterParameters),
+  'view',
+  'page',
+  'benchmark',
+  'benchmark_q',
+  'benchmark_creator',
+  'model',
+]
+
+const oneOf = <T extends string>(
+  value: string | null,
+  allowed: readonly T[],
+  fallback: T,
+): T => (value && allowed.includes(value as T) ? value as T : fallback)
+
+const positivePage = (value: string | null): number => {
+  if (!value || !/^\d+$/.test(value)) return DEFAULT_PAGE
+  const page = Number(value)
+  return Number.isSafeInteger(page) && page > 0 ? page : DEFAULT_PAGE
+}
+
+export function parseModelHubUrlState(search: string): ModelHubUrlState {
+  const parameters = new URLSearchParams(search)
+  return {
+    filters: {
+      search: parameters.get(filterParameters.search) ?? modelHubDirectoryDefaults.search,
+      kind: oneOf(
+        parameters.get(filterParameters.kind),
+        ['all', 'physical', 'virtual'] as const,
+        modelHubDirectoryDefaults.kind,
+      ),
+      distribution: oneOf(
+        parameters.get(filterParameters.distribution),
+        ['all', 'open_weights', 'proprietary_api', 'router_recipe'] as const,
+        modelHubDirectoryDefaults.distribution,
+      ),
+      publisher: parameters.get(filterParameters.publisher) || modelHubDirectoryDefaults.publisher,
+      provider: parameters.get(filterParameters.provider) || modelHubDirectoryDefaults.provider,
+      capability: parameters.get(filterParameters.capability) || modelHubDirectoryDefaults.capability,
+      lifecycle: oneOf(
+        parameters.get(filterParameters.lifecycle),
+        ['supported', 'all', 'active', 'experimental', 'deprecated', 'removed'] as const,
+        modelHubDirectoryDefaults.lifecycle,
+      ),
+      sort: oneOf(
+        parameters.get(filterParameters.sort),
+        ['newest', 'name', 'context'] as const,
+        modelHubDirectoryDefaults.sort,
+      ),
+    },
+    view: oneOf(parameters.get('view'), ['list', 'table'] as const, DEFAULT_VIEW),
+    page: positivePage(parameters.get('page')),
+    benchmark: {
+      filter: parameters.get('benchmark') || DEFAULT_BENCHMARK.filter,
+      query: parameters.get('benchmark_q') ?? DEFAULT_BENCHMARK.query,
+      publisher: parameters.get('benchmark_creator') || DEFAULT_BENCHMARK.publisher,
+    },
+    selectedModelID: parameters.get('model') || null,
+  }
+}
+
+const setWhenDifferent = (
+  parameters: URLSearchParams,
+  key: string,
+  value: string,
+  defaultValue: string,
+) => {
+  if (value === defaultValue) return
+  parameters.set(key, value)
+}
+
+export function serializeModelHubUrlState(
+  state: ModelHubUrlState,
+  existingSearch = '',
+): string {
+  const parameters = new URLSearchParams(existingSearch)
+  knownParameters.forEach(parameter => parameters.delete(parameter))
+
+  const filterFields = Object.keys(filterParameters) as Array<keyof ModelHubDirectoryFilters>
+  filterFields.forEach((field) => {
+    const value = state.filters[field]
+    const defaultValue = modelHubDirectoryDefaults[field]
+    setWhenDifferent(parameters, filterParameters[field], value, defaultValue)
+  })
+  setWhenDifferent(parameters, 'view', state.view, DEFAULT_VIEW)
+  if (state.page !== DEFAULT_PAGE) parameters.set('page', String(state.page))
+  setWhenDifferent(
+    parameters,
+    'benchmark',
+    state.benchmark.filter,
+    DEFAULT_BENCHMARK.filter,
+  )
+  setWhenDifferent(parameters, 'benchmark_q', state.benchmark.query, DEFAULT_BENCHMARK.query)
+  setWhenDifferent(
+    parameters,
+    'benchmark_creator',
+    state.benchmark.publisher,
+    DEFAULT_BENCHMARK.publisher,
+  )
+  if (state.selectedModelID) parameters.set('model', state.selectedModelID)
+
+  const serialized = parameters.toString()
+  return serialized ? `?${serialized}` : ''
+}

--- a/website/src/pages/models.tsx
+++ b/website/src/pages/models.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback, useMemo, useState } from 'react'
-import { useLocation } from '@docusaurus/router'
+import React, { useCallback, useMemo } from 'react'
+import { useHistory, useLocation } from '@docusaurus/router'
 import Translate from '@docusaurus/Translate'
 import Layout from '@theme/Layout'
 import BrowseLayout from '@site/src/components/site/BrowseLayout'
@@ -27,15 +27,26 @@ import {
   modelHubDirectoryDefaults,
   type ModelHubDirectoryFilters,
 } from '../data/modelHubDirectorySupport'
+import {
+  parseModelHubUrlState,
+  serializeModelHubUrlState,
+  type ModelHubBenchmarkUrlState,
+  type ModelHubUrlState,
+} from '../data/modelHubUrlState'
 import styles from './models.module.css'
 
 const catalog = catalogDocument as unknown as CatalogSnapshot
 const MODEL_PAGE_SIZE = 10
 const MODEL_HUB_SECTIONS = [
-  { key: 'models', label: 'Models', to: '/models#models' },
-  { key: 'benchmarks', label: 'Benchmarks', to: '/models#benchmarks' },
-  { key: 'providers', label: 'Providers', to: '/models#providers' },
+  { key: 'models', label: 'Models' },
+  { key: 'benchmarks', label: 'Benchmarks' },
+  { key: 'providers', label: 'Providers' },
 ] as const
+
+type UpdateModelHubUrlState = (
+  updater: (current: ModelHubUrlState) => ModelHubUrlState,
+  push?: boolean,
+) => void
 
 function modelHubActiveSection(hash: string): string {
   const id = hash.replace('#', '')
@@ -78,10 +89,11 @@ function availableEvaluations(): Map<string, CatalogEvaluation[]> {
   return grouped
 }
 
-function useCatalogDirectory() {
-  const [filters, setFilters] = useState(modelHubDirectoryDefaults)
-  const [view, setView] = useState<ModelView>('list')
-  const [page, setPage] = useState(1)
+function useCatalogDirectory(
+  urlState: ModelHubUrlState,
+  updateUrlState: UpdateModelHubUrlState,
+) {
+  const { filters, view } = urlState
   const providersByModel = useMemo(modelBindings, [])
   const evaluationsByModel = useMemo(availableEvaluations, [])
   const publishers = useMemo(
@@ -138,24 +150,34 @@ function useCatalogDirectory() {
         )
       })
   }, [filters, providersByModel])
-  const updateFilters = (patch: Partial<ModelHubDirectoryFilters>) => {
-    setFilters(current => ({ ...current, ...patch }))
-    setPage(1)
-  }
   const pageCount = Math.max(1, Math.ceil(models.length / MODEL_PAGE_SIZE))
+  const page = Math.min(urlState.page, pageCount)
   const pageModels = models.slice((page - 1) * MODEL_PAGE_SIZE, page * MODEL_PAGE_SIZE)
+  const updateFilters = (patch: Partial<ModelHubDirectoryFilters>) =>
+    updateUrlState(current => ({
+      ...current,
+      filters: { ...current.filters, ...patch },
+      page: 1,
+    }))
 
   return {
     filters,
     updateFilters,
-    resetFilters: () => {
-      setFilters(modelHubDirectoryDefaults)
-      setPage(1)
-    },
+    resetFilters: () => updateUrlState(current => ({
+      ...current,
+      filters: modelHubDirectoryDefaults,
+      page: 1,
+    })),
     view,
-    setView,
+    setView: (nextView: ModelView) => updateUrlState(current => ({
+      ...current,
+      view: nextView,
+    })),
     page,
-    setPage,
+    setPage: (nextPage: number) => updateUrlState(current => ({
+      ...current,
+      page: nextPage,
+    })),
     pageCount,
     pageModels,
     models,
@@ -167,7 +189,10 @@ function useCatalogDirectory() {
   }
 }
 
-function useBenchmarkExplorer() {
+function useBenchmarkExplorer(
+  benchmarkState: ModelHubBenchmarkUrlState,
+  updateUrlState: UpdateModelHubUrlState,
+) {
   const allCharts = useMemo(() => modelHubBenchmarkCharts(catalog), [])
   const colors = useMemo(
     () =>
@@ -177,9 +202,7 @@ function useBenchmarkExplorer() {
       ),
     [],
   )
-  const [benchmarkFilter, setBenchmarkFilter] = useState('all')
-  const [query, setQuery] = useState('')
-  const [publisher, setPublisher] = useState('all')
+  const { filter: benchmarkFilter, query, publisher } = benchmarkState
   const benchmarkFilters = useMemo(() => {
     const tagCounts = new Map<string, number>()
     const domainCounts = new Map<string, number>()
@@ -258,26 +281,48 @@ function useBenchmarkExplorer() {
     chartCount: allCharts.length,
     filters: benchmarkFilters,
     filter: activeBenchmarkFilter,
-    setFilter: setBenchmarkFilter,
+    setFilter: (filter: string) => updateUrlState(current => ({
+      ...current,
+      benchmark: { ...current.benchmark, filter },
+    })),
     query,
-    setQuery,
+    setQuery: (nextQuery: string) => updateUrlState(current => ({
+      ...current,
+      benchmark: { ...current.benchmark, query: nextQuery },
+    })),
     publisher: activePublisher,
-    setPublisher,
+    setPublisher: (nextPublisher: string) => updateUrlState(current => ({
+      ...current,
+      benchmark: { ...current.benchmark, publisher: nextPublisher },
+    })),
     publishers,
   }
 }
 
 export default function ModelsPage() {
-  const { hash } = useLocation()
-  const directory = useCatalogDirectory()
-  const [selectedModelID, setSelectedModelID] = useState<string | null>(null)
+  const history = useHistory()
+  const location = useLocation()
+  const urlState = useMemo(
+    () => parseModelHubUrlState(location.search),
+    [location.search],
+  )
+  const updateUrlState = useCallback<UpdateModelHubUrlState>((updater, push = false) => {
+    const current = parseModelHubUrlState(location.search)
+    const nextSearch = serializeModelHubUrlState(updater(current), location.search)
+    const nextLocation = `${location.pathname}${nextSearch}${location.hash}`
+    if (push) history.push(nextLocation)
+    else history.replace(nextLocation)
+  }, [history, location.hash, location.pathname, location.search])
+  const directory = useCatalogDirectory(urlState, updateUrlState)
   const modelByID = useMemo(() => new Map(catalog.models.map(model => [model.id, model])), [])
   const reasoningFamilies = useMemo(
     () => new Map(catalog.reasoning_families.map(family => [family.id, family])),
     [],
   )
-  const benchmark = useBenchmarkExplorer()
-  const selectedModel = selectedModelID ? modelByID.get(selectedModelID) : undefined
+  const benchmark = useBenchmarkExplorer(urlState.benchmark, updateUrlState)
+  const selectedModel = urlState.selectedModelID
+    ? modelByID.get(urlState.selectedModelID)
+    : undefined
   const selectedProviders = selectedModel
     ? (directory.providersByModel.get(selectedModel.id) ?? [])
     : []
@@ -289,7 +334,19 @@ export default function ModelsPage() {
   const selectedFamily = selectedModel?.reasoning_family
     ? reasoningFamilies.get(selectedModel.reasoning_family)
     : undefined
-  const closeModelDetail = useCallback(() => setSelectedModelID(null), [])
+  const selectModel = useCallback((selectedModelID: string) => {
+    updateUrlState(current => ({ ...current, selectedModelID }), true)
+  }, [updateUrlState])
+  const closeModelDetail = useCallback(() => {
+    updateUrlState(current => ({ ...current, selectedModelID: null }))
+  }, [updateUrlState])
+  const sections = useMemo(
+    () => MODEL_HUB_SECTIONS.map(section => ({
+      ...section,
+      to: `${location.pathname}${location.search}#${section.key}`,
+    })),
+    [location.pathname, location.search],
+  )
   const physicalModels = catalog.models.filter(model => model.kind === 'physical').length
   const virtualModels = catalog.models.length - physicalModels
   const creators = new Set(
@@ -304,14 +361,14 @@ export default function ModelsPage() {
     >
       <div className={styles.page}>
         <BrowseLayout
-          activeKey={modelHubActiveSection(hash)}
+          activeKey={modelHubActiveSection(location.hash)}
           description="Models, ready to route."
           eyebrow={<Translate id="models.layout.eyebrow">Catalog</Translate>}
           groups={[
             {
               key: 'explore',
               label: 'Explore',
-              items: [...MODEL_HUB_SECTIONS],
+              items: sections,
             },
           ]}
           sidebarLabel="Model Hub sections"
@@ -353,7 +410,7 @@ export default function ModelsPage() {
             <ModelHubDirectory
               {...directory}
               pageSize={MODEL_PAGE_SIZE}
-              selectModel={setSelectedModelID}
+              selectModel={selectModel}
             />
           </section>
 
@@ -362,7 +419,7 @@ export default function ModelsPage() {
               <h2 id="benchmarks-heading">Benchmarks</h2>
               <span>Exact published results</span>
             </header>
-            <ModelHubBenchmark {...benchmark} selectModel={setSelectedModelID} />
+            <ModelHubBenchmark {...benchmark} selectModel={selectModel} />
           </section>
 
           <section id="providers" className={styles.section} aria-labelledby="providers-heading">

--- a/website/static/model-catalog/catalog.json
+++ b/website/static/model-catalog/catalog.json
@@ -25056,6 +25056,516 @@
       }
     },
     {
+      "benchmark": "cais/humanitys-last-exam@1.0.0",
+      "benchmark_profile": "independent-standard",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/humanitys-last-exam",
+        "verification": "imported"
+      },
+      "id": "independent/gpt-6-astra-low-humanitys-last-exam@1.0.0",
+      "metrics": {
+        "accuracy": 0.492122335495829
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-08",
+      "reasoning_effort": "low",
+      "status": "available",
+      "subject": {
+        "run_kind": "independent",
+        "sample_count": 2158,
+        "source_model": "GPT-6 Astra (low)",
+        "source_model_slug": "gpt-6-astra-low",
+        "tool_policy": "no_tools"
+      }
+    },
+    {
+      "benchmark": "harbor/terminal-bench@2.1.0",
+      "benchmark_profile": "independent-agent",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/terminalbench-v2-1",
+        "verification": "imported"
+      },
+      "id": "independent/gpt-6-astra-low-terminalbench-v2-1@1.0.0",
+      "metrics": {
+        "resolved": 0.880149812734082
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-08",
+      "reasoning_effort": "low",
+      "status": "available",
+      "subject": {
+        "agent_harness": "Terminus 2",
+        "repeats": 3,
+        "run_kind": "independent",
+        "sandbox": "E2B",
+        "source_model": "GPT-6 Astra (low)",
+        "source_model_slug": "gpt-6-astra-low",
+        "task_count": 89
+      }
+    },
+    {
+      "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+      "benchmark_profile": "independent-standard",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/gpqa-diamond",
+        "verification": "imported"
+      },
+      "id": "independent/gpt-6-astra-low-gpqa-diamond@1.0.0",
+      "metrics": {
+        "accuracy": 0.931313131313131
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-08",
+      "reasoning_effort": "low",
+      "status": "available",
+      "subject": {
+        "run_kind": "independent",
+        "sample_count": 198,
+        "source_model": "GPT-6 Astra (low)",
+        "source_model_slug": "gpt-6-astra-low"
+      }
+    },
+    {
+      "benchmark": "scicode-bench/scicode@1.0.0",
+      "benchmark_profile": "independent-test-288",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/scicode",
+        "verification": "imported"
+      },
+      "id": "independent/gpt-6-astra-low-scicode@1.0.0",
+      "metrics": {
+        "score": 0.540509259259259
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-08",
+      "reasoning_effort": "low",
+      "status": "available",
+      "subject": {
+        "repeats": 3,
+        "run_kind": "independent",
+        "sample_count": 288,
+        "source_model": "GPT-6 Astra (low)",
+        "source_model_slug": "gpt-6-astra-low",
+        "tool_policy": "no_tools"
+      }
+    },
+    {
+      "benchmark": "cais/humanitys-last-exam@1.0.0",
+      "benchmark_profile": "independent-standard",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/humanitys-last-exam",
+        "verification": "imported"
+      },
+      "id": "independent/gpt-6-astra-medium-humanitys-last-exam@1.0.0",
+      "metrics": {
+        "accuracy": 0.527340129749768
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-08",
+      "reasoning_effort": "medium",
+      "status": "available",
+      "subject": {
+        "run_kind": "independent",
+        "sample_count": 2158,
+        "source_model": "GPT-6 Astra (medium)",
+        "source_model_slug": "gpt-6-astra-medium",
+        "tool_policy": "no_tools"
+      }
+    },
+    {
+      "benchmark": "harbor/terminal-bench@2.1.0",
+      "benchmark_profile": "independent-agent",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/terminalbench-v2-1",
+        "verification": "imported"
+      },
+      "id": "independent/gpt-6-astra-medium-terminalbench-v2-1@1.0.0",
+      "metrics": {
+        "resolved": 0.895131086142322
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-08",
+      "reasoning_effort": "medium",
+      "status": "available",
+      "subject": {
+        "agent_harness": "Terminus 2",
+        "repeats": 3,
+        "run_kind": "independent",
+        "sandbox": "E2B",
+        "source_model": "GPT-6 Astra (medium)",
+        "source_model_slug": "gpt-6-astra-medium",
+        "task_count": 89
+      }
+    },
+    {
+      "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+      "benchmark_profile": "independent-standard",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/gpqa-diamond",
+        "verification": "imported"
+      },
+      "id": "independent/gpt-6-astra-medium-gpqa-diamond@1.0.0",
+      "metrics": {
+        "accuracy": 0.939393939393939
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-08",
+      "reasoning_effort": "medium",
+      "status": "available",
+      "subject": {
+        "run_kind": "independent",
+        "sample_count": 198,
+        "source_model": "GPT-6 Astra (medium)",
+        "source_model_slug": "gpt-6-astra-medium"
+      }
+    },
+    {
+      "benchmark": "scicode-bench/scicode@1.0.0",
+      "benchmark_profile": "independent-test-288",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/scicode",
+        "verification": "imported"
+      },
+      "id": "independent/gpt-6-astra-medium-scicode@1.0.0",
+      "metrics": {
+        "score": 0.541666666666667
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-08",
+      "reasoning_effort": "medium",
+      "status": "available",
+      "subject": {
+        "repeats": 3,
+        "run_kind": "independent",
+        "sample_count": 288,
+        "source_model": "GPT-6 Astra (medium)",
+        "source_model_slug": "gpt-6-astra-medium",
+        "tool_policy": "no_tools"
+      }
+    },
+    {
+      "benchmark": "cais/humanitys-last-exam@1.0.0",
+      "benchmark_profile": "independent-standard",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/humanitys-last-exam",
+        "verification": "imported"
+      },
+      "id": "independent/gpt-6-astra-high-humanitys-last-exam@1.0.0",
+      "metrics": {
+        "accuracy": 0.530583873957368
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-08",
+      "reasoning_effort": "high",
+      "status": "available",
+      "subject": {
+        "run_kind": "independent",
+        "sample_count": 2158,
+        "source_model": "GPT-6 Astra (high)",
+        "source_model_slug": "gpt-6-astra-high",
+        "tool_policy": "no_tools"
+      }
+    },
+    {
+      "benchmark": "harbor/terminal-bench@2.1.0",
+      "benchmark_profile": "independent-agent",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/terminalbench-v2-1",
+        "verification": "imported"
+      },
+      "id": "independent/gpt-6-astra-high-terminalbench-v2-1@1.0.0",
+      "metrics": {
+        "resolved": 0.898876404494382
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-08",
+      "reasoning_effort": "high",
+      "status": "available",
+      "subject": {
+        "agent_harness": "Terminus 2",
+        "repeats": 3,
+        "run_kind": "independent",
+        "sandbox": "E2B",
+        "source_model": "GPT-6 Astra (high)",
+        "source_model_slug": "gpt-6-astra-high",
+        "task_count": 89
+      }
+    },
+    {
+      "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+      "benchmark_profile": "independent-standard",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/gpqa-diamond",
+        "verification": "imported"
+      },
+      "id": "independent/gpt-6-astra-high-gpqa-diamond@1.0.0",
+      "metrics": {
+        "accuracy": 0.94949494949495
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-08",
+      "reasoning_effort": "high",
+      "status": "available",
+      "subject": {
+        "run_kind": "independent",
+        "sample_count": 198,
+        "source_model": "GPT-6 Astra (high)",
+        "source_model_slug": "gpt-6-astra-high"
+      }
+    },
+    {
+      "benchmark": "scicode-bench/scicode@1.0.0",
+      "benchmark_profile": "independent-test-288",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/scicode",
+        "verification": "imported"
+      },
+      "id": "independent/gpt-6-astra-high-scicode@1.0.0",
+      "metrics": {
+        "score": 0.554398148148148
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-08",
+      "reasoning_effort": "high",
+      "status": "available",
+      "subject": {
+        "repeats": 3,
+        "run_kind": "independent",
+        "sample_count": 288,
+        "source_model": "GPT-6 Astra (high)",
+        "source_model_slug": "gpt-6-astra-high",
+        "tool_policy": "no_tools"
+      }
+    },
+    {
+      "benchmark": "cais/humanitys-last-exam@1.0.0",
+      "benchmark_profile": "independent-standard",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/humanitys-last-exam",
+        "verification": "imported"
+      },
+      "id": "independent/gpt-6-astra-xhigh-humanitys-last-exam@1.0.0",
+      "metrics": {
+        "accuracy": 0.545875810936052
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-08",
+      "reasoning_effort": "xhigh",
+      "status": "available",
+      "subject": {
+        "run_kind": "independent",
+        "sample_count": 2158,
+        "source_model": "GPT-6 Astra (xhigh)",
+        "source_model_slug": "gpt-6-astra-xhigh",
+        "tool_policy": "no_tools"
+      }
+    },
+    {
+      "benchmark": "harbor/terminal-bench@2.1.0",
+      "benchmark_profile": "independent-agent",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/terminalbench-v2-1",
+        "verification": "imported"
+      },
+      "id": "independent/gpt-6-astra-xhigh-terminalbench-v2-1@1.0.0",
+      "metrics": {
+        "resolved": 0.891385767790262
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-08",
+      "reasoning_effort": "xhigh",
+      "status": "available",
+      "subject": {
+        "agent_harness": "Terminus 2",
+        "repeats": 3,
+        "run_kind": "independent",
+        "sandbox": "E2B",
+        "source_model": "GPT-6 Astra (xhigh)",
+        "source_model_slug": "gpt-6-astra-xhigh",
+        "task_count": 89
+      }
+    },
+    {
+      "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+      "benchmark_profile": "independent-standard",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/gpqa-diamond",
+        "verification": "imported"
+      },
+      "id": "independent/gpt-6-astra-xhigh-gpqa-diamond@1.0.0",
+      "metrics": {
+        "accuracy": 0.962626262626263
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-08",
+      "reasoning_effort": "xhigh",
+      "status": "available",
+      "subject": {
+        "run_kind": "independent",
+        "sample_count": 198,
+        "source_model": "GPT-6 Astra (xhigh)",
+        "source_model_slug": "gpt-6-astra-xhigh"
+      }
+    },
+    {
+      "benchmark": "scicode-bench/scicode@1.0.0",
+      "benchmark_profile": "independent-test-288",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/scicode",
+        "verification": "imported"
+      },
+      "id": "independent/gpt-6-astra-xhigh-scicode@1.0.0",
+      "metrics": {
+        "score": 0.556712962962963
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-08",
+      "reasoning_effort": "xhigh",
+      "status": "available",
+      "subject": {
+        "repeats": 3,
+        "run_kind": "independent",
+        "sample_count": 288,
+        "source_model": "GPT-6 Astra (xhigh)",
+        "source_model_slug": "gpt-6-astra-xhigh",
+        "tool_policy": "no_tools"
+      }
+    },
+    {
+      "benchmark": "cais/humanitys-last-exam@1.0.0",
+      "benchmark_profile": "independent-standard",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/humanitys-last-exam",
+        "verification": "imported"
+      },
+      "id": "independent/gpt-6-astra-max-humanitys-last-exam@1.0.0",
+      "metrics": {
+        "accuracy": 0.546802594995366
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-08",
+      "reasoning_effort": "max",
+      "status": "available",
+      "subject": {
+        "run_kind": "independent",
+        "sample_count": 2158,
+        "source_model": "GPT-6 Astra (max)",
+        "source_model_slug": "gpt-6-astra",
+        "tool_policy": "no_tools"
+      }
+    },
+    {
+      "benchmark": "harbor/terminal-bench@2.1.0",
+      "benchmark_profile": "independent-agent",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/terminalbench-v2-1",
+        "verification": "imported"
+      },
+      "id": "independent/gpt-6-astra-max-terminalbench-v2-1@1.0.0",
+      "metrics": {
+        "resolved": 0.883895131086142
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-08",
+      "reasoning_effort": "max",
+      "status": "available",
+      "subject": {
+        "agent_harness": "Terminus 2",
+        "repeats": 3,
+        "run_kind": "independent",
+        "sandbox": "E2B",
+        "source_model": "GPT-6 Astra (max)",
+        "source_model_slug": "gpt-6-astra",
+        "task_count": 89
+      }
+    },
+    {
+      "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+      "benchmark_profile": "independent-standard",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/gpqa-diamond",
+        "verification": "imported"
+      },
+      "id": "independent/gpt-6-astra-max-gpqa-diamond@1.0.0",
+      "metrics": {
+        "accuracy": 0.960606060606061
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-08",
+      "reasoning_effort": "max",
+      "status": "available",
+      "subject": {
+        "run_kind": "independent",
+        "sample_count": 198,
+        "source_model": "GPT-6 Astra (max)",
+        "source_model_slug": "gpt-6-astra"
+      }
+    },
+    {
+      "benchmark": "scicode-bench/scicode@1.0.0",
+      "benchmark_profile": "independent-test-288",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/scicode",
+        "verification": "imported"
+      },
+      "id": "independent/gpt-6-astra-max-scicode@1.0.0",
+      "metrics": {
+        "score": 0.564814814814815
+      },
+      "model": "openai/gpt-6-astra",
+      "observed_at": "2026-09-08",
+      "reasoning_effort": "max",
+      "status": "available",
+      "subject": {
+        "repeats": 3,
+        "run_kind": "independent",
+        "sample_count": 288,
+        "source_model": "GPT-6 Astra (max)",
+        "source_model_slug": "gpt-6-astra",
+        "tool_policy": "no_tools"
+      }
+    },
+    {
       "benchmark": "idavidrein/gpqa-diamond@1.0.0",
       "benchmark_profile": "published-standard",
       "evidence": {


### PR DESCRIPTION
Fixes #3565

## Summary

- import 20 attributable GPT-6 Astra results from Artificial Analysis across low, medium, high, xhigh, and max effort for GPQA Diamond, Humanity’s Last Exam (no tools), Terminal-Bench 2.1, and SciCode
- keep independent imported evidence separate from the existing vendor-claimed launch snapshot; do not synthesize unavailable MMLU-Pro or SWE-bench Verified scores
- encode every Model Hub directory and benchmark control in the URL, including virtual-model filters, pagination, view mode, and selected model details
- make the model table fill the content width, refine the dropdown and chevron treatment, and render each virtual-model decision role on its own row

## Validation

- make model-catalog-check
- targeted Model Hub URL-state tests
- ESLint on the changed TypeScript and JavaScript files
- repository pre-commit hooks (local go-fmt hook skipped because gofmt is unavailable; generated Go is validated in CI)