### PR TITLE
[Bug] Point the evaluation registry at the mmbert32k checkpoints the router serves

### DIFF
--- a/src/training/model_eval/constants.py
+++ b/src/training/model_eval/constants.py
@@ -22,8 +22,8 @@ LANGUAGE_CODES = {
 # Registry of all MoM models (merged as well as LoRA)
 MODEL_REGISTRY = {
     "feedback": {
-        "id": "llm-semantic-router/mmbert-feedback-detector-merged",
-        "lora_id": "llm-semantic-router/mmbert-feedback-detector-lora",
+        "id": "llm-semantic-router/mmbert32k-feedback-detector-merged",
+        "lora_id": "llm-semantic-router/mmbert32k-feedback-detector-lora",
         "type": "text_classification",
         "hf_dataset": "llm-semantic-router/feedback-detector-dataset",
         "labels": ["SAT", "NEED_CLARIFICATION", "WRONG_ANSWER", "WANT_DIFFERENT"],
@@ -32,8 +32,8 @@ MODEL_REGISTRY = {
         "split": "validation",
     },
     "jailbreak": {
-        "id": "llm-semantic-router/mmbert-jailbreak-detector-merged",
-        "lora_id": "llm-semantic-router/mmbert-jailbreak-detector-lora",
+        "id": "llm-semantic-router/mmbert32k-jailbreak-detector-merged",
+        "lora_id": "llm-semantic-router/mmbert32k-jailbreak-detector-lora",
         "type": "text_classification",
         "hf_dataset": "llm-semantic-router/jailbreak-detection-dataset",
         "labels": ["safe", "unsafe"],
@@ -42,8 +42,8 @@ MODEL_REGISTRY = {
         "split": "test",
     },
     "fact-check": {
-        "id": "llm-semantic-router/mmbert-fact-check-merged",
-        "lora_id": "llm-semantic-router/mmbert-fact-check-lora",
+        "id": "llm-semantic-router/mmbert32k-factcheck-classifier-merged",
+        "lora_id": "llm-semantic-router/mmbert32k-factcheck-classifier-lora",
         "type": "text_classification",
         "hf_dataset": "llm-semantic-router/fact-check-classification-dataset",
         "labels": ["NO_FACT_CHECK_NEEDED", "FACT_CHECK_NEEDED"],
@@ -52,8 +52,8 @@ MODEL_REGISTRY = {
         "split": "test",
     },
     "intent": {
-        "id": "llm-semantic-router/mmbert-intent-classifier-merged",
-        "lora_id": "llm-semantic-router/mmbert-intent-classifier-lora",
+        "id": "llm-semantic-router/mmbert32k-intent-classifier-merged",
+        "lora_id": "llm-semantic-router/mmbert32k-intent-classifier-lora",
         "type": "text_classification",
         "hf_dataset": "TIGER-Lab/MMLU-Pro",
         "labels": [
@@ -77,8 +77,8 @@ MODEL_REGISTRY = {
         "split": "test",
     },
     "pii": {
-        "id": "llm-semantic-router/mmbert-pii-detector-merged",
-        "lora_id": "llm-semantic-router/mmbert-pii-detector-lora",
+        "id": "llm-semantic-router/mmbert32k-pii-detector-merged",
+        "lora_id": "llm-semantic-router/mmbert32k-pii-detector-lora",
         "type": "token_classification",
         "hf_dataset": "presidio",
         "labels": [

--- a/src/training/model_eval/tests/test_registry_matches_served_models.py
+++ b/src/training/model_eval/tests/test_registry_matches_served_models.py
@@ -1,0 +1,160 @@
+"""Contract tests tying the evaluation registry to the checkpoints the router serves.
+
+The repo writes the classifier model names down in three places and, until
+issue #3644, nothing tied them together:
+
+  * `tools/make/models.mk` decides what `make download-models` pulls,
+  * `config/config.yaml` decides what the router loads at runtime,
+  * `src/training/model_eval/constants.py` decides what the evaluation scores.
+
+The third drifted. For roughly seven months the registry named the older 8K
+`mmbert-*` repos while the router served the `mmbert32k-*` ones, so every
+accuracy, F1 and confusion matrix `mom_collection_eval.py` produced was a
+correct measurement of a checkpoint nobody runs. Nothing failed along the way,
+because the 8K repos still exist on the Hub and still load.
+
+These tests fail if the three lists come apart again.
+
+See https://github.com/vllm-project/semantic-router/issues/3644.
+
+`make test-training-contracts` runs on a stdlib-only system python3, so the
+makefile and the router config are read with `re` rather than with a make
+parser or PyYAML.
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+from src.training.model_eval.constants import MODEL_REGISTRY
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[4]
+MODELS_MK = REPOSITORY_ROOT / "tools/make/models.mk"
+ROUTER_CONFIG = REPOSITORY_ROOT / "config/config.yaml"
+
+# Registry role -> the `model_catalog.system` key in config.yaml that names the
+# checkpoint the router loads for that role. The two vocabularies grew up
+# separately, so the mapping has to be written out rather than derived.
+ROLE_TO_CONFIG_KEY = {
+    "feedback": "feedback_detector",
+    "jailbreak": "prompt_guard",
+    "fact-check": "fact_check_classifier",
+    "intent": "domain_classifier",
+    "pii": "pii_classifier",
+}
+
+# What the registry used to say. These repos still resolve, which is exactly
+# why the drift stayed invisible.
+LEGACY_PREFIX = "llm-semantic-router/mmbert-"
+
+MERGED_SUFFIX = "-merged"
+LORA_SUFFIX = "-lora"
+
+
+def read_make_variable(name: str) -> list[str]:
+    """Return the words assigned to a `:=` variable in models.mk.
+
+    Understands the backslash-continued list style the file uses for the model
+    name lists.
+    """
+    collecting = False
+    words: list[str] = []
+    for line in MODELS_MK.read_text(encoding="utf-8").splitlines():
+        if not collecting:
+            assignment = re.match(rf"{re.escape(name)}\s*:=(.*)$", line)
+            if assignment is None:
+                continue
+            collecting = True
+            rest = assignment.group(1)
+        else:
+            rest = line
+        stripped = rest.rstrip()
+        continued = stripped.endswith("\\")
+        words.extend(stripped.rstrip("\\").split())
+        if not continued:
+            return words
+    raise AssertionError(f"{name} is not assigned in {MODELS_MK}")
+
+
+def read_served_model(config_key: str) -> str:
+    """Return the checkpoint basename config.yaml gives one system classifier."""
+    config = ROUTER_CONFIG.read_text(encoding="utf-8")
+    matches = re.findall(
+        rf"^\s*{re.escape(config_key)}:\s*models/(\S+)\s*$", config, re.MULTILINE
+    )
+    if len(matches) != 1:
+        raise AssertionError(
+            f"expected exactly one '{config_key}: models/...' line in "
+            f"{ROUTER_CONFIG}, found {len(matches)}"
+        )
+    return matches[0]
+
+
+HF_ORG = read_make_variable("HF_ORG")[0]
+
+
+class EvaluationRegistryMatchesServedModels(unittest.TestCase):
+    def test_registry_covers_every_role_that_has_a_served_checkpoint(self):
+        self.assertEqual(
+            set(MODEL_REGISTRY),
+            set(ROLE_TO_CONFIG_KEY),
+            "a role gained or lost a registry entry; update ROLE_TO_CONFIG_KEY "
+            "so the rest of this file keeps checking it",
+        )
+
+    def test_merged_ids_match_the_makefile_download_list(self):
+        expected = {
+            f"{HF_ORG}/{name}"
+            for name in read_make_variable("MMBERT_32K_MERGED_MODELS")
+        }
+        actual = {config["id"] for config in MODEL_REGISTRY.values()}
+        self.assertEqual(
+            actual,
+            expected,
+            "the evaluation registry and MMBERT_32K_MERGED_MODELS name "
+            "different checkpoints",
+        )
+
+    def test_lora_ids_match_the_makefile_adapter_list(self):
+        expected = {
+            f"{HF_ORG}/{name}"
+            for name in read_make_variable("MMBERT_32K_LORA_ADAPTERS")
+        }
+        actual = {config["lora_id"] for config in MODEL_REGISTRY.values()}
+        self.assertEqual(
+            actual,
+            expected,
+            "the evaluation registry and MMBERT_32K_LORA_ADAPTERS name "
+            "different adapters",
+        )
+
+    def test_each_role_scores_the_checkpoint_the_router_loads(self):
+        for role, config_key in ROLE_TO_CONFIG_KEY.items():
+            with self.subTest(role=role):
+                self.assertEqual(
+                    MODEL_REGISTRY[role]["id"],
+                    f"{HF_ORG}/{read_served_model(config_key)}",
+                    f"the evaluation scores a different checkpoint than the "
+                    f"router serves as {config_key}",
+                )
+
+    def test_merged_and_lora_ids_name_the_same_artifact(self):
+        # Catches a half-finished rename: fact-check is the one role whose repo
+        # is not its 8K name with a prefix bolted on, so it is the one most
+        # likely to be updated on only one of its two lines.
+        for role, config in MODEL_REGISTRY.items():
+            with self.subTest(role=role):
+                self.assertTrue(config["id"].endswith(MERGED_SUFFIX))
+                self.assertTrue(config["lora_id"].endswith(LORA_SUFFIX))
+                self.assertEqual(
+                    config["id"].removesuffix(MERGED_SUFFIX),
+                    config["lora_id"].removesuffix(LORA_SUFFIX),
+                )
+
+    def test_no_role_still_points_at_a_legacy_8k_repo(self):
+        for role, config in MODEL_REGISTRY.items():
+            with self.subTest(role=role):
+                self.assertFalse(config["id"].startswith(LEGACY_PREFIX))
+                self.assertFalse(config["lora_id"].startswith(LEGACY_PREFIX))


### PR DESCRIPTION

Closes #3644

## Purpose

The evaluation was scoring the wrong models.

`src/training/model_eval/constants.py` named the old 8K `mmbert-*` repos, but the router serves the `mmbert32k-*` ones. So every accuracy, F1 and confusion matrix `mom_collection_eval.py` printed was a correct number about a checkpoint nobody runs. Nothing ever failed, because the old repos still exist and still load fine.

This points all five roles at the names already written down in `tools/make/models.mk`, so the eval measures what we actually ship.


The second commit adds a contract test. The root cause here is that we keep model names in three places (`constants.py`, `tools/make/models.mk`, `config/config.yaml`) and nothing checked them against each other, which is how this sat unnoticed for about seven months. The test reads all three and fails if they drift apart again. It is stdlib-only, so it runs under the plain `python3` that `make test-training-contracts` uses. No Makefile change needed, the target already picks up that directory.

## Test Plan

```bash
# lint, format and the contract suites CI runs
make check BASE_REF=origin/main
make test-training-contracts

# check the new test actually bites: run it against the old registry
git stash && git show origin/main:src/training/model_eval/constants.py > src/training/model_eval/constants.py
python3 -m unittest discover -s src/training/model_eval/tests -p 'test_registry*.py'

# confirm every new id is a real repo
curl -s -o /dev/null -w "%{http_code}\n" https://huggingface.co/api/models/llm-semantic-router/<each id>

# run the eval end to end on two of the repointed checkpoints
python src/training/model_eval/mom_collection_eval.py --model intent --limit 200 --batch_size 16 --device cpu
python src/training/model_eval/mom_collection_eval.py --model jailbreak --limit 200 --batch_size 16 --device cpu
```

## Test Result

`make check BASE_REF=origin/main` exits 0. `make test-training-contracts` is green: 6 suites, 139 tests.

All 10 new ids (5 merged, 5 LoRA) return 200 on the Hub.

The new test does its job. Against the old registry, 4 of its 6 tests fail across all 5 roles. I also tried a half-finished fact-check rename, where the merged id gets updated but the adapter is left behind, and 3 tests catch it.

Both repointed checkpoints load and evaluate cleanly on CPU. Here is what the same run gives on each checkpoint, first 200 samples of the test split, batch 16, CPU:

| role | | accuracy | F1 | p50 latency |
|---|---|---|---|---|
| intent | served 32K (this PR) | 0.9100 | 0.9529 | 101 ms |
| | old 8K (what it scored before) | 0.8400 | 0.9130 | 97 ms |
| | **change** | **+7.0 pts** | **+4.0 pts** | |
| jailbreak | served 32K (this PR) | 0.7500 | 0.7385 | 972 ms |
| | old 8K (what it scored before) | 0.8950 | 0.8949 | 1054 ms |
| | **change** | **-14.5 pts** | **-15.6 pts** | |


---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category, such as `[Feature]`, `[Bug]`, `[Docs]`, `[Test]`, `[Research]`, `[Community]`, or `[CI/Build]`
- [x] The title does not stack prefixes such as `[Router][Docs]`; affected modules belong in labels and the PR body
- [x] The PR links an `accepted` issue with exactly one owner: one `wg/*` label for project work or `owner/maintainers` for repository governance
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.