### PR TITLE
[Feature] Add Qwen3.8 Flash Next to the model catalog

### DIFF
--- a/config/catalog/README.md
+++ b/config/catalog/README.md
@@ -112,7 +112,7 @@ without duplicating its intrinsic identity. Virtual recipes are materialized
 from packaged assets and keep their own evaluation directory.
 
 The built-in physical inventory is curated at the creator-company level. The
-current baseline contains 84 physical cards from 22 mainstream creators and
+current baseline contains 85 physical cards from 22 mainstream creators and
 five separately stored virtual cards. For each creator, prefer roughly the
 latest three generations or representative product lines over accumulating a
 shallow long tail of lesser-known creators. This policy is about Model Cards,

--- a/config/catalog/manifest.yaml
+++ b/config/catalog/manifest.yaml
@@ -36,8 +36,8 @@ inventory:
       - publisher: Alibaba / Qwen
         representative_models:
           - qwen/qwen3.8-max
+          - qwen/qwen3.8-flash-next
           - qwen/qwen3.7-max
-          - qwen/qwen3.6-27b
       - publisher: Amazon
         representative_models:
           - amazon/nova-2-lite

--- a/config/catalog/resources/benchmarks.yaml
+++ b/config/catalog/resources/benchmarks.yaml
@@ -245,6 +245,10 @@
       unit: proportion
       direction: higher_is_better
       range: [0, 1]
+    - id: score
+      unit: proportion
+      direction: higher_is_better
+      range: [0, 1]
 - id: zapier/automation-bench@1.0.6
   display_name: AutomationBench 1.0.6
   domain: agentic_systems

--- a/config/catalog/resources/evaluations/single/deepseek.yaml
+++ b/config/catalog/resources/evaluations/single/deepseek.yaml
@@ -919,7 +919,7 @@
   metrics:
     resolved: 0.827
   status: available
-  observed_at: 2026-09-09
+  observed_at: 2026-09-08
   evidence:
     provenance: vendor_claimed
     verification: claimed

--- a/config/catalog/resources/evaluations/single/deepseek.yaml
+++ b/config/catalog/resources/evaluations/single/deepseek.yaml
@@ -911,18 +911,19 @@
   benchmark_profile: published-agent
   reasoning_effort: max
   subject:
-    variant: deepseek-v4-flash
+    variant: DeepSeek-V4-Flash-0731
+    model_revision: DeepSeek-V4-Flash-0731
     reasoning_effort: max
     terminal_harness: DeepSeek API evaluation harness
     source_kind: official_release_evaluation
   metrics:
     resolved: 0.827
   status: available
-  observed_at: 2026-09-06
+  observed_at: 2026-09-09
   evidence:
     provenance: vendor_claimed
     verification: claimed
-    source: https://api-docs.deepseek.com/updates/
+    source: https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731
     redistributable: true
 - id: independent/deepseek-v4-flash-terminalbench-v2-1@1.0.0
   model: deepseek/deepseek-v4-flash

--- a/config/catalog/resources/evaluations/single/qwen.yaml
+++ b/config/catalog/resources/evaluations/single/qwen.yaml
@@ -954,7 +954,7 @@
   metrics:
     resolved: 0.587
   status: available
-  observed_at: 2026-09-09
+  observed_at: 2026-09-08
   evidence:
     provenance: vendor_claimed
     verification: claimed
@@ -978,7 +978,7 @@
   metrics:
     resolved: 0.625
   status: available
-  observed_at: 2026-09-09
+  observed_at: 2026-09-08
   evidence:
     provenance: vendor_claimed
     verification: claimed
@@ -998,7 +998,7 @@
     pass_rate: 0.243
     score: 0.512
   status: available
-  observed_at: 2026-09-09
+  observed_at: 2026-09-08
   evidence:
     provenance: vendor_claimed
     verification: claimed
@@ -1017,7 +1017,7 @@
   metrics:
     accuracy: 0.813
   status: available
-  observed_at: 2026-09-09
+  observed_at: 2026-09-08
   evidence:
     provenance: vendor_claimed
     verification: claimed
@@ -1036,7 +1036,7 @@
   metrics:
     accuracy: 0.917
   status: available
-  observed_at: 2026-09-09
+  observed_at: 2026-09-08
   evidence:
     provenance: vendor_claimed
     verification: claimed
@@ -1056,7 +1056,7 @@
   metrics:
     accuracy: 0.359
   status: available
-  observed_at: 2026-09-09
+  observed_at: 2026-09-08
   evidence:
     provenance: vendor_claimed
     verification: claimed
@@ -1075,7 +1075,7 @@
   metrics:
     pass_at_1: 0.919
   status: available
-  observed_at: 2026-09-09
+  observed_at: 2026-09-08
   evidence:
     provenance: vendor_claimed
     verification: claimed
@@ -1095,7 +1095,7 @@
   metrics:
     score: 0.846
   status: available
-  observed_at: 2026-09-09
+  observed_at: 2026-09-08
   evidence:
     provenance: vendor_claimed
     verification: claimed
@@ -1115,7 +1115,7 @@
   metrics:
     score: 0.906
   status: available
-  observed_at: 2026-09-09
+  observed_at: 2026-09-08
   evidence:
     provenance: vendor_claimed
     verification: claimed

--- a/config/catalog/resources/evaluations/single/qwen.yaml
+++ b/config/catalog/resources/evaluations/single/qwen.yaml
@@ -936,6 +936,191 @@
     verification: imported
     source: https://artificialanalysis.ai/evaluations/tau3-banking
     redistributable: true
+- id: qwen/qwen3.8-flash-next-model-card-deep-swe@1.0.0
+  model: qwen/qwen3.8-flash-next
+  benchmark: datacurve/deep-swe@1.1.0
+  benchmark_profile: published-agent
+  reasoning_effort: unspecified
+  subject:
+    variant: Qwen3.8-Flash-Next
+    model_revision: de4b8e4d43b917e7706784d8bb445c9af86a3540
+    reasoning_effort: unspecified
+    source_kind: official_model_card
+    swe_harness: mini-SWE-agent
+    sampling_temperature: 1.0
+    sampling_top_p: 0.95
+    context_window_size: 262144
+    reported_selection: highest_across_claude_code_and_mini_swe_agent
+  metrics:
+    resolved: 0.587
+  status: available
+  observed_at: 2026-09-09
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/Qwen/Qwen3.8-Flash-Next
+    redistributable: true
+- id: qwen/qwen3.8-flash-next-model-card-swe-bench-pro@1.0.0
+  model: qwen/qwen3.8-flash-next
+  benchmark: swe-bench/pro@1.0.0
+  benchmark_profile: published-agent
+  reasoning_effort: unspecified
+  subject:
+    variant: Qwen3.8-Flash-Next
+    model_revision: de4b8e4d43b917e7706784d8bb445c9af86a3540
+    reasoning_effort: unspecified
+    source_kind: official_model_card
+    swe_harness: Claude Code
+    dataset_variant: refined
+    sampling_temperature: 1.0
+    sampling_top_p: 0.95
+    context_window_size: 262144
+  metrics:
+    resolved: 0.625
+  status: available
+  observed_at: 2026-09-09
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/Qwen/Qwen3.8-Flash-Next
+    redistributable: true
+- id: qwen/qwen3.8-flash-next-model-card-agents-last-exam@1.0.0
+  model: qwen/qwen3.8-flash-next
+  benchmark: berkeley-rdi/agents-last-exam@1.0.0
+  benchmark_profile: published-agent
+  reasoning_effort: unspecified
+  subject:
+    variant: Qwen3.8-Flash-Next
+    model_revision: de4b8e4d43b917e7706784d8bb445c9af86a3540
+    reasoning_effort: unspecified
+    source_kind: official_model_card
+  metrics:
+    pass_rate: 0.243
+    score: 0.512
+  status: available
+  observed_at: 2026-09-09
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/Qwen/Qwen3.8-Flash-Next
+    redistributable: true
+- id: qwen/qwen3.8-flash-next-model-card-ifbench@1.0.0
+  model: qwen/qwen3.8-flash-next
+  benchmark: allenai/ifbench@1.0.0
+  benchmark_profile: prompt-loose
+  reasoning_effort: unspecified
+  subject:
+    variant: Qwen3.8-Flash-Next
+    model_revision: de4b8e4d43b917e7706784d8bb445c9af86a3540
+    reasoning_effort: unspecified
+    source_kind: official_model_card
+  metrics:
+    accuracy: 0.813
+  status: available
+  observed_at: 2026-09-09
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/Qwen/Qwen3.8-Flash-Next
+    redistributable: true
+- id: qwen/qwen3.8-flash-next-model-card-gpqa-diamond@1.0.0
+  model: qwen/qwen3.8-flash-next
+  benchmark: idavidrein/gpqa-diamond@1.0.0
+  benchmark_profile: published-standard
+  reasoning_effort: unspecified
+  subject:
+    variant: Qwen3.8-Flash-Next
+    model_revision: de4b8e4d43b917e7706784d8bb445c9af86a3540
+    reasoning_effort: unspecified
+    source_kind: official_model_card
+  metrics:
+    accuracy: 0.917
+  status: available
+  observed_at: 2026-09-09
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/Qwen/Qwen3.8-Flash-Next
+    redistributable: true
+- id: qwen/qwen3.8-flash-next-model-card-humanitys-last-exam@1.0.0
+  model: qwen/qwen3.8-flash-next
+  benchmark: cais/humanitys-last-exam@1.0.0
+  benchmark_profile: published-unspecified
+  reasoning_effort: unspecified
+  subject:
+    variant: Qwen3.8-Flash-Next
+    model_revision: de4b8e4d43b917e7706784d8bb445c9af86a3540
+    reasoning_effort: unspecified
+    source_kind: official_model_card
+    hle_judge: GPT-4o
+  metrics:
+    accuracy: 0.359
+  status: available
+  observed_at: 2026-09-09
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/Qwen/Qwen3.8-Flash-Next
+    redistributable: true
+- id: qwen/qwen3.8-flash-next-model-card-livecodebench-v6@1.0.0
+  model: qwen/qwen3.8-flash-next
+  benchmark: livecodebench/livecodebench@6.0.0
+  benchmark_profile: code-generation-pass-at-1
+  reasoning_effort: unspecified
+  subject:
+    variant: Qwen3.8-Flash-Next
+    model_revision: de4b8e4d43b917e7706784d8bb445c9af86a3540
+    reasoning_effort: unspecified
+    source_kind: official_model_card
+  metrics:
+    pass_at_1: 0.919
+  status: available
+  observed_at: 2026-09-09
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/Qwen/Qwen3.8-Flash-Next
+    redistributable: true
+- id: qwen/qwen3.8-flash-next-model-card-charxiv-no-tools@1.0.0
+  model: qwen/qwen3.8-flash-next
+  benchmark: princeton-nlp/charxiv@1.0.0
+  benchmark_profile: no-tools
+  reasoning_effort: unspecified
+  subject:
+    variant: Qwen3.8-Flash-Next
+    model_revision: de4b8e4d43b917e7706784d8bb445c9af86a3540
+    reasoning_effort: unspecified
+    source_kind: official_model_card
+    tool_policy: without_code_interpreter
+  metrics:
+    score: 0.846
+  status: available
+  observed_at: 2026-09-09
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/Qwen/Qwen3.8-Flash-Next
+    redistributable: true
+- id: qwen/qwen3.8-flash-next-model-card-charxiv-with-tools@1.0.0
+  model: qwen/qwen3.8-flash-next
+  benchmark: princeton-nlp/charxiv@1.0.0
+  benchmark_profile: with-tools
+  reasoning_effort: unspecified
+  subject:
+    variant: Qwen3.8-Flash-Next
+    model_revision: de4b8e4d43b917e7706784d8bb445c9af86a3540
+    reasoning_effort: unspecified
+    source_kind: official_model_card
+    tool_policy: with_code_interpreter
+  metrics:
+    score: 0.906
+  status: available
+  observed_at: 2026-09-09
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/Qwen/Qwen3.8-Flash-Next
+    redistributable: true
 - id: independent/qwen3-8-27b-low-critpt@1.0.0
   model: qwen/qwen3.8-27b
   benchmark: artificial-analysis/critpt@1.0.0

--- a/config/catalog/resources/models/single/deepseek.yaml
+++ b/config/catalog/resources/models/single/deepseek.yaml
@@ -52,7 +52,7 @@
     monochrome: false
   distribution:
     type: open_weights
-    source: https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash
+    source: https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731
     license: MIT
   family: deepseek-v4
   parameter_size: 284B (13B active)
@@ -76,8 +76,8 @@
   verification:
     authority: DeepSeek
     status: claimed
-    verified_at: 2026-09-05
-    source: https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash
+    verified_at: 2026-09-09
+    source: https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731
   tags:
   - efficient
   - open_weights

--- a/config/catalog/resources/models/single/deepseek.yaml
+++ b/config/catalog/resources/models/single/deepseek.yaml
@@ -76,7 +76,7 @@
   verification:
     authority: DeepSeek
     status: claimed
-    verified_at: 2026-09-09
+    verified_at: 2026-09-08
     source: https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731
   tags:
   - efficient

--- a/config/catalog/resources/models/single/qwen.yaml
+++ b/config/catalog/resources/models/single/qwen.yaml
@@ -77,7 +77,7 @@
   verification:
     authority: Qwen Team
     status: claimed
-    verified_at: 2026-09-09
+    verified_at: 2026-09-08
     source: https://huggingface.co/Qwen/Qwen3.8-Flash-Next
   tags:
   - open_weights

--- a/config/catalog/resources/models/single/qwen.yaml
+++ b/config/catalog/resources/models/single/qwen.yaml
@@ -41,6 +41,51 @@
   - frontier
   - agentic
   released_at: '2026-08-10'
+- id: qwen/qwen3.8-flash-next
+  display_name: Qwen3.8 Flash Next
+  description: Experimental open-weight Qwen4 architecture preview for efficient multimodal reasoning and agents.
+  kind: physical
+  publisher: Alibaba / Qwen
+  presentation:
+    logo: package:qwen
+    monogram: Q
+    monochrome: false
+  distribution:
+    type: open_weights
+    source: https://huggingface.co/Qwen/Qwen3.8-Flash-Next
+    license: Qwen Community License 1.0
+  family: qwen3.8
+  parameter_size: 176B + 4B MTP (6B active)
+  lifecycle: experimental
+  limits:
+    context_window_size: 262144
+  capabilities:
+  - chat
+  - reasoning
+  - tools
+  - structured_output
+  - vision
+  - long_context
+  modalities:
+    input:
+    - text
+    - image
+    - video
+    output:
+    - text
+  reasoning_family: qwen3.8
+  verification:
+    authority: Qwen Team
+    status: claimed
+    verified_at: 2026-09-09
+    source: https://huggingface.co/Qwen/Qwen3.8-Flash-Next
+  tags:
+  - open_weights
+  - multimodal
+  - moe
+  - agentic
+  - long_context
+  released_at: '2026-08-24'
 - id: qwen/qwen3.8-27b
   display_name: Qwen3.8 27B
   description: Dense open-weight Qwen3.8 multimodal model for reasoning and agentic work.

--- a/config/catalog/resources/providers/sglang.yaml
+++ b/config/catalog/resources/providers/sglang.yaml
@@ -24,6 +24,18 @@ presentation:
 conformance:
   status: unverified
 models:
+- catalog: qwen/qwen3.8-flash-next
+  relationship: self_hosted
+  id: Qwen/Qwen3.8-Flash-Next
+  protocols:
+  - openai/chat-completions@1
+  - openai/responses@1
+  reasoning_transport: top_level_effort_template_switch
+  lifecycle: experimental
+  verification:
+    status: claimed
+    verified_at: 2026-09-09
+    source: https://docs.sglang.io/cookbook/autoregressive/Qwen/Qwen3.8-Flash-Next
 - catalog: qwen/qwen3.8-27b
   relationship: self_hosted
   id: Qwen/Qwen3.8-27B

--- a/config/catalog/resources/providers/sglang.yaml
+++ b/config/catalog/resources/providers/sglang.yaml
@@ -34,7 +34,7 @@ models:
   lifecycle: experimental
   verification:
     status: claimed
-    verified_at: 2026-09-09
+    verified_at: 2026-09-08
     source: https://docs.sglang.io/cookbook/autoregressive/Qwen/Qwen3.8-Flash-Next
 - catalog: qwen/qwen3.8-27b
   relationship: self_hosted

--- a/config/catalog/resources/providers/vllm.yaml
+++ b/config/catalog/resources/providers/vllm.yaml
@@ -154,7 +154,7 @@ models:
     source: https://huggingface.co/deepseek-ai/DeepSeek-V3.2
 - catalog: deepseek/deepseek-v4-flash
   relationship: self_hosted
-  id: deepseek-ai/DeepSeek-V4-Flash
+  id: deepseek-ai/DeepSeek-V4-Flash-0731
   protocols:
   - openai/chat-completions@1
   - openai/responses@1
@@ -162,8 +162,8 @@ models:
   lifecycle: active
   verification:
     status: claimed
-    verified_at: 2026-09-05
-    source: https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash
+    verified_at: 2026-09-09
+    source: https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731
 - catalog: deepseek/deepseek-v4-pro
   relationship: self_hosted
   id: deepseek-ai/DeepSeek-V4-Pro
@@ -386,6 +386,18 @@ models:
     status: claimed
     verified_at: 2026-09-05
     source: https://huggingface.co/Qwen/Qwen3.8-27B
+- catalog: qwen/qwen3.8-flash-next
+  relationship: self_hosted
+  id: Qwen/Qwen3.8-Flash-Next
+  protocols:
+  - openai/chat-completions@1
+  - openai/responses@1
+  reasoning_transport: top_level_effort_template_switch
+  lifecycle: experimental
+  verification:
+    status: claimed
+    verified_at: 2026-09-09
+    source: https://recipes.vllm.ai/Qwen/Qwen3.8-Flash-Next
 - catalog: qwen/qwen3.8-2.4t-a95b
   relationship: self_hosted
   id: Qwen/Qwen3.8-2.4T-A95B

--- a/config/catalog/resources/providers/vllm.yaml
+++ b/config/catalog/resources/providers/vllm.yaml
@@ -162,7 +162,7 @@ models:
   lifecycle: active
   verification:
     status: claimed
-    verified_at: 2026-09-09
+    verified_at: 2026-09-08
     source: https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731
 - catalog: deepseek/deepseek-v4-pro
   relationship: self_hosted
@@ -396,7 +396,7 @@ models:
   lifecycle: experimental
   verification:
     status: claimed
-    verified_at: 2026-09-09
+    verified_at: 2026-09-08
     source: https://recipes.vllm.ai/Qwen/Qwen3.8-Flash-Next
 - catalog: qwen/qwen3.8-2.4t-a95b
   relationship: self_hosted

--- a/config/recipes/built-in/latest/catalog.yaml
+++ b/config/recipes/built-in/latest/catalog.yaml
@@ -2378,7 +2378,7 @@ providers:
     lifecycle: experimental
     verification:
       status: claimed
-      verified_at: '2026-09-09'
+      verified_at: '2026-09-08'
       source: https://docs.sglang.io/cookbook/autoregressive/Qwen/Qwen3.8-Flash-Next
   - catalog: qwen/qwen3.8-27b
     relationship: self_hosted
@@ -2810,7 +2810,7 @@ providers:
     lifecycle: active
     verification:
       status: claimed
-      verified_at: '2026-09-09'
+      verified_at: '2026-09-08'
       source: https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731
   - catalog: deepseek/deepseek-v4-pro
     relationship: self_hosted
@@ -3044,7 +3044,7 @@ providers:
     lifecycle: experimental
     verification:
       status: claimed
-      verified_at: '2026-09-09'
+      verified_at: '2026-09-08'
       source: https://recipes.vllm.ai/Qwen/Qwen3.8-Flash-Next
   - catalog: qwen/qwen3.8-2.4t-a95b
     relationship: self_hosted
@@ -4913,7 +4913,7 @@ models:
   verification:
     authority: DeepSeek
     status: claimed
-    verified_at: '2026-09-09'
+    verified_at: '2026-09-08'
     source: https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731
   tags:
   - efficient
@@ -6563,7 +6563,7 @@ models:
   verification:
     authority: Qwen Team
     status: claimed
-    verified_at: '2026-09-09'
+    verified_at: '2026-09-08'
     source: https://huggingface.co/Qwen/Qwen3.8-Flash-Next
   tags:
   - open_weights
@@ -15384,7 +15384,7 @@ evaluations:
   metrics:
     resolved: 0.827
   status: available
-  observed_at: '2026-09-09'
+  observed_at: '2026-09-08'
   evidence:
     provenance: vendor_claimed
     verification: claimed
@@ -28856,7 +28856,7 @@ evaluations:
   metrics:
     resolved: 0.587
   status: available
-  observed_at: '2026-09-09'
+  observed_at: '2026-09-08'
   evidence:
     provenance: vendor_claimed
     verification: claimed
@@ -28880,7 +28880,7 @@ evaluations:
   metrics:
     resolved: 0.625
   status: available
-  observed_at: '2026-09-09'
+  observed_at: '2026-09-08'
   evidence:
     provenance: vendor_claimed
     verification: claimed
@@ -28900,7 +28900,7 @@ evaluations:
     pass_rate: 0.243
     score: 0.512
   status: available
-  observed_at: '2026-09-09'
+  observed_at: '2026-09-08'
   evidence:
     provenance: vendor_claimed
     verification: claimed
@@ -28919,7 +28919,7 @@ evaluations:
   metrics:
     accuracy: 0.813
   status: available
-  observed_at: '2026-09-09'
+  observed_at: '2026-09-08'
   evidence:
     provenance: vendor_claimed
     verification: claimed
@@ -28938,7 +28938,7 @@ evaluations:
   metrics:
     accuracy: 0.917
   status: available
-  observed_at: '2026-09-09'
+  observed_at: '2026-09-08'
   evidence:
     provenance: vendor_claimed
     verification: claimed
@@ -28958,7 +28958,7 @@ evaluations:
   metrics:
     accuracy: 0.359
   status: available
-  observed_at: '2026-09-09'
+  observed_at: '2026-09-08'
   evidence:
     provenance: vendor_claimed
     verification: claimed
@@ -28977,7 +28977,7 @@ evaluations:
   metrics:
     pass_at_1: 0.919
   status: available
-  observed_at: '2026-09-09'
+  observed_at: '2026-09-08'
   evidence:
     provenance: vendor_claimed
     verification: claimed
@@ -28997,7 +28997,7 @@ evaluations:
   metrics:
     score: 0.846
   status: available
-  observed_at: '2026-09-09'
+  observed_at: '2026-09-08'
   evidence:
     provenance: vendor_claimed
     verification: claimed
@@ -29017,7 +29017,7 @@ evaluations:
   metrics:
     score: 0.906
   status: available
-  observed_at: '2026-09-09'
+  observed_at: '2026-09-08'
   evidence:
     provenance: vendor_claimed
     verification: claimed

--- a/config/recipes/built-in/latest/catalog.yaml
+++ b/config/recipes/built-in/latest/catalog.yaml
@@ -2368,6 +2368,18 @@ providers:
   conformance:
     status: unverified
   models:
+  - catalog: qwen/qwen3.8-flash-next
+    relationship: self_hosted
+    id: Qwen/Qwen3.8-Flash-Next
+    protocols:
+    - openai/chat-completions@1
+    - openai/responses@1
+    reasoning_transport: top_level_effort_template_switch
+    lifecycle: experimental
+    verification:
+      status: claimed
+      verified_at: '2026-09-09'
+      source: https://docs.sglang.io/cookbook/autoregressive/Qwen/Qwen3.8-Flash-Next
   - catalog: qwen/qwen3.8-27b
     relationship: self_hosted
     id: Qwen/Qwen3.8-27B
@@ -2790,7 +2802,7 @@ providers:
       source: https://huggingface.co/deepseek-ai/DeepSeek-V3.2
   - catalog: deepseek/deepseek-v4-flash
     relationship: self_hosted
-    id: deepseek-ai/DeepSeek-V4-Flash
+    id: deepseek-ai/DeepSeek-V4-Flash-0731
     protocols:
     - openai/chat-completions@1
     - openai/responses@1
@@ -2798,8 +2810,8 @@ providers:
     lifecycle: active
     verification:
       status: claimed
-      verified_at: '2026-09-05'
-      source: https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash
+      verified_at: '2026-09-09'
+      source: https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731
   - catalog: deepseek/deepseek-v4-pro
     relationship: self_hosted
     id: deepseek-ai/DeepSeek-V4-Pro
@@ -3022,6 +3034,18 @@ providers:
       status: claimed
       verified_at: '2026-09-05'
       source: https://huggingface.co/Qwen/Qwen3.8-27B
+  - catalog: qwen/qwen3.8-flash-next
+    relationship: self_hosted
+    id: Qwen/Qwen3.8-Flash-Next
+    protocols:
+    - openai/chat-completions@1
+    - openai/responses@1
+    reasoning_transport: top_level_effort_template_switch
+    lifecycle: experimental
+    verification:
+      status: claimed
+      verified_at: '2026-09-09'
+      source: https://recipes.vllm.ai/Qwen/Qwen3.8-Flash-Next
   - catalog: qwen/qwen3.8-2.4t-a95b
     relationship: self_hosted
     id: Qwen/Qwen3.8-2.4T-A95B
@@ -4865,7 +4889,7 @@ models:
     monochrome: false
   distribution:
     type: open_weights
-    source: https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash
+    source: https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731
     license: MIT
   family: deepseek-v4
   parameter_size: 284B (13B active)
@@ -4889,8 +4913,8 @@ models:
   verification:
     authority: DeepSeek
     status: claimed
-    verified_at: '2026-09-05'
-    source: https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash
+    verified_at: '2026-09-09'
+    source: https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731
   tags:
   - efficient
   - open_weights
@@ -6503,6 +6527,51 @@ models:
   - frontier
   - agentic
   released_at: '2026-08-10'
+- id: qwen/qwen3.8-flash-next
+  display_name: Qwen3.8 Flash Next
+  description: Experimental open-weight Qwen4 architecture preview for efficient multimodal reasoning and agents.
+  kind: physical
+  publisher: Alibaba / Qwen
+  presentation:
+    logo: package:qwen
+    monogram: Q
+    monochrome: false
+  distribution:
+    type: open_weights
+    source: https://huggingface.co/Qwen/Qwen3.8-Flash-Next
+    license: Qwen Community License 1.0
+  family: qwen3.8
+  parameter_size: 176B + 4B MTP (6B active)
+  lifecycle: experimental
+  limits:
+    context_window_size: 262144
+  capabilities:
+  - chat
+  - reasoning
+  - tools
+  - structured_output
+  - vision
+  - long_context
+  modalities:
+    input:
+    - text
+    - image
+    - video
+    output:
+    - text
+  reasoning_family: qwen3.8
+  verification:
+    authority: Qwen Team
+    status: claimed
+    verified_at: '2026-09-09'
+    source: https://huggingface.co/Qwen/Qwen3.8-Flash-Next
+  tags:
+  - open_weights
+  - multimodal
+  - moe
+  - agentic
+  - long_context
+  released_at: '2026-08-24'
 - id: qwen/qwen3.8-27b
   display_name: Qwen3.8 27B
   description: Dense open-weight Qwen3.8 multimodal model for reasoning and agentic work.
@@ -8179,6 +8248,12 @@ benchmarks:
     description: Vendor-published full pass rate using a documented agent harness.
   metrics:
   - id: pass_rate
+    unit: proportion
+    direction: higher_is_better
+    range:
+    - 0
+    - 1
+  - id: score
     unit: proportion
     direction: higher_is_better
     range:
@@ -15301,18 +15376,19 @@ evaluations:
   benchmark_profile: published-agent
   reasoning_effort: max
   subject:
-    variant: deepseek-v4-flash
+    variant: DeepSeek-V4-Flash-0731
+    model_revision: DeepSeek-V4-Flash-0731
     reasoning_effort: max
     terminal_harness: DeepSeek API evaluation harness
     source_kind: official_release_evaluation
   metrics:
     resolved: 0.827
   status: available
-  observed_at: '2026-09-06'
+  observed_at: '2026-09-09'
   evidence:
     provenance: vendor_claimed
     verification: claimed
-    source: https://api-docs.deepseek.com/updates/
+    source: https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731
     redistributable: true
 - id: independent/deepseek-v4-flash-terminalbench-v2-1@1.0.0
   model: deepseek/deepseek-v4-flash
@@ -28761,6 +28837,191 @@ evaluations:
     provenance: third_party
     verification: imported
     source: https://artificialanalysis.ai/evaluations/tau3-banking
+    redistributable: true
+- id: qwen/qwen3.8-flash-next-model-card-deep-swe@1.0.0
+  model: qwen/qwen3.8-flash-next
+  benchmark: datacurve/deep-swe@1.1.0
+  benchmark_profile: published-agent
+  reasoning_effort: unspecified
+  subject:
+    variant: Qwen3.8-Flash-Next
+    model_revision: de4b8e4d43b917e7706784d8bb445c9af86a3540
+    reasoning_effort: unspecified
+    source_kind: official_model_card
+    swe_harness: mini-SWE-agent
+    sampling_temperature: 1.0
+    sampling_top_p: 0.95
+    context_window_size: 262144
+    reported_selection: highest_across_claude_code_and_mini_swe_agent
+  metrics:
+    resolved: 0.587
+  status: available
+  observed_at: '2026-09-09'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/Qwen/Qwen3.8-Flash-Next
+    redistributable: true
+- id: qwen/qwen3.8-flash-next-model-card-swe-bench-pro@1.0.0
+  model: qwen/qwen3.8-flash-next
+  benchmark: swe-bench/pro@1.0.0
+  benchmark_profile: published-agent
+  reasoning_effort: unspecified
+  subject:
+    variant: Qwen3.8-Flash-Next
+    model_revision: de4b8e4d43b917e7706784d8bb445c9af86a3540
+    reasoning_effort: unspecified
+    source_kind: official_model_card
+    swe_harness: Claude Code
+    dataset_variant: refined
+    sampling_temperature: 1.0
+    sampling_top_p: 0.95
+    context_window_size: 262144
+  metrics:
+    resolved: 0.625
+  status: available
+  observed_at: '2026-09-09'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/Qwen/Qwen3.8-Flash-Next
+    redistributable: true
+- id: qwen/qwen3.8-flash-next-model-card-agents-last-exam@1.0.0
+  model: qwen/qwen3.8-flash-next
+  benchmark: berkeley-rdi/agents-last-exam@1.0.0
+  benchmark_profile: published-agent
+  reasoning_effort: unspecified
+  subject:
+    variant: Qwen3.8-Flash-Next
+    model_revision: de4b8e4d43b917e7706784d8bb445c9af86a3540
+    reasoning_effort: unspecified
+    source_kind: official_model_card
+  metrics:
+    pass_rate: 0.243
+    score: 0.512
+  status: available
+  observed_at: '2026-09-09'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/Qwen/Qwen3.8-Flash-Next
+    redistributable: true
+- id: qwen/qwen3.8-flash-next-model-card-ifbench@1.0.0
+  model: qwen/qwen3.8-flash-next
+  benchmark: allenai/ifbench@1.0.0
+  benchmark_profile: prompt-loose
+  reasoning_effort: unspecified
+  subject:
+    variant: Qwen3.8-Flash-Next
+    model_revision: de4b8e4d43b917e7706784d8bb445c9af86a3540
+    reasoning_effort: unspecified
+    source_kind: official_model_card
+  metrics:
+    accuracy: 0.813
+  status: available
+  observed_at: '2026-09-09'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/Qwen/Qwen3.8-Flash-Next
+    redistributable: true
+- id: qwen/qwen3.8-flash-next-model-card-gpqa-diamond@1.0.0
+  model: qwen/qwen3.8-flash-next
+  benchmark: idavidrein/gpqa-diamond@1.0.0
+  benchmark_profile: published-standard
+  reasoning_effort: unspecified
+  subject:
+    variant: Qwen3.8-Flash-Next
+    model_revision: de4b8e4d43b917e7706784d8bb445c9af86a3540
+    reasoning_effort: unspecified
+    source_kind: official_model_card
+  metrics:
+    accuracy: 0.917
+  status: available
+  observed_at: '2026-09-09'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/Qwen/Qwen3.8-Flash-Next
+    redistributable: true
+- id: qwen/qwen3.8-flash-next-model-card-humanitys-last-exam@1.0.0
+  model: qwen/qwen3.8-flash-next
+  benchmark: cais/humanitys-last-exam@1.0.0
+  benchmark_profile: published-unspecified
+  reasoning_effort: unspecified
+  subject:
+    variant: Qwen3.8-Flash-Next
+    model_revision: de4b8e4d43b917e7706784d8bb445c9af86a3540
+    reasoning_effort: unspecified
+    source_kind: official_model_card
+    hle_judge: GPT-4o
+  metrics:
+    accuracy: 0.359
+  status: available
+  observed_at: '2026-09-09'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/Qwen/Qwen3.8-Flash-Next
+    redistributable: true
+- id: qwen/qwen3.8-flash-next-model-card-livecodebench-v6@1.0.0
+  model: qwen/qwen3.8-flash-next
+  benchmark: livecodebench/livecodebench@6.0.0
+  benchmark_profile: code-generation-pass-at-1
+  reasoning_effort: unspecified
+  subject:
+    variant: Qwen3.8-Flash-Next
+    model_revision: de4b8e4d43b917e7706784d8bb445c9af86a3540
+    reasoning_effort: unspecified
+    source_kind: official_model_card
+  metrics:
+    pass_at_1: 0.919
+  status: available
+  observed_at: '2026-09-09'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/Qwen/Qwen3.8-Flash-Next
+    redistributable: true
+- id: qwen/qwen3.8-flash-next-model-card-charxiv-no-tools@1.0.0
+  model: qwen/qwen3.8-flash-next
+  benchmark: princeton-nlp/charxiv@1.0.0
+  benchmark_profile: no-tools
+  reasoning_effort: unspecified
+  subject:
+    variant: Qwen3.8-Flash-Next
+    model_revision: de4b8e4d43b917e7706784d8bb445c9af86a3540
+    reasoning_effort: unspecified
+    source_kind: official_model_card
+    tool_policy: without_code_interpreter
+  metrics:
+    score: 0.846
+  status: available
+  observed_at: '2026-09-09'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/Qwen/Qwen3.8-Flash-Next
+    redistributable: true
+- id: qwen/qwen3.8-flash-next-model-card-charxiv-with-tools@1.0.0
+  model: qwen/qwen3.8-flash-next
+  benchmark: princeton-nlp/charxiv@1.0.0
+  benchmark_profile: with-tools
+  reasoning_effort: unspecified
+  subject:
+    variant: Qwen3.8-Flash-Next
+    model_revision: de4b8e4d43b917e7706784d8bb445c9af86a3540
+    reasoning_effort: unspecified
+    source_kind: official_model_card
+    tool_policy: with_code_interpreter
+  metrics:
+    score: 0.906
+  status: available
+  observed_at: '2026-09-09'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/Qwen/Qwen3.8-Flash-Next
     redistributable: true
 - id: independent/qwen3-8-27b-low-critpt@1.0.0
   model: qwen/qwen3.8-27b

--- a/src/semantic-router/pkg/catalog/compiler_test.go
+++ b/src/semantic-router/pkg/catalog/compiler_test.go
@@ -164,6 +164,17 @@ func TestDeepSeekV4HasEffortIsolatedEvaluationAndProviderBindings(t *testing.T) 
 	if !ok || !containsString(provider.Protocols, "openai/responses@1") {
 		t.Fatalf("deepseek provider is missing Responses support: %+v", provider)
 	}
+	card, ok := registry.Model("deepseek/deepseek-v4-flash")
+	if !ok || card.Revision != "DeepSeek-V4-Flash-0731" ||
+		card.Distribution.Source != "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731" {
+		t.Fatalf("deepseek flash card does not identify the 0731 checkpoint: %+v", card)
+	}
+	vllm, ok := registry.Provider("vllm")
+	binding, bound := providerBindingForModel(vllm, "deepseek/deepseek-v4-flash")
+	if !ok || !bound || binding.ID != "deepseek-ai/DeepSeek-V4-Flash-0731" ||
+		binding.Verification.Source != "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731" {
+		t.Fatalf("vLLM DeepSeek Flash binding does not use the 0731 checkpoint: %+v", binding)
+	}
 }
 
 func assertDeepSeekModelSupport(t *testing.T, registry *Registry, modelID string) {
@@ -185,12 +196,17 @@ func assertDeepSeekModelSupport(t *testing.T, registry *Registry, modelID string
 }
 
 func providerBindsModel(provider ProviderDefinition, modelID string) bool {
+	_, ok := providerBindingForModel(provider, modelID)
+	return ok
+}
+
+func providerBindingForModel(provider ProviderDefinition, modelID string) (CatalogModelBinding, bool) {
 	for _, binding := range provider.Models {
 		if binding.Catalog == modelID {
-			return true
+			return binding, true
 		}
 	}
-	return false
+	return CatalogModelBinding{}, false
 }
 
 func TestBuiltInProviderBindingsDeclareRelationships(t *testing.T) {

--- a/src/semantic-router/pkg/catalog/zz_generated_catalog.go
+++ b/src/semantic-router/pkg/catalog/zz_generated_catalog.go
@@ -2,7 +2,7 @@
 
 package catalog
 
-const builtInCatalogDigest = "sha256:023210b43682c690f9285426614e45140e3064cbee521d9bf5650a654edd3e16"
+const builtInCatalogDigest = "sha256:d49640f2c620de7b653073124d643240431ddc0874795af670dd2f2303d5e0c5"
 
 const builtInCatalogJSON = `{
   "benchmarks": [
@@ -452,6 +452,15 @@ const builtInCatalogJSON = `{
         {
           "direction": "higher_is_better",
           "id": "pass_rate",
+          "range": [
+            0,
+            1
+          ],
+          "unit": "proportion"
+        },
+        {
+          "direction": "higher_is_better",
+          "id": "score",
           "range": [
             0,
             1
@@ -9744,7 +9753,7 @@ const builtInCatalogJSON = `{
       "evidence": {
         "provenance": "vendor_claimed",
         "redistributable": true,
-        "source": "https://api-docs.deepseek.com/updates/",
+        "source": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731",
         "verification": "claimed"
       },
       "id": "deepseek/deepseek-v4-flash-release-eval-terminal-bench@1.0.0",
@@ -9752,14 +9761,15 @@ const builtInCatalogJSON = `{
         "resolved": 0.827
       },
       "model": "deepseek/deepseek-v4-flash",
-      "observed_at": "2026-09-06",
+      "observed_at": "2026-09-09",
       "reasoning_effort": "max",
       "status": "available",
       "subject": {
+        "model_revision": "DeepSeek-V4-Flash-0731",
         "reasoning_effort": "max",
         "source_kind": "official_release_evaluation",
         "terminal_harness": "DeepSeek API evaluation harness",
-        "variant": "deepseek-v4-flash"
+        "variant": "DeepSeek-V4-Flash-0731"
       }
     },
     {
@@ -26886,6 +26896,236 @@ const builtInCatalogJSON = `{
       }
     },
     {
+      "benchmark": "datacurve/deep-swe@1.1.0",
+      "benchmark_profile": "published-agent",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/Qwen/Qwen3.8-Flash-Next",
+        "verification": "claimed"
+      },
+      "id": "qwen/qwen3.8-flash-next-model-card-deep-swe@1.0.0",
+      "metrics": {
+        "resolved": 0.587
+      },
+      "model": "qwen/qwen3.8-flash-next",
+      "observed_at": "2026-09-09",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "context_window_size": 262144,
+        "model_revision": "de4b8e4d43b917e7706784d8bb445c9af86a3540",
+        "reasoning_effort": "unspecified",
+        "reported_selection": "highest_across_claude_code_and_mini_swe_agent",
+        "sampling_temperature": 1.0,
+        "sampling_top_p": 0.95,
+        "source_kind": "official_model_card",
+        "swe_harness": "mini-SWE-agent",
+        "variant": "Qwen3.8-Flash-Next"
+      }
+    },
+    {
+      "benchmark": "swe-bench/pro@1.0.0",
+      "benchmark_profile": "published-agent",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/Qwen/Qwen3.8-Flash-Next",
+        "verification": "claimed"
+      },
+      "id": "qwen/qwen3.8-flash-next-model-card-swe-bench-pro@1.0.0",
+      "metrics": {
+        "resolved": 0.625
+      },
+      "model": "qwen/qwen3.8-flash-next",
+      "observed_at": "2026-09-09",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "context_window_size": 262144,
+        "dataset_variant": "refined",
+        "model_revision": "de4b8e4d43b917e7706784d8bb445c9af86a3540",
+        "reasoning_effort": "unspecified",
+        "sampling_temperature": 1.0,
+        "sampling_top_p": 0.95,
+        "source_kind": "official_model_card",
+        "swe_harness": "Claude Code",
+        "variant": "Qwen3.8-Flash-Next"
+      }
+    },
+    {
+      "benchmark": "berkeley-rdi/agents-last-exam@1.0.0",
+      "benchmark_profile": "published-agent",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/Qwen/Qwen3.8-Flash-Next",
+        "verification": "claimed"
+      },
+      "id": "qwen/qwen3.8-flash-next-model-card-agents-last-exam@1.0.0",
+      "metrics": {
+        "pass_rate": 0.243,
+        "score": 0.512
+      },
+      "model": "qwen/qwen3.8-flash-next",
+      "observed_at": "2026-09-09",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "model_revision": "de4b8e4d43b917e7706784d8bb445c9af86a3540",
+        "reasoning_effort": "unspecified",
+        "source_kind": "official_model_card",
+        "variant": "Qwen3.8-Flash-Next"
+      }
+    },
+    {
+      "benchmark": "allenai/ifbench@1.0.0",
+      "benchmark_profile": "prompt-loose",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/Qwen/Qwen3.8-Flash-Next",
+        "verification": "claimed"
+      },
+      "id": "qwen/qwen3.8-flash-next-model-card-ifbench@1.0.0",
+      "metrics": {
+        "accuracy": 0.813
+      },
+      "model": "qwen/qwen3.8-flash-next",
+      "observed_at": "2026-09-09",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "model_revision": "de4b8e4d43b917e7706784d8bb445c9af86a3540",
+        "reasoning_effort": "unspecified",
+        "source_kind": "official_model_card",
+        "variant": "Qwen3.8-Flash-Next"
+      }
+    },
+    {
+      "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+      "benchmark_profile": "published-standard",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/Qwen/Qwen3.8-Flash-Next",
+        "verification": "claimed"
+      },
+      "id": "qwen/qwen3.8-flash-next-model-card-gpqa-diamond@1.0.0",
+      "metrics": {
+        "accuracy": 0.917
+      },
+      "model": "qwen/qwen3.8-flash-next",
+      "observed_at": "2026-09-09",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "model_revision": "de4b8e4d43b917e7706784d8bb445c9af86a3540",
+        "reasoning_effort": "unspecified",
+        "source_kind": "official_model_card",
+        "variant": "Qwen3.8-Flash-Next"
+      }
+    },
+    {
+      "benchmark": "cais/humanitys-last-exam@1.0.0",
+      "benchmark_profile": "published-unspecified",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/Qwen/Qwen3.8-Flash-Next",
+        "verification": "claimed"
+      },
+      "id": "qwen/qwen3.8-flash-next-model-card-humanitys-last-exam@1.0.0",
+      "metrics": {
+        "accuracy": 0.359
+      },
+      "model": "qwen/qwen3.8-flash-next",
+      "observed_at": "2026-09-09",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "hle_judge": "GPT-4o",
+        "model_revision": "de4b8e4d43b917e7706784d8bb445c9af86a3540",
+        "reasoning_effort": "unspecified",
+        "source_kind": "official_model_card",
+        "variant": "Qwen3.8-Flash-Next"
+      }
+    },
+    {
+      "benchmark": "livecodebench/livecodebench@6.0.0",
+      "benchmark_profile": "code-generation-pass-at-1",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/Qwen/Qwen3.8-Flash-Next",
+        "verification": "claimed"
+      },
+      "id": "qwen/qwen3.8-flash-next-model-card-livecodebench-v6@1.0.0",
+      "metrics": {
+        "pass_at_1": 0.919
+      },
+      "model": "qwen/qwen3.8-flash-next",
+      "observed_at": "2026-09-09",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "model_revision": "de4b8e4d43b917e7706784d8bb445c9af86a3540",
+        "reasoning_effort": "unspecified",
+        "source_kind": "official_model_card",
+        "variant": "Qwen3.8-Flash-Next"
+      }
+    },
+    {
+      "benchmark": "princeton-nlp/charxiv@1.0.0",
+      "benchmark_profile": "no-tools",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/Qwen/Qwen3.8-Flash-Next",
+        "verification": "claimed"
+      },
+      "id": "qwen/qwen3.8-flash-next-model-card-charxiv-no-tools@1.0.0",
+      "metrics": {
+        "score": 0.846
+      },
+      "model": "qwen/qwen3.8-flash-next",
+      "observed_at": "2026-09-09",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "model_revision": "de4b8e4d43b917e7706784d8bb445c9af86a3540",
+        "reasoning_effort": "unspecified",
+        "source_kind": "official_model_card",
+        "tool_policy": "without_code_interpreter",
+        "variant": "Qwen3.8-Flash-Next"
+      }
+    },
+    {
+      "benchmark": "princeton-nlp/charxiv@1.0.0",
+      "benchmark_profile": "with-tools",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/Qwen/Qwen3.8-Flash-Next",
+        "verification": "claimed"
+      },
+      "id": "qwen/qwen3.8-flash-next-model-card-charxiv-with-tools@1.0.0",
+      "metrics": {
+        "score": 0.906
+      },
+      "model": "qwen/qwen3.8-flash-next",
+      "observed_at": "2026-09-09",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "model_revision": "de4b8e4d43b917e7706784d8bb445c9af86a3540",
+        "reasoning_effort": "unspecified",
+        "source_kind": "official_model_card",
+        "tool_policy": "with_code_interpreter",
+        "variant": "Qwen3.8-Flash-Next"
+      }
+    },
+    {
       "benchmark": "artificial-analysis/critpt@1.0.0",
       "benchmark_profile": "independent-standard",
       "evidence": {
@@ -37150,7 +37390,7 @@ const builtInCatalogJSON = `{
       "display_name": "DeepSeek V4 Flash",
       "distribution": {
         "license": "MIT",
-        "source": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash",
+        "source": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731",
         "type": "open_weights"
       },
       "family": "deepseek-v4",
@@ -37187,9 +37427,9 @@ const builtInCatalogJSON = `{
       ],
       "verification": {
         "authority": "DeepSeek",
-        "source": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash",
+        "source": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731",
         "status": "claimed",
-        "verified_at": "2026-09-05"
+        "verified_at": "2026-09-09"
       }
     },
     {
@@ -39213,6 +39453,62 @@ const builtInCatalogJSON = `{
         "source": "https://www.alibabacloud.com/help/en/model-studio/text-generation-model",
         "status": "claimed",
         "verified_at": "2026-09-05"
+      }
+    },
+    {
+      "capabilities": [
+        "chat",
+        "reasoning",
+        "tools",
+        "structured_output",
+        "vision",
+        "long_context"
+      ],
+      "description": "Experimental open-weight Qwen4 architecture preview for efficient multimodal reasoning and agents.",
+      "display_name": "Qwen3.8 Flash Next",
+      "distribution": {
+        "license": "Qwen Community License 1.0",
+        "source": "https://huggingface.co/Qwen/Qwen3.8-Flash-Next",
+        "type": "open_weights"
+      },
+      "family": "qwen3.8",
+      "id": "qwen/qwen3.8-flash-next",
+      "kind": "physical",
+      "lifecycle": "experimental",
+      "limits": {
+        "context_window_size": 262144
+      },
+      "modalities": {
+        "input": [
+          "text",
+          "image",
+          "video"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "parameter_size": "176B + 4B MTP (6B active)",
+      "presentation": {
+        "logo": "package:qwen",
+        "monochrome": false,
+        "monogram": "Q"
+      },
+      "publisher": "Alibaba / Qwen",
+      "reasoning_family": "qwen3.8",
+      "released_at": "2026-08-24",
+      "tags": [
+        "open_weights",
+        "multimodal",
+        "moe",
+        "agentic",
+        "long_context"
+      ],
+      "verification": {
+        "authority": "Qwen Team",
+        "source": "https://huggingface.co/Qwen/Qwen3.8-Flash-Next",
+        "status": "claimed",
+        "verified_at": "2026-09-09"
       }
     },
     {
@@ -44096,6 +44392,22 @@ const builtInCatalogJSON = `{
       "id": "sglang",
       "models": [
         {
+          "catalog": "qwen/qwen3.8-flash-next",
+          "id": "Qwen/Qwen3.8-Flash-Next",
+          "lifecycle": "experimental",
+          "protocols": [
+            "openai/chat-completions@1",
+            "openai/responses@1"
+          ],
+          "reasoning_transport": "top_level_effort_template_switch",
+          "relationship": "self_hosted",
+          "verification": {
+            "source": "https://docs.sglang.io/cookbook/autoregressive/Qwen/Qwen3.8-Flash-Next",
+            "status": "claimed",
+            "verified_at": "2026-09-09"
+          }
+        },
+        {
           "catalog": "qwen/qwen3.8-27b",
           "id": "Qwen/Qwen3.8-27B",
           "lifecycle": "experimental",
@@ -44662,7 +44974,7 @@ const builtInCatalogJSON = `{
         },
         {
           "catalog": "deepseek/deepseek-v4-flash",
-          "id": "deepseek-ai/DeepSeek-V4-Flash",
+          "id": "deepseek-ai/DeepSeek-V4-Flash-0731",
           "lifecycle": "active",
           "protocols": [
             "openai/chat-completions@1",
@@ -44671,9 +44983,9 @@ const builtInCatalogJSON = `{
           "reasoning_transport": "top_level_effort",
           "relationship": "self_hosted",
           "verification": {
-            "source": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash",
+            "source": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731",
             "status": "claimed",
-            "verified_at": "2026-09-05"
+            "verified_at": "2026-09-09"
           }
         },
         {
@@ -44976,6 +45288,22 @@ const builtInCatalogJSON = `{
             "source": "https://huggingface.co/Qwen/Qwen3.8-27B",
             "status": "claimed",
             "verified_at": "2026-09-05"
+          }
+        },
+        {
+          "catalog": "qwen/qwen3.8-flash-next",
+          "id": "Qwen/Qwen3.8-Flash-Next",
+          "lifecycle": "experimental",
+          "protocols": [
+            "openai/chat-completions@1",
+            "openai/responses@1"
+          ],
+          "reasoning_transport": "top_level_effort_template_switch",
+          "relationship": "self_hosted",
+          "verification": {
+            "source": "https://recipes.vllm.ai/Qwen/Qwen3.8-Flash-Next",
+            "status": "claimed",
+            "verified_at": "2026-09-09"
           }
         },
         {

--- a/src/semantic-router/pkg/catalog/zz_generated_catalog.go
+++ b/src/semantic-router/pkg/catalog/zz_generated_catalog.go
@@ -2,7 +2,7 @@
 
 package catalog
 
-const builtInCatalogDigest = "sha256:d49640f2c620de7b653073124d643240431ddc0874795af670dd2f2303d5e0c5"
+const builtInCatalogDigest = "sha256:d471331e99da2407e6277debf0f6e5e817993d16e3315388eb8ef0315531dc82"
 
 const builtInCatalogJSON = `{
   "benchmarks": [
@@ -9761,7 +9761,7 @@ const builtInCatalogJSON = `{
         "resolved": 0.827
       },
       "model": "deepseek/deepseek-v4-flash",
-      "observed_at": "2026-09-09",
+      "observed_at": "2026-09-08",
       "reasoning_effort": "max",
       "status": "available",
       "subject": {
@@ -26909,7 +26909,7 @@ const builtInCatalogJSON = `{
         "resolved": 0.587
       },
       "model": "qwen/qwen3.8-flash-next",
-      "observed_at": "2026-09-09",
+      "observed_at": "2026-09-08",
       "reasoning_effort": "unspecified",
       "status": "available",
       "subject": {
@@ -26938,7 +26938,7 @@ const builtInCatalogJSON = `{
         "resolved": 0.625
       },
       "model": "qwen/qwen3.8-flash-next",
-      "observed_at": "2026-09-09",
+      "observed_at": "2026-09-08",
       "reasoning_effort": "unspecified",
       "status": "available",
       "subject": {
@@ -26968,7 +26968,7 @@ const builtInCatalogJSON = `{
         "score": 0.512
       },
       "model": "qwen/qwen3.8-flash-next",
-      "observed_at": "2026-09-09",
+      "observed_at": "2026-09-08",
       "reasoning_effort": "unspecified",
       "status": "available",
       "subject": {
@@ -26992,7 +26992,7 @@ const builtInCatalogJSON = `{
         "accuracy": 0.813
       },
       "model": "qwen/qwen3.8-flash-next",
-      "observed_at": "2026-09-09",
+      "observed_at": "2026-09-08",
       "reasoning_effort": "unspecified",
       "status": "available",
       "subject": {
@@ -27016,7 +27016,7 @@ const builtInCatalogJSON = `{
         "accuracy": 0.917
       },
       "model": "qwen/qwen3.8-flash-next",
-      "observed_at": "2026-09-09",
+      "observed_at": "2026-09-08",
       "reasoning_effort": "unspecified",
       "status": "available",
       "subject": {
@@ -27040,7 +27040,7 @@ const builtInCatalogJSON = `{
         "accuracy": 0.359
       },
       "model": "qwen/qwen3.8-flash-next",
-      "observed_at": "2026-09-09",
+      "observed_at": "2026-09-08",
       "reasoning_effort": "unspecified",
       "status": "available",
       "subject": {
@@ -27065,7 +27065,7 @@ const builtInCatalogJSON = `{
         "pass_at_1": 0.919
       },
       "model": "qwen/qwen3.8-flash-next",
-      "observed_at": "2026-09-09",
+      "observed_at": "2026-09-08",
       "reasoning_effort": "unspecified",
       "status": "available",
       "subject": {
@@ -27089,7 +27089,7 @@ const builtInCatalogJSON = `{
         "score": 0.846
       },
       "model": "qwen/qwen3.8-flash-next",
-      "observed_at": "2026-09-09",
+      "observed_at": "2026-09-08",
       "reasoning_effort": "unspecified",
       "status": "available",
       "subject": {
@@ -27114,7 +27114,7 @@ const builtInCatalogJSON = `{
         "score": 0.906
       },
       "model": "qwen/qwen3.8-flash-next",
-      "observed_at": "2026-09-09",
+      "observed_at": "2026-09-08",
       "reasoning_effort": "unspecified",
       "status": "available",
       "subject": {
@@ -37429,7 +37429,7 @@ const builtInCatalogJSON = `{
         "authority": "DeepSeek",
         "source": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731",
         "status": "claimed",
-        "verified_at": "2026-09-09"
+        "verified_at": "2026-09-08"
       }
     },
     {
@@ -39508,7 +39508,7 @@ const builtInCatalogJSON = `{
         "authority": "Qwen Team",
         "source": "https://huggingface.co/Qwen/Qwen3.8-Flash-Next",
         "status": "claimed",
-        "verified_at": "2026-09-09"
+        "verified_at": "2026-09-08"
       }
     },
     {
@@ -44404,7 +44404,7 @@ const builtInCatalogJSON = `{
           "verification": {
             "source": "https://docs.sglang.io/cookbook/autoregressive/Qwen/Qwen3.8-Flash-Next",
             "status": "claimed",
-            "verified_at": "2026-09-09"
+            "verified_at": "2026-09-08"
           }
         },
         {
@@ -44985,7 +44985,7 @@ const builtInCatalogJSON = `{
           "verification": {
             "source": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731",
             "status": "claimed",
-            "verified_at": "2026-09-09"
+            "verified_at": "2026-09-08"
           }
         },
         {
@@ -45303,7 +45303,7 @@ const builtInCatalogJSON = `{
           "verification": {
             "source": "https://recipes.vllm.ai/Qwen/Qwen3.8-Flash-Next",
             "status": "claimed",
-            "verified_at": "2026-09-09"
+            "verified_at": "2026-09-08"
           }
         },
         {

--- a/src/semantic-router/pkg/extproc/provider_request_catalog_contract_test.go
+++ b/src/semantic-router/pkg/extproc/provider_request_catalog_contract_test.go
@@ -103,7 +103,7 @@ func TestBuiltInCatalogReasoningWireContracts(t *testing.T) {
 func TestBuiltInCatalogLocalRuntimeReasoningWireContracts(t *testing.T) {
 	tests := []catalogReasoningWireCase{
 		{
-			name: "vLLM Qwen top-level effort and template switch", catalog: "qwen/qwen3.8-27b", provider: "vllm",
+			name: "vLLM Qwen Flash Next top-level effort and template switch", catalog: "qwen/qwen3.8-flash-next", provider: "vllm",
 			enabled: true, mode: config.ReasoningModeEnabled, effort: "xhigh",
 			wantTransport: modelcatalog.ReasoningTransportEffortTemplateSwitch,
 			wantControls: map[string]interface{}{
@@ -112,7 +112,7 @@ func TestBuiltInCatalogLocalRuntimeReasoningWireContracts(t *testing.T) {
 			},
 		},
 		{
-			name: "vLLM Qwen template switch disabled", catalog: "qwen/qwen3.8-27b", provider: "vllm",
+			name: "vLLM Qwen Flash Next template switch disabled", catalog: "qwen/qwen3.8-flash-next", provider: "vllm",
 			enabled: false, mode: config.ReasoningModeDisabled,
 			wantTransport: modelcatalog.ReasoningTransportEffortTemplateSwitch,
 			wantControls: map[string]interface{}{"chat_template_kwargs": map[string]interface{}{
@@ -120,7 +120,7 @@ func TestBuiltInCatalogLocalRuntimeReasoningWireContracts(t *testing.T) {
 			}},
 		},
 		{
-			name: "vLLM Qwen Responses uses protocol-native reasoning object", catalog: "qwen/qwen3.8-27b", provider: "vllm",
+			name: "vLLM Qwen Flash Next Responses uses protocol-native reasoning object", catalog: "qwen/qwen3.8-flash-next", provider: "vllm",
 			apiFormat: config.APIFormatResponses, enabled: true, mode: config.ReasoningModeEnabled, effort: "medium",
 			wantTransport: modelcatalog.ReasoningTransportEffortTemplateSwitch,
 			wantControls:  map[string]interface{}{"reasoning": map[string]interface{}{"effort": "medium"}},

--- a/tools/catalog/tests/test_generate_model_catalog.py
+++ b/tools/catalog/tests/test_generate_model_catalog.py
@@ -369,6 +369,143 @@ class ModelCatalogCompilerTests(unittest.TestCase):
             ["openai/gpt-6-astra", "openai/gpt-5.6-sol", "openai/gpt-5.5"],
         )
 
+    def test_qwen_3_8_flash_next_day_zero_contract_is_complete(self) -> None:
+        manifest, resources, _ = catalog.load_and_validate()
+        models = {model["id"]: model for model in resources["models"]}
+        flash_next = models["qwen/qwen3.8-flash-next"]
+        self.assertEqual(
+            flash_next["distribution"],
+            {
+                "type": "open_weights",
+                "source": "https://huggingface.co/Qwen/Qwen3.8-Flash-Next",
+                "license": "Qwen Community License 1.0",
+            },
+        )
+        self.assertEqual(flash_next["lifecycle"], "experimental")
+        self.assertEqual(flash_next["limits"], {"context_window_size": 262_144})
+        self.assertEqual(flash_next["reasoning_family"], "qwen3.8")
+        self.assertEqual(
+            flash_next["modalities"],
+            {"input": ["text", "image", "video"], "output": ["text"]},
+        )
+        self.assertTrue(
+            {"chat", "reasoning", "tools", "structured_output", "vision"}.issubset(
+                flash_next["capabilities"]
+            )
+        )
+
+        providers = {provider["id"]: provider for provider in resources["providers"]}
+        expected_sources = {
+            "vllm": "https://recipes.vllm.ai/Qwen/Qwen3.8-Flash-Next",
+            "sglang": (
+                "https://docs.sglang.io/cookbook/autoregressive/Qwen/"
+                "Qwen3.8-Flash-Next"
+            ),
+        }
+        for provider_id, source in expected_sources.items():
+            binding = next(
+                item
+                for item in providers[provider_id]["models"]
+                if item["catalog"] == "qwen/qwen3.8-flash-next"
+            )
+            self.assertEqual(binding["id"], "Qwen/Qwen3.8-Flash-Next")
+            self.assertEqual(binding["relationship"], "self_hosted")
+            self.assertEqual(
+                binding["protocols"],
+                ["openai/chat-completions@1", "openai/responses@1"],
+            )
+            self.assertEqual(
+                binding["reasoning_transport"],
+                "top_level_effort_template_switch",
+            )
+            self.assertEqual(binding["verification"]["source"], source)
+
+        evaluations = {
+            (item["benchmark"], item["benchmark_profile"]): item
+            for item in resources["evaluations"]
+            if item["model"] == "qwen/qwen3.8-flash-next"
+        }
+        self.assertEqual(
+            {key: item["metrics"] for key, item in evaluations.items()},
+            {
+                ("datacurve/deep-swe@1.1.0", "published-agent"): {"resolved": 0.587},
+                ("swe-bench/pro@1.0.0", "published-agent"): {"resolved": 0.625},
+                ("berkeley-rdi/agents-last-exam@1.0.0", "published-agent"): {
+                    "pass_rate": 0.243,
+                    "score": 0.512,
+                },
+                ("allenai/ifbench@1.0.0", "prompt-loose"): {"accuracy": 0.813},
+                ("idavidrein/gpqa-diamond@1.0.0", "published-standard"): {
+                    "accuracy": 0.917
+                },
+                ("cais/humanitys-last-exam@1.0.0", "published-unspecified"): {
+                    "accuracy": 0.359
+                },
+                (
+                    "livecodebench/livecodebench@6.0.0",
+                    "code-generation-pass-at-1",
+                ): {"pass_at_1": 0.919},
+                ("princeton-nlp/charxiv@1.0.0", "no-tools"): {"score": 0.846},
+                ("princeton-nlp/charxiv@1.0.0", "with-tools"): {"score": 0.906},
+            },
+        )
+        self.assertTrue(
+            all(
+                item["reasoning_effort"] == "unspecified"
+                and item["subject"]["model_revision"]
+                == "de4b8e4d43b917e7706784d8bb445c9af86a3540"
+                and item["evidence"]["provenance"] == "vendor_claimed"
+                and item["evidence"]["verification"] == "claimed"
+                for item in evaluations.values()
+            )
+        )
+
+        qwen_inventory = next(
+            creator
+            for creator in manifest["inventory"]["physical"]["creators"]
+            if creator["publisher"] == "Alibaba / Qwen"
+        )
+        self.assertEqual(
+            qwen_inventory["representative_models"],
+            [
+                "qwen/qwen3.8-max",
+                "qwen/qwen3.8-flash-next",
+                "qwen/qwen3.7-max",
+            ],
+        )
+
+    def test_deepseek_v4_flash_uses_the_exact_0731_self_hosted_checkpoint(
+        self,
+    ) -> None:
+        _, resources, _ = catalog.load_and_validate()
+        models = {model["id"]: model for model in resources["models"]}
+        flash = models["deepseek/deepseek-v4-flash"]
+        exact_source = "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731"
+        self.assertEqual(flash["revision"], "DeepSeek-V4-Flash-0731")
+        self.assertEqual(flash["distribution"]["source"], exact_source)
+        self.assertEqual(flash["verification"]["source"], exact_source)
+
+        providers = {provider["id"]: provider for provider in resources["providers"]}
+        binding = next(
+            item
+            for item in providers["vllm"]["models"]
+            if item["catalog"] == "deepseek/deepseek-v4-flash"
+        )
+        self.assertEqual(binding["id"], "deepseek-ai/DeepSeek-V4-Flash-0731")
+        self.assertEqual(binding["verification"]["source"], exact_source)
+
+        release_eval = next(
+            item
+            for item in resources["evaluations"]
+            if item["id"]
+            == "deepseek/deepseek-v4-flash-release-eval-terminal-bench@1.0.0"
+        )
+        self.assertEqual(release_eval["subject"]["variant"], "DeepSeek-V4-Flash-0731")
+        self.assertEqual(
+            release_eval["subject"]["model_revision"], "DeepSeek-V4-Flash-0731"
+        )
+        self.assertEqual(release_eval["evidence"]["source"], exact_source)
+
     def test_baidu_creator_has_exact_evidence_buckets_and_real_bindings(self) -> None:
         manifest, resources, _ = catalog.load_and_validate()
         baidu_models = {
@@ -724,6 +861,7 @@ class ModelCatalogCompilerTests(unittest.TestCase):
             "mistral/mistral-medium-3.5": "mistral-none-high",
             "mistral/mistral-small-4": "mistral-none-high",
             "qwen/qwen3.8-27b": "qwen3.8",
+            "qwen/qwen3.8-flash-next": "qwen3.8",
             "qwen/qwen3.8-2.4t-a95b": "qwen3.8-always-on",
             "zai/glm-5.2": "glm-5.2",
             "anthropic/claude-fable-5": "claude-effort-always-on",
@@ -772,15 +910,16 @@ class ModelCatalogCompilerTests(unittest.TestCase):
             minimax_binding["reasoning_modes"], ["disabled", "adaptive", "enabled"]
         )
         for runtime in ("vllm", "sglang"):
-            qwen_binding = next(
-                binding
-                for binding in providers[runtime]["models"]
-                if binding["catalog"] == "qwen/qwen3.8-27b"
-            )
-            self.assertEqual(
-                qwen_binding["reasoning_transport"],
-                "top_level_effort_template_switch",
-            )
+            for model_id in ("qwen/qwen3.8-27b", "qwen/qwen3.8-flash-next"):
+                qwen_binding = next(
+                    binding
+                    for binding in providers[runtime]["models"]
+                    if binding["catalog"] == model_id
+                )
+                self.assertEqual(
+                    qwen_binding["reasoning_transport"],
+                    "top_level_effort_template_switch",
+                )
         dashscope_qwen = next(
             binding
             for binding in providers["dashscope"]["models"]

--- a/website/docs/proposals/unified-model-catalog-and-evaluation-index.md
+++ b/website/docs/proposals/unified-model-catalog-and-evaluation-index.md
@@ -48,15 +48,15 @@ and a recommended model reference is not a complete built-in model card.
 The old Dashboard therefore contained 40 provider presets, while the Router
 had seven hard-coded runtime types and the packaged catalog had no
 general-purpose physical-model registry. The implemented snapshot compiles 60
-serving providers, three protocol definitions, 84 physical Model Cards, five
-virtual Model Cards, 169 provider-owned model mappings, 64 benchmark
-definitions, and 1,365 exact evaluation records. The five default benchmark
-components produce 1,325 explicit slots over 265 model/effort rows; 125 slots
+serving providers, three protocol definitions, 85 physical Model Cards, five
+virtual Model Cards, 171 provider-owned model mappings, 64 benchmark
+definitions, and 1,394 exact evaluation records. The five default benchmark
+components produce 1,345 explicit slots over 269 model/effort rows; 126 slots
 are currently measured and every other slot stays explicitly missing. Support
 tier, lifecycle, and conformance remain independent, so catalog inclusion is
 not flattened into a native-support or benchmark claim.
 
-All 84 physical cards pass the hard admission rule: at least one exact
+All 85 physical cards pass the hard admission rule: at least one exact
 model, reasoning-effort, and evidence-provenance bucket contains five distinct
 benchmark identities.
 That does not mean every runtime-selectable effort has five published results.
@@ -81,7 +81,7 @@ baseline change.
 | Model creator (`publisher`) | Recent generations and representative lines | Models |
 | --- | --- | ---: |
 | AI21 Labs | Jamba2 Mini, Jamba Reasoning 3B, Jamba Large 1.7 | 3 |
-| Alibaba / Qwen | Qwen3.8 Max/27B/2.4T, Qwen3.7 Max, Qwen3.6 27B/35B | 6 |
+| Alibaba / Qwen | Qwen3.8 Max/Flash Next/27B/2.4T, Qwen3.7 Max, Qwen3.6 27B/35B | 7 |
 | Amazon | Nova 2 Lite, Nova Premier, Nova Pro | 3 |
 | Anthropic | Claude Fable 5.1/5, Opus 5/4.8, Sonnet 5 | 5 |
 | Baidu | ERNIE 5.1, ERNIE 5.0, ERNIE 4.5 300B A47B | 3 |
@@ -726,8 +726,8 @@ The initial population audit makes both coverage and gaps visible. The 64
 benchmark definitions retain all exact measurements as source records, while
 public Hub surfaces remove every exact benchmark/profile/metric tuple measured
 on fewer than ten distinct models. The default five-component matrix
-materializes 1,325 slots over 265
-model/effort rows. At this snapshot, 125 of those slots have an exact
+materializes 1,345 slots over 269
+model/effort rows. At this snapshot, 126 of those slots have an exact
 measurement. Other rows remain explicitly `missing`, `failed`,
 `not_applicable`, or `withheld`; none is fabricated as zero.
 
@@ -1031,8 +1031,9 @@ URL/path semantics, supported operations, discovery policy, conformance, and
 the model mappings that can be verified in that change. An issue must not
 silently broaden into another creator or unrelated provider.
 
-The first current-line candidates are Qwen3.8 Flash, NVIDIA Nemotron 3 Nano
-text, and Claude Haiku 4.5. Nova 2 Pro Preview, Cohere North Micro Vision,
+With Qwen3.8 Flash Next now included, the first remaining current-line
+candidates are NVIDIA Nemotron 3 Nano text and Claude Haiku 4.5. Nova 2 Pro
+Preview, Cohere North Micro Vision,
 MAI-Code 1.1 Flash, and Jamba2 3B remain blocked candidates until
 their runtime binding, public endpoint, or fifth distinct exact benchmark
 is verifiable. Baidu/ERNIE 5.1, 5.0, and 4.5 and StepFun 3.7, 3.5, and Step3-VL

--- a/website/static/model-catalog/catalog.json
+++ b/website/static/model-catalog/catalog.json
@@ -9755,7 +9755,7 @@
         "resolved": 0.827
       },
       "model": "deepseek/deepseek-v4-flash",
-      "observed_at": "2026-09-09",
+      "observed_at": "2026-09-08",
       "reasoning_effort": "max",
       "status": "available",
       "subject": {
@@ -26903,7 +26903,7 @@
         "resolved": 0.587
       },
       "model": "qwen/qwen3.8-flash-next",
-      "observed_at": "2026-09-09",
+      "observed_at": "2026-09-08",
       "reasoning_effort": "unspecified",
       "status": "available",
       "subject": {
@@ -26932,7 +26932,7 @@
         "resolved": 0.625
       },
       "model": "qwen/qwen3.8-flash-next",
-      "observed_at": "2026-09-09",
+      "observed_at": "2026-09-08",
       "reasoning_effort": "unspecified",
       "status": "available",
       "subject": {
@@ -26962,7 +26962,7 @@
         "score": 0.512
       },
       "model": "qwen/qwen3.8-flash-next",
-      "observed_at": "2026-09-09",
+      "observed_at": "2026-09-08",
       "reasoning_effort": "unspecified",
       "status": "available",
       "subject": {
@@ -26986,7 +26986,7 @@
         "accuracy": 0.813
       },
       "model": "qwen/qwen3.8-flash-next",
-      "observed_at": "2026-09-09",
+      "observed_at": "2026-09-08",
       "reasoning_effort": "unspecified",
       "status": "available",
       "subject": {
@@ -27010,7 +27010,7 @@
         "accuracy": 0.917
       },
       "model": "qwen/qwen3.8-flash-next",
-      "observed_at": "2026-09-09",
+      "observed_at": "2026-09-08",
       "reasoning_effort": "unspecified",
       "status": "available",
       "subject": {
@@ -27034,7 +27034,7 @@
         "accuracy": 0.359
       },
       "model": "qwen/qwen3.8-flash-next",
-      "observed_at": "2026-09-09",
+      "observed_at": "2026-09-08",
       "reasoning_effort": "unspecified",
       "status": "available",
       "subject": {
@@ -27059,7 +27059,7 @@
         "pass_at_1": 0.919
       },
       "model": "qwen/qwen3.8-flash-next",
-      "observed_at": "2026-09-09",
+      "observed_at": "2026-09-08",
       "reasoning_effort": "unspecified",
       "status": "available",
       "subject": {
@@ -27083,7 +27083,7 @@
         "score": 0.846
       },
       "model": "qwen/qwen3.8-flash-next",
-      "observed_at": "2026-09-09",
+      "observed_at": "2026-09-08",
       "reasoning_effort": "unspecified",
       "status": "available",
       "subject": {
@@ -27108,7 +27108,7 @@
         "score": 0.906
       },
       "model": "qwen/qwen3.8-flash-next",
-      "observed_at": "2026-09-09",
+      "observed_at": "2026-09-08",
       "reasoning_effort": "unspecified",
       "status": "available",
       "subject": {
@@ -37423,7 +37423,7 @@
         "authority": "DeepSeek",
         "source": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731",
         "status": "claimed",
-        "verified_at": "2026-09-09"
+        "verified_at": "2026-09-08"
       }
     },
     {
@@ -39502,7 +39502,7 @@
         "authority": "Qwen Team",
         "source": "https://huggingface.co/Qwen/Qwen3.8-Flash-Next",
         "status": "claimed",
-        "verified_at": "2026-09-09"
+        "verified_at": "2026-09-08"
       }
     },
     {
@@ -44398,7 +44398,7 @@
           "verification": {
             "source": "https://docs.sglang.io/cookbook/autoregressive/Qwen/Qwen3.8-Flash-Next",
             "status": "claimed",
-            "verified_at": "2026-09-09"
+            "verified_at": "2026-09-08"
           }
         },
         {
@@ -44979,7 +44979,7 @@
           "verification": {
             "source": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731",
             "status": "claimed",
-            "verified_at": "2026-09-09"
+            "verified_at": "2026-09-08"
           }
         },
         {
@@ -45297,7 +45297,7 @@
           "verification": {
             "source": "https://recipes.vllm.ai/Qwen/Qwen3.8-Flash-Next",
             "status": "claimed",
-            "verified_at": "2026-09-09"
+            "verified_at": "2026-09-08"
           }
         },
         {

--- a/website/static/model-catalog/catalog.json
+++ b/website/static/model-catalog/catalog.json
@@ -451,6 +451,15 @@
             1
           ],
           "unit": "proportion"
+        },
+        {
+          "direction": "higher_is_better",
+          "id": "score",
+          "range": [
+            0,
+            1
+          ],
+          "unit": "proportion"
         }
       ],
       "profiles": [
@@ -9738,7 +9747,7 @@
       "evidence": {
         "provenance": "vendor_claimed",
         "redistributable": true,
-        "source": "https://api-docs.deepseek.com/updates/",
+        "source": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731",
         "verification": "claimed"
       },
       "id": "deepseek/deepseek-v4-flash-release-eval-terminal-bench@1.0.0",
@@ -9746,14 +9755,15 @@
         "resolved": 0.827
       },
       "model": "deepseek/deepseek-v4-flash",
-      "observed_at": "2026-09-06",
+      "observed_at": "2026-09-09",
       "reasoning_effort": "max",
       "status": "available",
       "subject": {
+        "model_revision": "DeepSeek-V4-Flash-0731",
         "reasoning_effort": "max",
         "source_kind": "official_release_evaluation",
         "terminal_harness": "DeepSeek API evaluation harness",
-        "variant": "deepseek-v4-flash"
+        "variant": "DeepSeek-V4-Flash-0731"
       }
     },
     {
@@ -26880,6 +26890,236 @@
       }
     },
     {
+      "benchmark": "datacurve/deep-swe@1.1.0",
+      "benchmark_profile": "published-agent",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/Qwen/Qwen3.8-Flash-Next",
+        "verification": "claimed"
+      },
+      "id": "qwen/qwen3.8-flash-next-model-card-deep-swe@1.0.0",
+      "metrics": {
+        "resolved": 0.587
+      },
+      "model": "qwen/qwen3.8-flash-next",
+      "observed_at": "2026-09-09",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "context_window_size": 262144,
+        "model_revision": "de4b8e4d43b917e7706784d8bb445c9af86a3540",
+        "reasoning_effort": "unspecified",
+        "reported_selection": "highest_across_claude_code_and_mini_swe_agent",
+        "sampling_temperature": 1.0,
+        "sampling_top_p": 0.95,
+        "source_kind": "official_model_card",
+        "swe_harness": "mini-SWE-agent",
+        "variant": "Qwen3.8-Flash-Next"
+      }
+    },
+    {
+      "benchmark": "swe-bench/pro@1.0.0",
+      "benchmark_profile": "published-agent",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/Qwen/Qwen3.8-Flash-Next",
+        "verification": "claimed"
+      },
+      "id": "qwen/qwen3.8-flash-next-model-card-swe-bench-pro@1.0.0",
+      "metrics": {
+        "resolved": 0.625
+      },
+      "model": "qwen/qwen3.8-flash-next",
+      "observed_at": "2026-09-09",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "context_window_size": 262144,
+        "dataset_variant": "refined",
+        "model_revision": "de4b8e4d43b917e7706784d8bb445c9af86a3540",
+        "reasoning_effort": "unspecified",
+        "sampling_temperature": 1.0,
+        "sampling_top_p": 0.95,
+        "source_kind": "official_model_card",
+        "swe_harness": "Claude Code",
+        "variant": "Qwen3.8-Flash-Next"
+      }
+    },
+    {
+      "benchmark": "berkeley-rdi/agents-last-exam@1.0.0",
+      "benchmark_profile": "published-agent",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/Qwen/Qwen3.8-Flash-Next",
+        "verification": "claimed"
+      },
+      "id": "qwen/qwen3.8-flash-next-model-card-agents-last-exam@1.0.0",
+      "metrics": {
+        "pass_rate": 0.243,
+        "score": 0.512
+      },
+      "model": "qwen/qwen3.8-flash-next",
+      "observed_at": "2026-09-09",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "model_revision": "de4b8e4d43b917e7706784d8bb445c9af86a3540",
+        "reasoning_effort": "unspecified",
+        "source_kind": "official_model_card",
+        "variant": "Qwen3.8-Flash-Next"
+      }
+    },
+    {
+      "benchmark": "allenai/ifbench@1.0.0",
+      "benchmark_profile": "prompt-loose",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/Qwen/Qwen3.8-Flash-Next",
+        "verification": "claimed"
+      },
+      "id": "qwen/qwen3.8-flash-next-model-card-ifbench@1.0.0",
+      "metrics": {
+        "accuracy": 0.813
+      },
+      "model": "qwen/qwen3.8-flash-next",
+      "observed_at": "2026-09-09",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "model_revision": "de4b8e4d43b917e7706784d8bb445c9af86a3540",
+        "reasoning_effort": "unspecified",
+        "source_kind": "official_model_card",
+        "variant": "Qwen3.8-Flash-Next"
+      }
+    },
+    {
+      "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+      "benchmark_profile": "published-standard",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/Qwen/Qwen3.8-Flash-Next",
+        "verification": "claimed"
+      },
+      "id": "qwen/qwen3.8-flash-next-model-card-gpqa-diamond@1.0.0",
+      "metrics": {
+        "accuracy": 0.917
+      },
+      "model": "qwen/qwen3.8-flash-next",
+      "observed_at": "2026-09-09",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "model_revision": "de4b8e4d43b917e7706784d8bb445c9af86a3540",
+        "reasoning_effort": "unspecified",
+        "source_kind": "official_model_card",
+        "variant": "Qwen3.8-Flash-Next"
+      }
+    },
+    {
+      "benchmark": "cais/humanitys-last-exam@1.0.0",
+      "benchmark_profile": "published-unspecified",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/Qwen/Qwen3.8-Flash-Next",
+        "verification": "claimed"
+      },
+      "id": "qwen/qwen3.8-flash-next-model-card-humanitys-last-exam@1.0.0",
+      "metrics": {
+        "accuracy": 0.359
+      },
+      "model": "qwen/qwen3.8-flash-next",
+      "observed_at": "2026-09-09",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "hle_judge": "GPT-4o",
+        "model_revision": "de4b8e4d43b917e7706784d8bb445c9af86a3540",
+        "reasoning_effort": "unspecified",
+        "source_kind": "official_model_card",
+        "variant": "Qwen3.8-Flash-Next"
+      }
+    },
+    {
+      "benchmark": "livecodebench/livecodebench@6.0.0",
+      "benchmark_profile": "code-generation-pass-at-1",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/Qwen/Qwen3.8-Flash-Next",
+        "verification": "claimed"
+      },
+      "id": "qwen/qwen3.8-flash-next-model-card-livecodebench-v6@1.0.0",
+      "metrics": {
+        "pass_at_1": 0.919
+      },
+      "model": "qwen/qwen3.8-flash-next",
+      "observed_at": "2026-09-09",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "model_revision": "de4b8e4d43b917e7706784d8bb445c9af86a3540",
+        "reasoning_effort": "unspecified",
+        "source_kind": "official_model_card",
+        "variant": "Qwen3.8-Flash-Next"
+      }
+    },
+    {
+      "benchmark": "princeton-nlp/charxiv@1.0.0",
+      "benchmark_profile": "no-tools",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/Qwen/Qwen3.8-Flash-Next",
+        "verification": "claimed"
+      },
+      "id": "qwen/qwen3.8-flash-next-model-card-charxiv-no-tools@1.0.0",
+      "metrics": {
+        "score": 0.846
+      },
+      "model": "qwen/qwen3.8-flash-next",
+      "observed_at": "2026-09-09",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "model_revision": "de4b8e4d43b917e7706784d8bb445c9af86a3540",
+        "reasoning_effort": "unspecified",
+        "source_kind": "official_model_card",
+        "tool_policy": "without_code_interpreter",
+        "variant": "Qwen3.8-Flash-Next"
+      }
+    },
+    {
+      "benchmark": "princeton-nlp/charxiv@1.0.0",
+      "benchmark_profile": "with-tools",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/Qwen/Qwen3.8-Flash-Next",
+        "verification": "claimed"
+      },
+      "id": "qwen/qwen3.8-flash-next-model-card-charxiv-with-tools@1.0.0",
+      "metrics": {
+        "score": 0.906
+      },
+      "model": "qwen/qwen3.8-flash-next",
+      "observed_at": "2026-09-09",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "model_revision": "de4b8e4d43b917e7706784d8bb445c9af86a3540",
+        "reasoning_effort": "unspecified",
+        "source_kind": "official_model_card",
+        "tool_policy": "with_code_interpreter",
+        "variant": "Qwen3.8-Flash-Next"
+      }
+    },
+    {
       "benchmark": "artificial-analysis/critpt@1.0.0",
       "benchmark_profile": "independent-standard",
       "evidence": {
@@ -37144,7 +37384,7 @@
       "display_name": "DeepSeek V4 Flash",
       "distribution": {
         "license": "MIT",
-        "source": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash",
+        "source": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731",
         "type": "open_weights"
       },
       "family": "deepseek-v4",
@@ -37181,9 +37421,9 @@
       ],
       "verification": {
         "authority": "DeepSeek",
-        "source": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash",
+        "source": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731",
         "status": "claimed",
-        "verified_at": "2026-09-05"
+        "verified_at": "2026-09-09"
       }
     },
     {
@@ -39207,6 +39447,62 @@
         "source": "https://www.alibabacloud.com/help/en/model-studio/text-generation-model",
         "status": "claimed",
         "verified_at": "2026-09-05"
+      }
+    },
+    {
+      "capabilities": [
+        "chat",
+        "reasoning",
+        "tools",
+        "structured_output",
+        "vision",
+        "long_context"
+      ],
+      "description": "Experimental open-weight Qwen4 architecture preview for efficient multimodal reasoning and agents.",
+      "display_name": "Qwen3.8 Flash Next",
+      "distribution": {
+        "license": "Qwen Community License 1.0",
+        "source": "https://huggingface.co/Qwen/Qwen3.8-Flash-Next",
+        "type": "open_weights"
+      },
+      "family": "qwen3.8",
+      "id": "qwen/qwen3.8-flash-next",
+      "kind": "physical",
+      "lifecycle": "experimental",
+      "limits": {
+        "context_window_size": 262144
+      },
+      "modalities": {
+        "input": [
+          "text",
+          "image",
+          "video"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "parameter_size": "176B + 4B MTP (6B active)",
+      "presentation": {
+        "logo": "package:qwen",
+        "monochrome": false,
+        "monogram": "Q"
+      },
+      "publisher": "Alibaba / Qwen",
+      "reasoning_family": "qwen3.8",
+      "released_at": "2026-08-24",
+      "tags": [
+        "open_weights",
+        "multimodal",
+        "moe",
+        "agentic",
+        "long_context"
+      ],
+      "verification": {
+        "authority": "Qwen Team",
+        "source": "https://huggingface.co/Qwen/Qwen3.8-Flash-Next",
+        "status": "claimed",
+        "verified_at": "2026-09-09"
       }
     },
     {
@@ -44090,6 +44386,22 @@
       "id": "sglang",
       "models": [
         {
+          "catalog": "qwen/qwen3.8-flash-next",
+          "id": "Qwen/Qwen3.8-Flash-Next",
+          "lifecycle": "experimental",
+          "protocols": [
+            "openai/chat-completions@1",
+            "openai/responses@1"
+          ],
+          "reasoning_transport": "top_level_effort_template_switch",
+          "relationship": "self_hosted",
+          "verification": {
+            "source": "https://docs.sglang.io/cookbook/autoregressive/Qwen/Qwen3.8-Flash-Next",
+            "status": "claimed",
+            "verified_at": "2026-09-09"
+          }
+        },
+        {
           "catalog": "qwen/qwen3.8-27b",
           "id": "Qwen/Qwen3.8-27B",
           "lifecycle": "experimental",
@@ -44656,7 +44968,7 @@
         },
         {
           "catalog": "deepseek/deepseek-v4-flash",
-          "id": "deepseek-ai/DeepSeek-V4-Flash",
+          "id": "deepseek-ai/DeepSeek-V4-Flash-0731",
           "lifecycle": "active",
           "protocols": [
             "openai/chat-completions@1",
@@ -44665,9 +44977,9 @@
           "reasoning_transport": "top_level_effort",
           "relationship": "self_hosted",
           "verification": {
-            "source": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash",
+            "source": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731",
             "status": "claimed",
-            "verified_at": "2026-09-05"
+            "verified_at": "2026-09-09"
           }
         },
         {
@@ -44970,6 +45282,22 @@
             "source": "https://huggingface.co/Qwen/Qwen3.8-27B",
             "status": "claimed",
             "verified_at": "2026-09-05"
+          }
+        },
+        {
+          "catalog": "qwen/qwen3.8-flash-next",
+          "id": "Qwen/Qwen3.8-Flash-Next",
+          "lifecycle": "experimental",
+          "protocols": [
+            "openai/chat-completions@1",
+            "openai/responses@1"
+          ],
+          "reasoning_transport": "top_level_effort_template_switch",
+          "relationship": "self_hosted",
+          "verification": {
+            "source": "https://recipes.vllm.ai/Qwen/Qwen3.8-Flash-Next",
+            "status": "claimed",
+            "verified_at": "2026-09-09"
           }
         },
         {


### PR DESCRIPTION
Related #3577

## Purpose

- Add the exact `Qwen/Qwen3.8-Flash-Next` physical Model Card, vLLM and SGLang self-hosted mappings, multimodal/reasoning contract, and regenerated catalog projections.
- Record nine official model-card evaluation rows across eight distinct benchmark identities. Every row pins the published Hugging Face revision and remains `vendor_claimed` / `claimed` with `reasoning_effort: unspecified`; this does not present vendor scores as vLLM-SR-reproduced route-grade evidence.
- Correct the DeepSeek V4 Flash physical card, vLLM binding, and official Terminal Bench evaluation evidence to the released `deepseek-ai/DeepSeek-V4-Flash-0731` checkpoint while preserving preview-version history.
- Refresh catalog inventory counts and the proposal snapshot.

Primary evidence: [Qwen model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next), [vLLM recipe](https://recipes.vllm.ai/Qwen/Qwen3.8-Flash-Next), [SGLang cookbook](https://docs.sglang.io/cookbook/autoregressive/Qwen/Qwen3.8-Flash-Next), and [DeepSeek 0731 model card](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731).

## Test Plan

- `make model-catalog-check`
- `python3 tools/catalog/audit_model_catalog.py --models qwen/qwen3.8-flash-next --json`
- `make impact ENV=cpu BASE_REF=upstream/main`
- `make check BASE_REF=upstream/main`

## Test Result

- Catalog compiler/schema tests: 60 passed.
- Qwen audit: one physical card, two provider bindings, nine evaluation records, and eight distinct exact benchmark identities; selectable low/medium/xhigh effort buckets remain explicitly unmeasured because the source does not identify its benchmark effort.
- Full current-harness check passed, including pre-commit, security and architecture checks, translation coverage, Semantic Router tests, and static recipe conformance.
- Impact selected no E2E profile for these paths.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category
- [x] The title does not stack prefixes
- [x] The PR links accepted issue #3577 with owner Xunzhuo and `wg/evaluation-quality`
- [x] Commits are signed off with `git commit -s`
- [x] Purpose, Test Plan, and Test Result reflect the actual scope and results

</details>