### PR TITLE
[Bug] Scan the whole answer for hallucinations, not its first window

### DIFF
--- a/src/semantic-router/pkg/classification/hallucination_detector.go
+++ b/src/semantic-router/pkg/classification/hallucination_detector.go
@@ -18,6 +18,67 @@ type HallucinationResult struct {
 	SupportedSpans        []string `json:"supported_spans,omitempty"`   // Text spans grounded in context
 }
 
+const (
+	// The detector scores at most 512 tokens and windows only the context, so an
+	// answer longer than that window is truncated and its tail is never scored.
+	// A long answer is scanned in bounded overlapping chunks instead, the way the
+	// response jailbreak path scans a long body. The budget leaves the rest of
+	// the window for the context and the question.
+	hallucinationAnswerChunkBudget  = 256 * 4
+	hallucinationAnswerOverlapRunes = 64
+)
+
+// hallucinationAnswerChunks returns the pieces of an answer to score. An answer
+// that fits the window yields one chunk, which is the single call the detector
+// made before.
+func hallucinationAnswerChunks(answer string) []string {
+	return securitySignalChunks(answer, hallucinationAnswerChunkBudget, hallucinationAnswerOverlapRunes)
+}
+
+// detectHallucinationsInChunks scores every part of the answer against the same
+// context. A hallucination in any chunk is a hallucination in the answer, the
+// reported confidence is that of the strongest chunk that found one, and a clean
+// answer reports its least confident chunk. Chunks overlap, so spans that repeat
+// are kept once.
+func detectHallucinationsInChunks(context, question, answer string, threshold float32) (*candle.HallucinationDetectionResult, error) {
+	chunks := hallucinationAnswerChunks(answer)
+	if len(chunks) <= 1 {
+		return candle.DetectHallucinations(context, question, answer, threshold)
+	}
+
+	merged := &candle.HallucinationDetectionResult{Confidence: 1}
+	seen := make(map[string]struct{})
+	for _, chunk := range chunks {
+		result, err := candle.DetectHallucinations(context, question, chunk, threshold)
+		if err != nil {
+			return nil, err
+		}
+		merged.Confidence = mergeChunkConfidence(merged.HasHallucination, merged.Confidence, result.HasHallucination, result.Confidence)
+		merged.HasHallucination = merged.HasHallucination || result.HasHallucination
+		for _, span := range result.Spans {
+			if _, duplicate := seen[span.Text]; duplicate {
+				continue
+			}
+			seen[span.Text] = struct{}{}
+			merged.Spans = append(merged.Spans, span)
+		}
+	}
+	return merged, nil
+}
+
+// mergeChunkConfidence folds one chunk verdict into the answer verdict: the
+// highest confidence among the chunks that reported a hallucination, or the
+// lowest among the chunks that reported none.
+func mergeChunkConfidence(merged bool, mergedConfidence float32, chunk bool, chunkConfidence float32) float32 {
+	switch {
+	case chunk && (!merged || chunkConfidence > mergedConfidence):
+		return chunkConfidence
+	case !chunk && !merged && chunkConfidence < mergedConfidence:
+		return chunkConfidence
+	}
+	return mergedConfidence
+}
+
 // HallucinationDetector handles hallucination detection
 // It checks if an LLM answer contains claims that are not supported by the provided context
 type HallucinationDetector struct {
@@ -100,7 +161,7 @@ func (d *HallucinationDetector) Detect(context, question, answer string) (*Hallu
 	// Call hallucination detection via candle bindings with threshold
 	// Threshold is applied at token level in Rust - only tokens with confidence >= threshold
 	// are considered hallucinated and included in spans
-	candleResult, err := candle.DetectHallucinations(context, question, answer, threshold)
+	candleResult, err := detectHallucinationsInChunks(context, question, answer, threshold)
 	if err != nil {
 		return nil, fmt.Errorf("hallucination detection error: %w", err)
 	}

--- a/src/semantic-router/pkg/classification/hallucination_detector_nli.go
+++ b/src/semantic-router/pkg/classification/hallucination_detector_nli.go
@@ -123,6 +123,35 @@ func (d *HallucinationDetector) ClassifyNLI(premise, hypothesis string) (*NLIRes
 	}, nil
 }
 
+// detectHallucinationsWithNLIInChunks scans a long answer the way
+// detectHallucinationsInChunks does, because the NLI entry point windows only
+// its premise and truncates the answer the same way.
+func detectHallucinationsWithNLIInChunks(context, question, answer string, threshold float32) (*candle.EnhancedHallucinationDetectionResult, error) {
+	chunks := hallucinationAnswerChunks(answer)
+	if len(chunks) <= 1 {
+		return candle.DetectHallucinationsWithNLI(context, question, answer, threshold)
+	}
+
+	merged := &candle.EnhancedHallucinationDetectionResult{Confidence: 1}
+	seen := make(map[string]struct{})
+	for _, chunk := range chunks {
+		result, err := candle.DetectHallucinationsWithNLI(context, question, chunk, threshold)
+		if err != nil {
+			return nil, err
+		}
+		merged.Confidence = mergeChunkConfidence(merged.HasHallucination, merged.Confidence, result.HasHallucination, result.Confidence)
+		merged.HasHallucination = merged.HasHallucination || result.HasHallucination
+		for _, span := range result.Spans {
+			if _, duplicate := seen[span.Text]; duplicate {
+				continue
+			}
+			seen[span.Text] = struct{}{}
+			merged.Spans = append(merged.Spans, span)
+		}
+	}
+	return merged, nil
+}
+
 // DetectWithNLI detects hallucinations and provides NLI-based explanations.
 // It combines token-level hallucination detection with NLI classification.
 func (d *HallucinationDetector) DetectWithNLI(context, question, answer string) (*EnhancedHallucinationResult, error) {
@@ -147,7 +176,7 @@ func (d *HallucinationDetector) DetectWithNLI(context, question, answer string) 
 
 	hallucinationThreshold := d.hallucinationThreshold()
 	nliThreshold := d.nliThreshold()
-	candleResult, err := candle.DetectHallucinationsWithNLI(context, question, answer, hallucinationThreshold)
+	candleResult, err := detectHallucinationsWithNLIInChunks(context, question, answer, hallucinationThreshold)
 	if err != nil {
 		return nil, fmt.Errorf("enhanced hallucination detection error: %w", err)
 	}

--- a/src/semantic-router/pkg/classification/hallucination_detector_window_test.go
+++ b/src/semantic-router/pkg/classification/hallucination_detector_window_test.go
@@ -25,7 +25,7 @@ func TestHallucinationDetector_LongContextReachesAnswer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create detector: %v", err)
 	}
-	if err := detector.Initialize(); err != nil {
+	if err = detector.Initialize(); err != nil {
 		t.Fatalf("Failed to initialize detector: %v", err)
 	}
 
@@ -36,5 +36,123 @@ func TestHallucinationDetector_LongContextReachesAnswer(t *testing.T) {
 	t.Logf("Long context (%d chars): detected=%v confidence=%.3f spans=%v", len(toolContext), result.HallucinationDetected, result.Confidence, result.UnsupportedSpans)
 	if !result.HallucinationDetected {
 		t.Errorf("Expected hallucination with %d-char context, but none detected", len(toolContext))
+	}
+}
+
+// TestHallucinationDetector_LongAnswerTailIsScanned guards the other half of the
+// 512-token window: an unsupported claim at the end of a long answer must be
+// found rather than truncated away.
+func TestHallucinationDetector_LongAnswerTailIsScanned(t *testing.T) {
+	skipIfNoModel(t)
+
+	toolContext, userQuestion, assistantAnswer := longAnswerWithUnsupportedTail(t)
+
+	cfg := &config.HallucinationModelConfig{
+		ModelID:   getHallucinationModelPath(),
+		Threshold: 0.5,
+		UseCPU:    true,
+	}
+	detector, err := NewHallucinationDetector(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create detector: %v", err)
+	}
+	if err = detector.Initialize(); err != nil {
+		t.Fatalf("Failed to initialize detector: %v", err)
+	}
+
+	result, err := detector.Detect(toolContext, userQuestion, assistantAnswer)
+	if err != nil {
+		t.Fatalf("Detection failed: %v", err)
+	}
+	t.Logf("Long answer (%d words): detected=%v confidence=%.3f spans=%v",
+		len(strings.Fields(assistantAnswer)), result.HallucinationDetected, result.Confidence, result.UnsupportedSpans)
+	if !result.HallucinationDetected {
+		t.Errorf("Expected the unsupported claim at the end of a %d-word answer to be detected",
+			len(strings.Fields(assistantAnswer)))
+	}
+}
+
+// longAnswerWithUnsupportedTail returns a context, a question, and an answer whose
+// only unsupported sentence is its last one, long enough that the answer alone
+// passes the detector's 512-token window.
+func longAnswerWithUnsupportedTail(t *testing.T) (string, string, string) {
+	t.Helper()
+	toolContext := "The Eiffel Tower is a wrought iron lattice tower in Paris, France. " +
+		"It was designed by Gustave Eiffel and completed in 1889 for the World's Fair. " +
+		"The tower is 330 metres tall."
+	userQuestion := "Tell me about the Eiffel Tower."
+	grounded := strings.Repeat("The tower stands in Paris. It is built from wrought iron. "+
+		"Gustave Eiffel designed it. It was raised for the World's Fair. ", 30)
+	answer := grounded + "The tower was completed in 1912 and it is 550 metres tall."
+	if chunks := hallucinationAnswerChunks(answer); len(chunks) < 2 {
+		t.Fatalf("fixture needs to chunk, got %d chunk(s)", len(chunks))
+	}
+	return toolContext, userQuestion, answer
+}
+
+// TestHallucinationDetector_LongAnswerTailIsScannedWithNLI covers the second entry
+// point, which windows only its premise and truncated the answer the same way.
+func TestHallucinationDetector_LongAnswerTailIsScannedWithNLI(t *testing.T) {
+	skipIfNoModel(t)
+	skipIfNoNLIModel(t)
+
+	toolContext, userQuestion, assistantAnswer := longAnswerWithUnsupportedTail(t)
+
+	detector, err := NewHallucinationDetector(&config.HallucinationModelConfig{
+		ModelID:   getHallucinationModelPath(),
+		Threshold: 0.5,
+		UseCPU:    true,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create detector: %v", err)
+	}
+	if err = detector.Initialize(); err != nil {
+		t.Fatalf("Failed to initialize detector: %v", err)
+	}
+	detector.SetNLIConfig(&config.NLIModelConfig{
+		ModelID:   getNLIModelPath(),
+		Threshold: 0.7,
+		UseCPU:    true,
+	})
+	if err = detector.InitializeNLI(); err != nil {
+		t.Fatalf("Failed to initialize NLI: %v", err)
+	}
+
+	result, err := detector.DetectWithNLI(toolContext, userQuestion, assistantAnswer)
+	if err != nil {
+		t.Fatalf("Detection failed: %v", err)
+	}
+	t.Logf("Long answer with NLI (%d words): detected=%v confidence=%.3f spans=%d",
+		len(strings.Fields(assistantAnswer)), result.HallucinationDetected, result.Confidence, len(result.Spans))
+	if !result.HallucinationDetected {
+		t.Errorf("Expected the unsupported claim at the end of a %d-word answer to be detected",
+			len(strings.Fields(assistantAnswer)))
+	}
+}
+
+// TestMergeChunkConfidence covers the fold that turns per chunk verdicts into one
+// answer verdict, which runs whether or not the model is present.
+func TestMergeChunkConfidence(t *testing.T) {
+	tests := []struct {
+		name             string
+		merged           bool
+		mergedConfidence float32
+		chunk            bool
+		chunkConfidence  float32
+		want             float32
+	}{
+		{"first detection replaces the clean confidence", false, 1.0, true, 0.8, 0.8},
+		{"a stronger detection wins", true, 0.8, true, 0.9, 0.9},
+		{"a weaker detection is kept out", true, 0.9, true, 0.6, 0.9},
+		{"a clean chunk cannot dilute a detection", true, 0.9, false, 0.2, 0.9},
+		{"the least confident clean chunk is reported", false, 1.0, false, 0.7, 0.7},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mergeChunkConfidence(tc.merged, tc.mergedConfidence, tc.chunk, tc.chunkConfidence)
+			if got != tc.want {
+				t.Fatalf("mergeChunkConfidence = %.2f, want %.2f", got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Closes #3641

## Purpose

`detect_hallucinations` windows the context so the answer survives right truncation (#3365). The budget is `max_length - suffix_tokens` (`candle-binding/src/core/tokenization_window.rs:12`) and the suffix is `" Question: {question} [SEP] {answer}"`. Once that suffix alone reaches the model's 512 token window, the budget is zero and the answer itself is right truncated, so anything past the window is never scored and an unsupported claim near the end of a long answer comes back with no spans.

Measured on `models/mom-halugate-detector` at threshold 0.5, before this change:

| answer tokens | words | claim first | claim last |
|---|---|---|---|
| 463 | 352 | detected 0.9966 | detected 0.9981 |
| 508 | 386 | detected 0.9966 | not detected, 0 spans |

`Detect` and `DetectWithNLI` now scan a long answer in bounded overlapping chunks through `securitySignalChunks`, the helper the response jailbreak path already uses to scan a long body (#3206, #3333). A hallucination in any chunk is a hallucination in the answer, the reported confidence is that of the strongest chunk that found one, a clean answer reports its least confident chunk, and a span repeated across the 64 rune overlap is kept once. The chunk budget is 256 units, which leaves the rest of the window for the context and the question. An answer that already fits the window makes exactly the single call it made before.

This is the local detector only. `EndpointHallucinationDetector` is a separate type whose remote backend has no such window, and it is untouched.

## Test Plan

`go test ./pkg/classification/` with the hallucination and NLI models present, `scripts/gates.sh` for the CI PR lane, and the `hallucination` E2E profile on a local kind cluster.

## Test Result

Three new tests. `TestHallucinationDetector_LongAnswerTailIsScanned` and `TestHallucinationDetector_LongAnswerTailIsScannedWithNLI` build a 672 word answer whose only unsupported sentence is its last one. `TestMergeChunkConfidence` covers the fold from chunk verdicts to one answer verdict and needs no model.

On the parent commit the same fixture reports `detected=false confidence=1.000 spans=[]`. With this change it reports `detected=true confidence=0.999` with the unsupported sentence among the spans, and the NLI entry point reports `detected=true confidence=0.999` with 8 spans.

```
ok  	github.com/vllm-project/semantic-router/src/semantic-router/pkg/classification	72.953s
```

The `hallucination` E2E profile passes on this branch, 5 of 5 responses warned. That profile serves its detector from a remote mock endpoint, so it is a regression check rather than a test of this fix. An E2E case that can fail on this defect needs a profile running the local detector, which no profile does today, and that belongs in its own change.
