### PR TITLE
[Bug] Update the catalog inventory assertion to the 20 added evaluations

### DIFF
--- a/dashboard/backend/handlers/model_catalog_test.go
+++ b/dashboard/backend/handlers/model_catalog_test.go
@@ -451,7 +451,7 @@ func TestGeneratedPublicModelCatalogSatisfiesDashboardContract(t *testing.T) {
 	if unmarshalErr := json.Unmarshal(normalized, &document); unmarshalErr != nil {
 		t.Fatalf("decode normalized public catalog: %v", unmarshalErr)
 	}
-	if len(document.Models) != 89 || len(document.Providers) != 60 || len(document.Evaluations) != 1365 {
+	if len(document.Models) != 89 || len(document.Providers) != 60 || len(document.Evaluations) != 1385 {
 		t.Fatalf(
 			"unexpected generated inventory: models=%d providers=%d evaluations=%d",
 			len(document.Models),


### PR DESCRIPTION
Closes #3633

## Problem

`main` is red. `TestGeneratedPublicModelCatalogSatisfiesDashboardContract` fails on a clean checkout:

```
--- FAIL: TestGeneratedPublicModelCatalogSatisfiesDashboardContract
    model_catalog_test.go:455: unexpected generated inventory: models=89 providers=60 evaluations=1385
```

The test pins the generated catalog inventory. 4cc8e85f ([Model Hub] Enrich Astra evaluations and shareable views) added 410 lines of evaluations to `config/recipes/resources/evaluations/single/openai.yaml` and `config/recipes/built-in/latest/catalog.yaml` and regenerated the artifacts, which took the evaluation count from 1365 to 1385. It did not touch `model_catalog_test.go`, where 1365 was last set by a46fdcda.

Only the evaluation count moved. `models=89` and `providers=60` still match, so this is the counter that drifted rather than anything structural.

## Why it is worth a standalone PR

The Dashboard job feeds `PR Gate`, so every open pull request currently shows a red gate for a failure it did not cause. I hit it on #2767 and #3617, both of which are approved and blocked only by this. Fixing it on its own branch unblocks the queue rather than burying the fix inside an unrelated change.

## Verification

```
cd dashboard/backend
go test ./handlers/ -run TestGeneratedPublicModelCatalog   -> ok
go test ./handlers/                                        -> ok   (full package, 32s)
```

## One suggestion, not in this PR

An exact-count assertion fails on every legitimate catalog change and the failure says only that a number moved. It caught nothing here that a reviewer would have wanted flagged; it just went stale.

If the intent is to stop the catalog changing by accident, invariants would hold that line without needing an edit each time content is added: every evaluation references a known model, no duplicate evaluation keys, every model resolves to a known provider, counts are non-zero. Those fail loudly on a real regression and stay quiet when someone adds twenty evaluations on purpose.

Happy to send that as a follow-up if you want it. Keeping this PR to the one number so it can land immediately.
