### PR TITLE
[Bug] Search a long RAG query by every window, not its first

### DIFF
--- a/candle-binding/semantic-router.go
+++ b/candle-binding/semantic-router.go
@@ -164,6 +164,13 @@ typedef struct {
     bool error;
 } TokenizationResult;
 
+// Byte ranges of an input that each fit the embedding window
+typedef struct {
+    int* offsets;
+    int window_count;
+    bool error;
+} TextWindowsResult;
+
 // Classification result structure
 typedef struct {
     int class;
@@ -247,6 +254,8 @@ extern int get_embedding_models_info(EmbeddingModelsInfoResult* result);
 extern void free_embedding_models_info(EmbeddingModelsInfoResult* result);
 extern TokenizationResult tokenize_text(const char* text, int max_length);
 extern int embedding_text_exceeds_window(const char* text, const char* model_type);
+extern TextWindowsResult get_text_windows(const char* text, int max_length);
+extern void free_text_windows(TextWindowsResult result);
 extern void free_cstring(char* s);
 extern void free_embedding(float* data, int length);
 
@@ -672,6 +681,42 @@ func EmbeddingTextExceedsWindow(text, modelType string) (bool, error) {
 	default:
 		return false, fmt.Errorf("embedding model %q not loaded", modelType)
 	}
+}
+
+// TextWindow is one byte range of a text that fits the embedding window.
+type TextWindow struct {
+	Start int
+	End   int
+}
+
+// TextWindows returns the byte ranges a text has to be split into for the whole
+// of it to be embedded. A text that already fits comes back as one range, and
+// consecutive ranges overlap by half a window.
+func TextWindows(text string, maxLength int) ([]TextWindow, error) {
+	if !modelInitialized {
+		return nil, fmt.Errorf("BERT model not initialized")
+	}
+
+	cText := C.CString(text)
+	defer C.free(unsafe.Pointer(cText))
+
+	result := C.get_text_windows(cText, C.int(maxLength))
+	defer C.free_text_windows(result)
+
+	if bool(result.error) {
+		return nil, fmt.Errorf("failed to window text")
+	}
+
+	count := int(result.window_count)
+	if count == 0 || result.offsets == nil {
+		return nil, nil
+	}
+	offsets := (*[1 << 28]C.int)(unsafe.Pointer(result.offsets))[: count*2 : count*2]
+	windows := make([]TextWindow, count)
+	for i := 0; i < count; i++ {
+		windows[i] = TextWindow{Start: int(offsets[i*2]), End: int(offsets[i*2+1])}
+	}
+	return windows, nil
 }
 
 // GetEmbedding gets the embedding vector for a text

--- a/candle-binding/semantic-router_mock.go
+++ b/candle-binding/semantic-router_mock.go
@@ -166,6 +166,17 @@ func EmbeddingTextExceedsWindow(text, modelType string) (bool, error) {
 	return false, ErrBackendUnavailable
 }
 
+// TextWindow is one byte range of a text that fits the embedding window.
+type TextWindow struct {
+	Start int
+	End   int
+}
+
+// TextWindows returns the byte ranges a text has to be split into to be embedded
+func TextWindows(text string, maxLength int) ([]TextWindow, error) {
+	return nil, ErrBackendUnavailable
+}
+
 // GetEmbedding gets the embedding vector for a text
 func GetEmbedding(text string, maxLength int) ([]float32, error) {
 	return nil, ErrBackendUnavailable

--- a/candle-binding/src/core/similarity.rs
+++ b/candle-binding/src/core/similarity.rs
@@ -125,7 +125,7 @@ impl BertSimilarity {
         } else {
             unsafe {
                 VarBuilder::from_mmaped_safetensors(
-                    &[weights_filename.clone()],
+                    std::slice::from_ref(&weights_filename),
                     DType::F32,
                     &device,
                 )?
@@ -225,6 +225,36 @@ impl BertSimilarity {
         let embedding = pooled.to_dtype(DType::F32)?;
 
         normalize_l2(&embedding)
+    }
+
+    /// Byte ranges of `text` that each fit the model's window.
+    ///
+    /// [`get_embedding`] truncates at the window, so a caller that embeds a long
+    /// input once sees only its opening. Embedding each range instead keeps
+    /// every part of the input reachable. Ranges overlap by half a window so a
+    /// sentence cut by one boundary is whole inside its neighbour.
+    pub fn window_byte_ranges(
+        &self,
+        text: &str,
+        max_length: Option<usize>,
+    ) -> Result<Vec<(usize, usize)>> {
+        let window = max_length.unwrap_or(512);
+        let mut tokenizer = self.tokenizer.clone();
+        tokenizer.with_truncation(None).map_err(E::msg)?;
+        let encoding = tokenizer.encode(text, false).map_err(E::msg)?;
+        let offsets: Vec<(usize, usize)> = encoding
+            .get_offsets()
+            .iter()
+            .copied()
+            .filter(|(start, end)| end > start)
+            .collect();
+        // Every window is encoded with its own two special tokens.
+        let budget = window.saturating_sub(2).max(1);
+        Ok(crate::core::tokenization_window::window_ranges(
+            &offsets,
+            budget,
+            budget.div_ceil(2),
+        ))
     }
 
     /// Calculate cosine similarity between two texts

--- a/candle-binding/src/core/tokenization_window.rs
+++ b/candle-binding/src/core/tokenization_window.rs
@@ -26,3 +26,59 @@ pub fn fit_prefix_to_window(
     };
     Ok(prefix[..end].to_string())
 }
+
+/// Group token offsets into byte ranges of at most `budget` tokens each,
+/// starting a new range every `stride` tokens.
+///
+/// A stride below the budget makes the ranges overlap, so a sentence that one
+/// boundary cuts is whole inside the next range.
+pub fn window_ranges(
+    offsets: &[(usize, usize)],
+    budget: usize,
+    stride: usize,
+) -> Vec<(usize, usize)> {
+    if offsets.is_empty() || budget == 0 {
+        return Vec::new();
+    }
+    let stride = stride.clamp(1, budget);
+    let mut ranges = Vec::new();
+    let mut start = 0;
+    while start < offsets.len() {
+        let end = (start + budget).min(offsets.len());
+        ranges.push((offsets[start].0, offsets[end - 1].1));
+        if end == offsets.len() {
+            break;
+        }
+        start += stride;
+    }
+    ranges
+}
+
+#[cfg(test)]
+mod tests {
+    use super::window_ranges;
+
+    #[test]
+    fn test_window_ranges_cover_every_token() {
+        let offsets = [(0, 2), (3, 5), (6, 8), (9, 11), (12, 14)];
+        assert_eq!(
+            window_ranges(&offsets, 2, 2),
+            vec![(0, 5), (6, 11), (12, 14)]
+        );
+        assert_eq!(window_ranges(&offsets, 5, 5), vec![(0, 14)]);
+        assert_eq!(window_ranges(&offsets, 8, 4), vec![(0, 14)]);
+    }
+
+    #[test]
+    fn test_window_ranges_overlap_on_a_short_stride() {
+        let offsets = [(0, 2), (3, 5), (6, 8), (9, 11), (12, 14)];
+        assert_eq!(window_ranges(&offsets, 4, 2), vec![(0, 11), (6, 14)]);
+    }
+
+    #[test]
+    fn test_window_ranges_edges() {
+        assert!(window_ranges(&[], 4, 2).is_empty());
+        assert!(window_ranges(&[(0, 2)], 0, 1).is_empty());
+        assert_eq!(window_ranges(&[(0, 2)], 1, 0), vec![(0, 2)]);
+    }
+}

--- a/candle-binding/src/ffi/mod.rs
+++ b/candle-binding/src/ffi/mod.rs
@@ -11,6 +11,7 @@ pub mod init; //  initialization functions
 pub mod memory; //  memory management functions
 pub mod mlp; // MLP selector for model selection (GPU-accelerated)
 pub mod similarity; //  similarity functions
+pub mod text_windows; //  embedding window ranges
 pub mod tokenization; //  tokenization function
 pub mod types; //  C structure definitions
 pub mod validation; //  parameter validation functions
@@ -28,6 +29,7 @@ pub use memory::*;
 pub use mlp::*; // MLP selector FFI functions
 
 pub use similarity::*;
+pub use text_windows::*;
 pub use tokenization::*;
 pub use types::*;
 pub use validation::*;

--- a/candle-binding/src/ffi/text_windows.rs
+++ b/candle-binding/src/ffi/text_windows.rs
@@ -1,0 +1,90 @@
+//! FFI for splitting an input into the windows an embedding model can read.
+//!
+//! `get_text_embedding` truncates at the model's window, so a caller that embeds
+//! a long input once sees only its opening. These ranges let a caller embed every
+//! part of it instead.
+
+use crate::ffi::init::BERT_SIMILARITY;
+use std::ffi::{c_char, CStr};
+
+/// Byte ranges of an input that each fit the model's window, as start and end
+/// pairs laid out back to back in `offsets`.
+#[repr(C)]
+#[derive(Debug)]
+pub struct TextWindowsResult {
+    pub offsets: *mut i32,
+    pub window_count: i32,
+    pub error: bool,
+}
+
+fn failed_windows() -> TextWindowsResult {
+    TextWindowsResult {
+        offsets: std::ptr::null_mut(),
+        window_count: 0,
+        error: true,
+    }
+}
+
+/// Byte ranges of `text` that each fit the model's embedding window.
+///
+/// Free the result with `free_text_windows`.
+///
+/// # Safety
+/// - `text` must be a valid null-terminated C string
+#[no_mangle]
+pub unsafe extern "C" fn get_text_windows(
+    text: *const c_char,
+    max_length: i32,
+) -> TextWindowsResult {
+    let text = match unsafe { CStr::from_ptr(text) }.to_str() {
+        Ok(text) => text,
+        Err(_) => return failed_windows(),
+    };
+    let bert = match BERT_SIMILARITY.get() {
+        Some(bert) => bert.clone(),
+        None => {
+            eprintln!("BERT model not initialized");
+            return failed_windows();
+        }
+    };
+    let max_length_opt = if max_length <= 0 {
+        None
+    } else {
+        Some(max_length as usize)
+    };
+    let ranges = match bert.window_byte_ranges(text, max_length_opt) {
+        Ok(ranges) => ranges,
+        Err(e) => {
+            eprintln!("Failed to window text: {e}");
+            return failed_windows();
+        }
+    };
+
+    let mut flat: Vec<i32> = Vec::with_capacity(ranges.len() * 2);
+    for (start, end) in &ranges {
+        flat.push(*start as i32);
+        flat.push(*end as i32);
+    }
+    flat.shrink_to_fit();
+    let window_count = ranges.len() as i32;
+    let offsets = flat.as_mut_ptr();
+    std::mem::forget(flat);
+    TextWindowsResult {
+        offsets,
+        window_count,
+        error: false,
+    }
+}
+
+/// Free the ranges returned by `get_text_windows`.
+///
+/// # Safety
+/// - `result` must come from `get_text_windows` and must not be freed twice
+#[no_mangle]
+pub unsafe extern "C" fn free_text_windows(result: TextWindowsResult) {
+    if result.offsets.is_null() || result.window_count <= 0 {
+        return;
+    }
+    let length = result.window_count as usize * 2;
+    let _ = unsafe { Vec::from_raw_parts(result.offsets, length, length) };
+}

--- a/src/semantic-router/pkg/extproc/req_filter_rag_external.go
+++ b/src/semantic-router/pkg/extproc/req_filter_rag_external.go
@@ -12,7 +12,6 @@ import (
 	"time"
 	"unicode"
 
-	candle_binding "github.com/vllm-project/semantic-router/candle-binding"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
 	httputil "github.com/vllm-project/semantic-router/src/semantic-router/pkg/utils/http"
@@ -95,19 +94,35 @@ func (r *OpenAIRouter) retrieveFromExternalAPI(traceCtx context.Context, ctx *Re
 		return "", fmt.Errorf("invalid external API RAG config: %w", err)
 	}
 
-	// Build request based on format
-	var requestBody []byte
+	// Build one request per window of the query for the formats that search by
+	// vector, so a long query is not searched by its opening alone.
+	var requestBodies [][]byte
 	var buildErr error
 
 	switch apiConfig.RequestFormat {
-	case "pinecone":
-		requestBody, buildErr = r.buildPineconeRequest(ctx, ragConfig)
-	case "weaviate":
-		requestBody, buildErr = r.buildWeaviateRequest(ctx, ragConfig)
+	case "pinecone", "weaviate":
+		var queryEmbeddings [][]float32
+		queryEmbeddings, buildErr = ragQueryEmbeddings(ctx.UserContent)
+		for _, queryEmbedding := range queryEmbeddings {
+			var body []byte
+			if apiConfig.RequestFormat == "pinecone" {
+				body, buildErr = r.buildPineconeRequest(queryEmbedding, ragConfig)
+			} else {
+				body, buildErr = r.buildWeaviateRequest(queryEmbedding, ragConfig)
+			}
+			if buildErr != nil {
+				break
+			}
+			requestBodies = append(requestBodies, body)
+		}
 	case "elasticsearch":
-		requestBody, buildErr = r.buildElasticsearchRequest(ctx, ragConfig)
+		var body []byte
+		body, buildErr = r.buildElasticsearchRequest(ctx, ragConfig)
+		requestBodies = [][]byte{body}
 	case "custom":
-		requestBody, buildErr = r.buildCustomRequest(ctx, ragConfig, apiConfig.RequestTemplate)
+		var body []byte
+		body, buildErr = r.buildCustomRequest(ctx, ragConfig, apiConfig.RequestTemplate)
+		requestBodies = [][]byte{body}
 	default:
 		return "", fmt.Errorf("unsupported request format: %s", apiConfig.RequestFormat)
 	}
@@ -116,10 +131,55 @@ func (r *OpenAIRouter) retrieveFromExternalAPI(traceCtx context.Context, ctx *Re
 		return "", fmt.Errorf("failed to build request: %w", buildErr)
 	}
 
-	// Create HTTP request
+	topK := 5
+	if ragConfig.TopK != nil {
+		topK = *ragConfig.TopK
+	}
+
+	// A document that several windows retrieve is kept once, at the rank the
+	// first window that found it gave it.
+	var documents []string
+	seen := make(map[string]struct{})
+	var totalLatency float64
+	for _, requestBody := range requestBodies {
+		apiResponse, latency, sendErr := r.sendExternalRAGRequest(traceCtx, apiConfig, requestBody)
+		totalLatency += latency
+		if sendErr != nil {
+			return "", sendErr
+		}
+		windowDocuments, extractErr := r.extractDocumentsFromResponse(apiResponse, apiConfig.RequestFormat)
+		if extractErr != nil {
+			return "", fmt.Errorf("failed to extract context: %w", extractErr)
+		}
+		for _, document := range windowDocuments {
+			if _, duplicate := seen[document]; duplicate {
+				continue
+			}
+			seen[document] = struct{}{}
+			documents = append(documents, document)
+		}
+	}
+	ctx.RAGRetrievalLatency = totalLatency
+
+	if len(documents) == 0 {
+		return "", fmt.Errorf("no content found in %s response", apiConfig.RequestFormat)
+	}
+	if topK > 0 && len(documents) > topK {
+		documents = documents[:topK]
+	}
+
+	logging.Infof("Retrieved %d documents from external API over %d query window(s) (latency: %.3fs, format: %s)",
+		len(documents), len(requestBodies), totalLatency, apiConfig.RequestFormat)
+	return strings.Join(documents, "\n\n---\n\n"), nil
+}
+
+// sendExternalRAGRequest posts one request body and decodes the response,
+// returning how long the call took so a caller that sends several can report
+// their total.
+func (r *OpenAIRouter) sendExternalRAGRequest(traceCtx context.Context, apiConfig *config.ExternalAPIRAGConfig, requestBody []byte) (map[string]interface{}, float64, error) {
 	req, err := http.NewRequestWithContext(traceCtx, "POST", apiConfig.Endpoint, bytes.NewBuffer(requestBody))
 	if err != nil {
-		return "", fmt.Errorf("failed to create request: %w", err)
+		return nil, 0, fmt.Errorf("failed to create request: %w", err)
 	}
 
 	// Set headers
@@ -132,14 +192,14 @@ func (r *OpenAIRouter) retrieveFromExternalAPI(traceCtx context.Context, ctx *Re
 
 		// Validate header name
 		if validateErr := validateHeaderName(authHeader); validateErr != nil {
-			return "", fmt.Errorf("invalid auth header name: %w", validateErr)
+			return nil, 0, fmt.Errorf("invalid auth header name: %w", validateErr)
 		}
 
 		// Validate and sanitize API key to prevent header injection
 		sanitizedAPIKey, validateErr := validateHeaderValue(apiConfig.APIKey)
 		if validateErr != nil {
 			logging.Errorf("Failed to sanitize API key: %v", validateErr)
-			return "", fmt.Errorf("invalid API key format")
+			return nil, 0, fmt.Errorf("invalid API key format")
 		}
 
 		req.Header.Set(authHeader, fmt.Sprintf("Bearer %s", sanitizedAPIKey))
@@ -178,36 +238,27 @@ func (r *OpenAIRouter) retrieveFromExternalAPI(traceCtx context.Context, ctx *Re
 	start := time.Now()
 	resp, err := client.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("API request failed: %w", err)
+		return nil, 0, fmt.Errorf("API request failed: %w", err)
 	}
 	defer func() {
 		_ = resp.Body.Close()
 	}()
 
 	latency := time.Since(start).Seconds()
-	ctx.RAGRetrievalLatency = latency
 
 	if resp.StatusCode != http.StatusOK {
 		// Limit error response body size to prevent memory exhaustion
 		const maxErrorBodySize = 1024 * 10 // 10KB limit
 		limitedReader := io.LimitReader(resp.Body, maxErrorBodySize)
 		body, _ := io.ReadAll(limitedReader)
-		return "", fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(body))
+		return nil, latency, fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(body))
 	}
 
 	apiResponse, decodeErr := decodeExternalRAGResponse(resp.Body, apiConfig.MaxResponseBytes)
 	if decodeErr != nil {
-		return "", fmt.Errorf("failed to parse response: %w", decodeErr)
+		return nil, latency, fmt.Errorf("failed to parse response: %w", decodeErr)
 	}
-
-	// Extract context based on format
-	context, err := r.extractContextFromResponse(apiResponse, apiConfig.RequestFormat)
-	if err != nil {
-		return "", fmt.Errorf("failed to extract context: %w", err)
-	}
-
-	logging.Infof("Retrieved context from external API (latency: %.3fs, format: %s)", latency, apiConfig.RequestFormat)
-	return context, nil
+	return apiResponse, latency, nil
 }
 
 func decodeExternalRAGResponse(body io.Reader, maxResponseBytes int64) (map[string]interface{}, error) {
@@ -227,13 +278,7 @@ func decodeExternalRAGResponse(body io.Reader, maxResponseBytes int64) (map[stri
 }
 
 // buildPineconeRequest builds a Pinecone query request
-func (r *OpenAIRouter) buildPineconeRequest(ctx *RequestContext, ragConfig *config.RAGPluginConfig) ([]byte, error) {
-	// Generate embedding
-	queryEmbedding, err := candle_binding.GetEmbedding(ctx.UserContent, 0)
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate embedding: %w", err)
-	}
-
+func (r *OpenAIRouter) buildPineconeRequest(queryEmbedding []float32, ragConfig *config.RAGPluginConfig) ([]byte, error) {
 	topK := 5
 	if ragConfig.TopK != nil {
 		topK = *ragConfig.TopK
@@ -250,13 +295,7 @@ func (r *OpenAIRouter) buildPineconeRequest(ctx *RequestContext, ragConfig *conf
 }
 
 // buildWeaviateRequest builds a Weaviate query request
-func (r *OpenAIRouter) buildWeaviateRequest(ctx *RequestContext, ragConfig *config.RAGPluginConfig) ([]byte, error) {
-	// Generate embedding
-	queryEmbedding, err := candle_binding.GetEmbedding(ctx.UserContent, 0)
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate embedding: %w", err)
-	}
-
+func (r *OpenAIRouter) buildWeaviateRequest(queryEmbedding []float32, ragConfig *config.RAGPluginConfig) ([]byte, error) {
 	topK := 5
 	if ragConfig.TopK != nil {
 		topK = *ragConfig.TopK
@@ -352,7 +391,7 @@ func (r *OpenAIRouter) buildCustomRequest(ctx *RequestContext, ragConfig *config
 }
 
 // extractContextFromResponse extracts context from API response based on format
-func (r *OpenAIRouter) extractContextFromResponse(response map[string]interface{}, format string) (string, error) {
+func (r *OpenAIRouter) extractDocumentsFromResponse(response map[string]interface{}, format string) ([]string, error) {
 	switch format {
 	case "pinecone":
 		return r.extractPineconeContext(response)
@@ -363,10 +402,10 @@ func (r *OpenAIRouter) extractContextFromResponse(response map[string]interface{
 	case "custom":
 		// For custom format, assume response has a "content" or "text" field
 		if content, ok := response["content"].(string); ok {
-			return content, nil
+			return []string{content}, nil
 		}
 		if text, ok := response["text"].(string); ok {
-			return text, nil
+			return []string{text}, nil
 		}
 		// Try to extract from results array
 		if results, ok := response["results"].([]interface{}); ok {
@@ -380,19 +419,19 @@ func (r *OpenAIRouter) extractContextFromResponse(response map[string]interface{
 					}
 				}
 			}
-			return strings.Join(parts, "\n\n---\n\n"), nil
+			return parts, nil
 		}
-		return "", fmt.Errorf("unable to extract context from custom response format")
+		return nil, fmt.Errorf("unable to extract context from custom response format")
 	default:
-		return "", fmt.Errorf("unknown response format: %s", format)
+		return nil, fmt.Errorf("unknown response format: %s", format)
 	}
 }
 
 // extractPineconeContext extracts context from Pinecone response
-func (r *OpenAIRouter) extractPineconeContext(response map[string]interface{}) (string, error) {
+func (r *OpenAIRouter) extractPineconeContext(response map[string]interface{}) ([]string, error) {
 	matches, ok := response["matches"].([]interface{})
 	if !ok {
-		return "", fmt.Errorf("no matches in Pinecone response")
+		return nil, fmt.Errorf("no matches in Pinecone response")
 	}
 
 	var parts []string
@@ -408,28 +447,24 @@ func (r *OpenAIRouter) extractPineconeContext(response map[string]interface{}) (
 		}
 	}
 
-	if len(parts) == 0 {
-		return "", fmt.Errorf("no content found in Pinecone matches")
-	}
-
-	return strings.Join(parts, "\n\n---\n\n"), nil
+	return parts, nil
 }
 
 // extractWeaviateContext extracts context from Weaviate response
-func (r *OpenAIRouter) extractWeaviateContext(response map[string]interface{}) (string, error) {
+func (r *OpenAIRouter) extractWeaviateContext(response map[string]interface{}) ([]string, error) {
 	data, ok := response["data"].(map[string]interface{})
 	if !ok {
-		return "", fmt.Errorf("no data in Weaviate response")
+		return nil, fmt.Errorf("no data in Weaviate response")
 	}
 
 	get, ok := data["Get"].(map[string]interface{})
 	if !ok {
-		return "", fmt.Errorf("no Get in Weaviate response")
+		return nil, fmt.Errorf("no Get in Weaviate response")
 	}
 
 	document, ok := get["Document"].([]interface{})
 	if !ok {
-		return "", fmt.Errorf("no Document in Weaviate response")
+		return nil, fmt.Errorf("no Document in Weaviate response")
 	}
 
 	var parts []string
@@ -441,23 +476,19 @@ func (r *OpenAIRouter) extractWeaviateContext(response map[string]interface{}) (
 		}
 	}
 
-	if len(parts) == 0 {
-		return "", fmt.Errorf("no content found in Weaviate documents")
-	}
-
-	return strings.Join(parts, "\n\n---\n\n"), nil
+	return parts, nil
 }
 
 // extractElasticsearchContext extracts context from Elasticsearch response
-func (r *OpenAIRouter) extractElasticsearchContext(response map[string]interface{}) (string, error) {
+func (r *OpenAIRouter) extractElasticsearchContext(response map[string]interface{}) ([]string, error) {
 	hits, ok := response["hits"].(map[string]interface{})
 	if !ok {
-		return "", fmt.Errorf("no hits in Elasticsearch response")
+		return nil, fmt.Errorf("no hits in Elasticsearch response")
 	}
 
 	hitsArray, ok := hits["hits"].([]interface{})
 	if !ok {
-		return "", fmt.Errorf("no hits array in Elasticsearch response")
+		return nil, fmt.Errorf("no hits array in Elasticsearch response")
 	}
 
 	var parts []string
@@ -473,9 +504,5 @@ func (r *OpenAIRouter) extractElasticsearchContext(response map[string]interface
 		}
 	}
 
-	if len(parts) == 0 {
-		return "", fmt.Errorf("no content found in Elasticsearch hits")
-	}
-
-	return strings.Join(parts, "\n\n---\n\n"), nil
+	return parts, nil
 }

--- a/src/semantic-router/pkg/extproc/req_filter_rag_milvus.go
+++ b/src/semantic-router/pkg/extproc/req_filter_rag_milvus.go
@@ -6,7 +6,6 @@ import (
 	"regexp"
 	"strings"
 
-	candle_binding "github.com/vllm-project/semantic-router/candle-binding"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/cache"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
@@ -48,8 +47,9 @@ func (r *OpenAIRouter) retrieveFromMilvus(traceCtx context.Context, ctx *Request
 		topK = *ragConfig.TopK
 	}
 
-	// Generate embedding for query
-	queryEmbedding, err := candle_binding.GetEmbedding(query, 0) // Auto-detect dimension
+	// Generate one embedding per window of the query, so a long query is not
+	// searched by its opening alone.
+	queryEmbeddings, err := ragQueryEmbeddings(query)
 	if err != nil {
 		// Log full error internally but don't expose it to avoid information disclosure
 		logging.Errorf("Failed to generate embedding for RAG query: %v", err)
@@ -86,21 +86,26 @@ func (r *OpenAIRouter) retrieveFromMilvus(traceCtx context.Context, ctx *Request
 	// Use MilvusCache SearchDocuments method
 	// Pass empty strings/0 for vector field config to use cache defaults
 	// If RAG collection has different config, these can be added to MilvusRAGConfig
-	contextParts, scores, err := milvusCache.SearchDocuments(
-		traceCtx,
-		collectionName,
-		queryEmbedding,
-		threshold,
-		topK,
-		filterExpr,
-		contentField,
-		"", // vectorFieldName - use cache default
-		"", // metricType - use cache default
-		0,  // ef - use cache default
-	)
-	if err != nil {
-		return "", fmt.Errorf("milvus search failed: %w", err)
+	var hits ragHits
+	for _, queryEmbedding := range queryEmbeddings {
+		windowParts, windowScores, searchErr := milvusCache.SearchDocuments(
+			traceCtx,
+			collectionName,
+			queryEmbedding,
+			threshold,
+			topK,
+			filterExpr,
+			contentField,
+			"", // vectorFieldName - use cache default
+			"", // metricType - use cache default
+			0,  // ef - use cache default
+		)
+		if searchErr != nil {
+			return "", fmt.Errorf("milvus search failed: %w", searchErr)
+		}
+		hits.add(windowParts, windowScores)
 	}
+	contextParts, scores := hits.top(topK)
 
 	if len(contextParts) == 0 {
 		return "", fmt.Errorf("no results above similarity threshold %.3f", threshold)

--- a/src/semantic-router/pkg/extproc/req_filter_rag_qdrant.go
+++ b/src/semantic-router/pkg/extproc/req_filter_rag_qdrant.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	candle_binding "github.com/vllm-project/semantic-router/candle-binding"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/cache"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
@@ -55,23 +54,28 @@ func (r *OpenAIRouter) retrieveFromQdrant(traceCtx context.Context, ctx *Request
 		topK = *ragConfig.TopK
 	}
 
-	queryEmbedding, err := candle_binding.GetEmbedding(query, 0)
+	queryEmbeddings, err := ragQueryEmbeddings(query)
 	if err != nil {
 		logging.Errorf("Failed to generate embedding for Qdrant RAG query: %v", err)
 		return "", fmt.Errorf("failed to generate embedding")
 	}
 
-	contextParts, scores, err := qdrantCache.SearchCollection(
-		traceCtx,
-		collectionName,
-		queryEmbedding,
-		threshold,
-		topK,
-		contentField,
-	)
-	if err != nil {
-		return "", fmt.Errorf("qdrant search failed: %w", err)
+	var hits ragHits
+	for _, queryEmbedding := range queryEmbeddings {
+		windowParts, windowScores, searchErr := qdrantCache.SearchCollection(
+			traceCtx,
+			collectionName,
+			queryEmbedding,
+			threshold,
+			topK,
+			contentField,
+		)
+		if searchErr != nil {
+			return "", fmt.Errorf("qdrant search failed: %w", searchErr)
+		}
+		hits.add(windowParts, windowScores)
 	}
+	contextParts, scores := hits.top(topK)
 
 	if len(contextParts) == 0 {
 		return "", fmt.Errorf("no results above similarity threshold %.3f", threshold)

--- a/src/semantic-router/pkg/extproc/req_filter_rag_windowing.go
+++ b/src/semantic-router/pkg/extproc/req_filter_rag_windowing.go
@@ -1,0 +1,104 @@
+package extproc
+
+import (
+	"sort"
+
+	candle_binding "github.com/vllm-project/semantic-router/candle-binding"
+)
+
+// ragQueryWindowLimit caps how many windows of one query are searched. Each
+// window costs an embedding and a store round trip, and a query long enough to
+// need more than this has already been sampled from end to end.
+const ragQueryWindowLimit = 8
+
+// ragQueryEmbeddings returns one embedding per window of the query.
+//
+// Embedding a long query once reads only its first window, so two questions
+// behind the same long preamble produce the same vector and retrieve the same
+// documents. Every window is embedded instead, and the caller searches with each
+// and keeps a document's best score, which is the aggregation that ranks best
+// over passages of a long input.
+func ragQueryEmbeddings(query string) ([][]float32, error) {
+	windows, err := candle_binding.TextWindows(query, 0)
+	if err != nil {
+		return nil, err
+	}
+	if len(windows) <= 1 {
+		embedding, embedErr := candle_binding.GetEmbedding(query, 0)
+		if embedErr != nil {
+			return nil, embedErr
+		}
+		return [][]float32{embedding}, nil
+	}
+
+	sampled := sampleQueryWindows(windows, ragQueryWindowLimit)
+	embeddings := make([][]float32, 0, len(sampled))
+	for _, window := range sampled {
+		embedding, embedErr := candle_binding.GetEmbedding(query[window.Start:window.End], 0)
+		if embedErr != nil {
+			return nil, embedErr
+		}
+		embeddings = append(embeddings, embedding)
+	}
+	return embeddings, nil
+}
+
+// sampleQueryWindows keeps at most limit windows, evenly spaced and always
+// including the first and the last, because the question a long query asks sits
+// at either end of it about as often.
+func sampleQueryWindows(windows []candle_binding.TextWindow, limit int) []candle_binding.TextWindow {
+	if limit <= 0 || len(windows) <= limit {
+		return windows
+	}
+	if limit == 1 {
+		return windows[:1]
+	}
+	kept := make([]candle_binding.TextWindow, limit)
+	for i := range kept {
+		kept[i] = windows[i*(len(windows)-1)/(limit-1)]
+	}
+	return kept
+}
+
+// ragHits collects the documents the windows of one query retrieved, keeping the
+// best score each document reached.
+type ragHits struct {
+	best map[string]float32
+}
+
+func (h *ragHits) add(contents []string, scores []float32) {
+	if h.best == nil {
+		h.best = make(map[string]float32, len(contents))
+	}
+	for i, content := range contents {
+		var score float32
+		if i < len(scores) {
+			score = scores[i]
+		}
+		if current, seen := h.best[content]; !seen || score > current {
+			h.best[content] = score
+		}
+	}
+}
+
+// top returns the documents by descending best score, at most topK of them.
+func (h *ragHits) top(topK int) ([]string, []float32) {
+	contents := make([]string, 0, len(h.best))
+	for content := range h.best {
+		contents = append(contents, content)
+	}
+	sort.Slice(contents, func(i, j int) bool {
+		if h.best[contents[i]] == h.best[contents[j]] {
+			return contents[i] < contents[j]
+		}
+		return h.best[contents[i]] > h.best[contents[j]]
+	})
+	if topK > 0 && len(contents) > topK {
+		contents = contents[:topK]
+	}
+	scores := make([]float32, len(contents))
+	for i, content := range contents {
+		scores[i] = h.best[content]
+	}
+	return contents, scores
+}

--- a/src/semantic-router/pkg/extproc/req_filter_rag_windowing_test.go
+++ b/src/semantic-router/pkg/extproc/req_filter_rag_windowing_test.go
@@ -1,0 +1,74 @@
+package extproc
+
+import (
+	"testing"
+
+	candle_binding "github.com/vllm-project/semantic-router/candle-binding"
+)
+
+func TestSampleQueryWindowsKeepsBothEnds(t *testing.T) {
+	windows := make([]candle_binding.TextWindow, 47)
+	for i := range windows {
+		windows[i] = candle_binding.TextWindow{Start: i * 10, End: i*10 + 10}
+	}
+
+	kept := sampleQueryWindows(windows, 8)
+	if len(kept) != 8 {
+		t.Fatalf("kept %d windows, want 8", len(kept))
+	}
+	if kept[0] != windows[0] {
+		t.Errorf("first window is %v, want %v", kept[0], windows[0])
+	}
+	if kept[len(kept)-1] != windows[len(windows)-1] {
+		t.Errorf("last window is %v, want %v", kept[len(kept)-1], windows[len(windows)-1])
+	}
+	for i := 1; i < len(kept); i++ {
+		if kept[i].Start <= kept[i-1].Start {
+			t.Fatalf("windows are not in order at %d: %v then %v", i, kept[i-1], kept[i])
+		}
+	}
+}
+
+func TestSampleQueryWindowsBelowTheLimit(t *testing.T) {
+	windows := []candle_binding.TextWindow{{Start: 0, End: 10}, {Start: 5, End: 15}}
+	if kept := sampleQueryWindows(windows, 8); len(kept) != 2 {
+		t.Fatalf("kept %d windows, want both", len(kept))
+	}
+	if kept := sampleQueryWindows(windows, 1); len(kept) != 1 || kept[0] != windows[0] {
+		t.Fatalf("a limit of one keeps the first window, got %v", kept)
+	}
+}
+
+func TestRagHitsKeepBestScorePerDocument(t *testing.T) {
+	var hits ragHits
+	hits.add([]string{"alpha", "beta"}, []float32{0.30, 0.90})
+	hits.add([]string{"alpha", "gamma"}, []float32{0.80, 0.40})
+
+	contents, scores := hits.top(0)
+	if len(contents) != 3 {
+		t.Fatalf("kept %d documents, want 3", len(contents))
+	}
+	want := []struct {
+		content string
+		score   float32
+	}{{"beta", 0.90}, {"alpha", 0.80}, {"gamma", 0.40}}
+	for i, expected := range want {
+		if contents[i] != expected.content || scores[i] != expected.score {
+			t.Fatalf("rank %d is %q at %.2f, want %q at %.2f", i, contents[i], scores[i], expected.content, expected.score)
+		}
+	}
+
+	topContents, topScores := hits.top(2)
+	if len(topContents) != 2 || len(topScores) != 2 || topContents[0] != "beta" {
+		t.Fatalf("top 2 is %v at %v", topContents, topScores)
+	}
+}
+
+func TestRagHitsToleratesMissingScores(t *testing.T) {
+	var hits ragHits
+	hits.add([]string{"alpha", "beta"}, nil)
+	contents, scores := hits.top(0)
+	if len(contents) != 2 || len(scores) != 2 {
+		t.Fatalf("kept %v at %v", contents, scores)
+	}
+}

--- a/tools/make/rust.mk
+++ b/tools/make/rust.mk
@@ -14,6 +14,9 @@ TEST_GPU_DEVICE ?= 2
 # models from ../models unless those tests have been converted to skip cleanly.
 RUST_CI_LIB_TESTS ?= \
 	core::tokenization_test::test_tokenization_config_default \
+	core::tokenization_window::tests::test_window_ranges_cover_every_token \
+	core::tokenization_window::tests::test_window_ranges_overlap_on_a_short_stride \
+	core::tokenization_window::tests::test_window_ranges_edges \
 	core::tokenization_test::test_tokenization_config_custom \
 	ffi::embedding_test::test_truncate_embedding_renormalizes_prefix \
 	model_architectures::embedding::multimodal_embedding::tests::test_siglip_vision_encoder_loads_with_head_weights \


### PR DESCRIPTION
Closes #3385

## Purpose

The three RAG retrieval paths embedded the query with one call that truncates at the embedding window (`similarity.rs` tokenizes with `max_length.unwrap_or(512)` and right truncation), so only the first 512 tokens reached the store. Two questions behind the same long preamble embedded to the same vector and retrieved the same documents.

A query longer than the window is now split into overlapping windows, each window is embedded and searched, and a document keeps the best score it reached in any window. A query that already fits makes exactly one embedding call and one search, as before.

Three choices worth naming:

* **Best window, not the average.** Averaging the windows into one vector is the usual way to make a single embedding of a long input, and it is not enough here: measured below, it recovers the right document at 3,400 runes and loses it again at 16,680, because the one window carrying the question is diluted by the rest. Taking each window's own score and keeping a document's best is the aggregation that ranks best over passages of a long input in the retrieval literature (MaxP over FirstP, SumP and AvgP).
* **A cap of eight windows per query,** always keeping the first and the last and sampling evenly between them. Each window costs an embedding and a store round trip, and a question sits at either end of a long query about as often.
* **Windows overlap by half a window,** so a sentence one boundary cuts is whole inside its neighbour.

The change is scoped to retrieval. `get_text_embedding` keeps its meaning for every other caller, including the semantic cache that #3455 is giving a window check of its own.

## Test Plan

`make test-rust-ci`, `go test ./pkg/extproc/`, `scripts/gates.sh` for the CI PR lane, and a retrieval measurement against the shipped path with `models/mom-embedding-light` on CPU.

## Test Result

Three Rust tests for the window ranges, registered in `RUST_CI_LIB_TESTS`, and four Go tests for the window sampling and the best-score merge. `make test-rust-ci` passes 10 of 10 and the gates are green on all four lines.

Retrieval measured over a corpus of two documents, one about refunds and one about the audit log, with a question about refunds behind a repeated preamble. The column is the document the query retrieves:

| preamble | query length | windows used | before | after |
|---|---|---|---|---|
| none | 80 runes | 1 of 1 | refund | refund |
| 20 repeats | 3,400 runes | 2 of 2 | audit | refund |
| 100 repeats | 16,680 runes | 8 of 11 | audit | refund |
| 400 repeats | 66,480 runes | 8 of 47 | audit | refund |

The control question about the audit log retrieves the audit document in every row, before and after.
