### PR TITLE
[Feature] Add Looper attempt telemetry

### DIFF
--- a/e2e/profiles/looper/manifests/fake-backend.yaml
+++ b/e2e/profiles/looper/manifests/fake-backend.yaml
@@ -11,6 +11,8 @@ data:
     RESPONSES = {
         "ratings-model-a": ("answer-from-ratings-model-a", 3, 2),
         "ratings-model-b": ("answer-from-ratings-model-b", 7, 4),
+        "confidence-model-low": ("private-low-confidence-candidate", 5, 2),
+        "confidence-model-high": ("selected-high-confidence-answer", 7, 3),
         "fusion-panel-valid": ("usable-fusion-panel-answer", 11, 3),
     }
 
@@ -100,16 +102,23 @@ data:
                 return
 
             content, prompt_tokens, completion_tokens = RESPONSES[model]
+            choice = {
+                "index": 0,
+                "message": {"role": "assistant", "content": content},
+                "finish_reason": "stop",
+            }
+            if model.startswith("confidence-model-"):
+                choice["logprobs"] = {"content": [{
+                    "token": "answer",
+                    "logprob": -2.0 if model.endswith("low") else -0.1,
+                    "top_logprobs": [],
+                }]}
             self.send_json(200, {
                 "id": "chatcmpl-looper-e2e-" + model,
                 "object": "chat.completion",
                 "created": 1,
                 "model": model,
-                "choices": [{
-                    "index": 0,
-                    "message": {"role": "assistant", "content": content},
-                    "finish_reason": "stop",
-                }],
+                "choices": [choice],
                 "usage": {
                     "prompt_tokens": prompt_tokens,
                     "completion_tokens": completion_tokens,

--- a/e2e/profiles/looper/profile.go
+++ b/e2e/profiles/looper/profile.go
@@ -62,6 +62,7 @@ func (p *Profile) GetTestCases() []string {
 	return []string{
 		"looper-ratings-happy-path",
 		"looper-fusion-usable-quorum",
+		"looper-confidence-telemetry",
 	}
 }
 

--- a/e2e/profiles/looper/values.yaml
+++ b/e2e/profiles/looper/values.yaml
@@ -19,6 +19,18 @@ config:
             provider: vllm
             endpoint: looper-fake-backend.default.svc.cluster.local:8000
             weight: 1
+      - name: confidence-model-low
+        provider_model_id: confidence-model-low
+        backend_refs:
+          - name: looper-fake-backend
+            endpoint: looper-fake-backend.default.svc.cluster.local:8000
+            weight: 1
+      - name: confidence-model-high
+        provider_model_id: confidence-model-high
+        backend_refs:
+          - name: looper-fake-backend
+            endpoint: looper-fake-backend.default.svc.cluster.local:8000
+            weight: 1
       - name: fusion-panel-valid
         provider_model_id: fusion-panel-valid
         backend_refs:
@@ -47,6 +59,8 @@ config:
     modelCards:
       - name: ratings-model-a
       - name: ratings-model-b
+      - name: confidence-model-low
+      - name: confidence-model-high
       - name: fusion-panel-valid
       - name: fusion-panel-empty
       - name: fusion-panel-fail
@@ -62,6 +76,11 @@ config:
           operator: OR
           keywords:
             - __LOOPER_FUSION_QUORUM_PROBE__
+          case_sensitive: true
+        - name: looper_confidence_trace_probe_keywords
+          operator: OR
+          keywords:
+            - __LOOPER_CONFIDENCE_TRACE_PROBE__
           case_sensitive: true
     decisions:
       - name: looper_ratings_decision
@@ -82,6 +101,26 @@ config:
           ratings:
             max_concurrent: 2
             on_error: skip
+      - name: looper_confidence_trace_decision
+        description: Deterministic Confidence attempt telemetry for issue 2855
+        priority: 120
+        rules:
+          operator: OR
+          conditions:
+            - type: keyword
+              name: looper_confidence_trace_probe_keywords
+        modelRefs:
+          - model: confidence-model-low
+            use_reasoning: false
+          - model: confidence-model-high
+            use_reasoning: false
+        algorithm:
+          type: confidence
+          confidence:
+            confidence_method: avg_logprob
+            threshold: 0.72
+            escalation_order: declared
+            on_error: fail
       - name: looper_fusion_quorum_decision
         description: Reject Fusion synthesis when usable panel responses do not meet quorum
         priority: 110
@@ -124,7 +163,9 @@ config:
       response_api:
         enabled: false
       router_replay:
-        enabled: false
+        enabled: true
+        store_backend: memory
+        async_writes: false
     stores:
       response_cache:
         enabled: false

--- a/e2e/testcases/looper_confidence_telemetry.go
+++ b/e2e/testcases/looper_confidence_telemetry.go
@@ -29,6 +29,7 @@ import (
 	pkgtestcases "github.com/vllm-project/semantic-router/e2e/pkg/testcases"
 )
 
+// looperConfidenceTraceProbe selects the deterministic Confidence telemetry route.
 const looperConfidenceTraceProbe = "__LOOPER_CONFIDENCE_TRACE_PROBE__"
 
 func init() {

--- a/e2e/testcases/looper_confidence_telemetry.go
+++ b/e2e/testcases/looper_confidence_telemetry.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testcases
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/vllm-project/semantic-router/e2e/pkg/fixtures"
+	pkgtestcases "github.com/vllm-project/semantic-router/e2e/pkg/testcases"
+)
+
+const looperConfidenceTraceProbe = "__LOOPER_CONFIDENCE_TRACE_PROBE__"
+
+func init() {
+	pkgtestcases.Register("looper-confidence-telemetry", pkgtestcases.TestCase{
+		Description: "Verify Confidence attempt diagnostics in Router Replay and bounded Prometheus metrics",
+		Tags:        []string{"kubernetes", "routing", "looper", "observability"},
+		Fn:          testLooperConfidenceTelemetry,
+	})
+}
+
+func testLooperConfidenceTelemetry(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	localPort, stop, err := setupServiceConnection(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+	defer stop()
+
+	response, err := sendLocalChatCompletion(ctx, localPort, "MoM", looperConfidenceTraceProbe, 30*time.Second)
+	if err != nil {
+		return fmt.Errorf("confidence telemetry request: %w", err)
+	}
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("confidence telemetry request: %s", formatUnexpectedChatCompletionStatus(response))
+	}
+	management, err := fixtures.OpenRouterAPISession(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+	defer management.Close()
+	replayID, err := fetchFirstReplayRecordID(
+		management,
+		"/v1/router_replay?decision=looper_confidence_trace_decision&limit=1",
+		false,
+	)
+	if err != nil {
+		return fmt.Errorf("list confidence replay: %w", err)
+	}
+
+	replayResponse, err := fixtures.DoGETRequest(ctx, management.HTTPClient(15*time.Second), management.URL("/v1/router_replay/"+replayID))
+	if err != nil {
+		return fmt.Errorf("fetch confidence replay: %w", err)
+	}
+	if replayResponse.StatusCode != http.StatusOK {
+		return fmt.Errorf("fetch confidence replay: status %d: %s", replayResponse.StatusCode, replayResponse.Body)
+	}
+	var replay struct {
+		RouteDiagnostics struct {
+			Looper struct {
+				Attempts            []struct{} `json:"attempts"`
+				FinalAttemptOrdinal int        `json:"final_attempt_ordinal"`
+			} `json:"looper"`
+		} `json:"route_diagnostics"`
+	}
+	if decodeErr := replayResponse.DecodeJSON(&replay); decodeErr != nil {
+		return fmt.Errorf("decode confidence replay: %w", decodeErr)
+	}
+	if len(replay.RouteDiagnostics.Looper.Attempts) != 2 || replay.RouteDiagnostics.Looper.FinalAttemptOrdinal != 2 {
+		return fmt.Errorf("confidence replay attempts=%d final=%d, want 2 and 2", len(replay.RouteDiagnostics.Looper.Attempts), replay.RouteDiagnostics.Looper.FinalAttemptOrdinal)
+	}
+	if strings.Contains(string(replayResponse.Body), "private-low-confidence-candidate") {
+		return fmt.Errorf("confidence replay leaked candidate content")
+	}
+
+	metricsSession, err := fixtures.OpenSemanticRouterMetricsSession(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+	defer metricsSession.Close()
+	metricsBody, err := fetchMetrics(ctx, metricsSession)
+	if err != nil {
+		return err
+	}
+	for _, metric := range []string{"llm_looper_attempts_total", "llm_looper_execution_duration_seconds"} {
+		if !strings.Contains(metricsBody, metric) || !strings.Contains(metricsBody, `algorithm="confidence"`) {
+			return fmt.Errorf("metrics output missing Confidence series for %s", metric)
+		}
+	}
+	return nil
+}

--- a/e2e/testcases/router_replay_restart_recovery.go
+++ b/e2e/testcases/router_replay_restart_recovery.go
@@ -84,7 +84,7 @@ func triggerReplayRecordBeforeRestart(ctx context.Context, client *kubernetes.Cl
 	}
 	time.Sleep(3 * time.Second)
 
-	recordID, err := fetchFirstReplayRecordID(apiSession, opts.Verbose)
+	recordID, err := fetchFirstReplayRecordID(apiSession, "/v1/router_replay?limit=1", opts.Verbose)
 	if err != nil {
 		return "", err
 	}
@@ -112,10 +112,10 @@ type replayRecordSummary struct {
 	TurnIndex int    `json:"turn_index"`
 }
 
-// fetchFirstReplayRecordID calls GET /v1/router_replay?limit=1 and returns the
-// first record's ID. When verbose is true, prints the full JSON response.
-func fetchFirstReplayRecordID(managementSession *fixtures.ServiceSession, verbose bool) (string, error) {
-	raw, err := doRouterReplayManagementGET(context.Background(), managementSession, "/v1/router_replay?limit=1")
+// fetchFirstReplayRecordID returns the first record ID from a Replay list target.
+// When verbose is true, it prints the full JSON response.
+func fetchFirstReplayRecordID(managementSession *fixtures.ServiceSession, requestTarget string, verbose bool) (string, error) {
+	raw, err := doRouterReplayManagementGET(context.Background(), managementSession, requestTarget)
 	if err != nil {
 		return "", fmt.Errorf("GET /v1/router_replay failed: %w", err)
 	}

--- a/src/semantic-router/pkg/extproc/recorder_route_diagnostics.go
+++ b/src/semantic-router/pkg/extproc/recorder_route_diagnostics.go
@@ -30,6 +30,7 @@ func buildReplayRouteDiagnostics(
 		SelectionMethod:                ctx.VSRSelectionMethod,
 		SelectionReasoning:             ctx.VSRSelectionReasoning,
 		FusionQuorum:                   ctx.VSRFusionQuorum,
+		Looper:                         ctx.VSRLooperDiagnostics,
 		PromptHelperModel:              ctx.VSRPromptHelperModel,
 		PromptHelperPromptTokens:       ctx.VSRPromptHelperPromptTokens,
 		PromptHelperCompletionTokens:   ctx.VSRPromptHelperCompletionTokens,

--- a/src/semantic-router/pkg/extproc/req_filter_looper.go
+++ b/src/semantic-router/pkg/extproc/req_filter_looper.go
@@ -235,8 +235,9 @@ func (r *OpenAIRouter) recordSuccessfulLooperExecution(
 	reqCtx.VSRSelectedModel = resp.Model
 	reqCtx.VSRSelectionMethod = resp.AlgorithmType
 
-	// Capture router replay information if enabled
-	// ModelsUsed is the execution trace; resp.Model is the final response model.
+	// Capture router replay information if enabled. Detailed attempts remain in
+	// Replay; the public response surface keeps only aggregate Looper headers.
+	reqCtx.VSRLooperDiagnostics = looperReplayDiagnostics(resp.ExecutionTrace)
 	r.startRouterReplay(reqCtx, originalModel, resp.Model, decision.Name)
 	r.updateLooperReplayUsage(reqCtx, resp.Usage)
 	if resp.Usage.PromptTokens > 0 || resp.Usage.CompletionTokens > 0 {

--- a/src/semantic-router/pkg/extproc/req_filter_looper_failure.go
+++ b/src/semantic-router/pkg/extproc/req_filter_looper_failure.go
@@ -29,11 +29,12 @@ import (
 )
 
 type looperFailureEvidence struct {
-	algorithm    string
-	modelsUsed   []string
-	iterations   int
-	usage        looper.TokenUsage
-	fusionQuorum *routerreplay.FusionQuorumDiagnostics
+	algorithm      string
+	modelsUsed     []string
+	iterations     int
+	usage          looper.TokenUsage
+	executionTrace looper.ExecutionTrace
+	fusionQuorum   *routerreplay.FusionQuorumDiagnostics
 }
 
 func (r *OpenAIRouter) looperExecutionErrorResponse(
@@ -71,10 +72,11 @@ func (r *OpenAIRouter) looperExecutionErrorResponse(
 func looperFailureEvidenceFromError(err error) (looperFailureEvidence, bool) {
 	if evidence, ok := looper.ConfidenceEvidenceFromError(err); ok {
 		return looperFailureEvidence{
-			algorithm:  config.DecisionAlgorithmConfidence,
-			modelsUsed: append([]string(nil), evidence.ModelsUsed...),
-			iterations: evidence.Iterations,
-			usage:      evidence.Usage,
+			algorithm:      config.DecisionAlgorithmConfidence,
+			modelsUsed:     append([]string(nil), evidence.ModelsUsed...),
+			iterations:     evidence.Iterations,
+			usage:          evidence.Usage,
+			executionTrace: evidence.ExecutionTrace,
 		}, true
 	}
 	if evidence, ok := looper.FusionQuorumEvidenceFromError(err); ok {
@@ -152,6 +154,7 @@ func (r *OpenAIRouter) recordLooperFailure(
 func applyLooperFailureEvidence(ctx *RequestContext, evidence looperFailureEvidence) {
 	switch evidence.algorithm {
 	case config.DecisionAlgorithmConfidence:
+		ctx.VSRLooperDiagnostics = looperReplayDiagnostics(evidence.executionTrace)
 		if evidence.iterations <= 0 {
 			return
 		}

--- a/src/semantic-router/pkg/extproc/req_filter_looper_replay_test.go
+++ b/src/semantic-router/pkg/extproc/req_filter_looper_replay_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/headers"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/internalauth"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/llmprotocol"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/looper"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/routerreplay"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/routerreplay/store"
 )
@@ -199,6 +200,15 @@ func assertPartialConfidenceTrace(t *testing.T, record store.Record) {
 	}
 	if strings.Contains(record.ResponseBody, "candidate private answer") {
 		t.Fatalf("replay response body leaked candidate answer: %q", record.ResponseBody)
+	}
+	looperTrace := record.RouteDiagnostics.Looper
+	if looperTrace == nil || len(looperTrace.Attempts) != 1 {
+		t.Fatalf("replay Looper trace = %+v, want one completed attempt", looperTrace)
+	}
+	attempt := looperTrace.Attempts[0]
+	if attempt.Ordinal != 1 || attempt.Status != string(looper.AttemptStatusSucceeded) ||
+		attempt.Reason != string(looper.AttemptReasonUnusable) || attempt.Usage.TotalTokens != 7 {
+		t.Fatalf("replay Looper attempt = %+v", attempt)
 	}
 }
 

--- a/src/semantic-router/pkg/extproc/req_filter_looper_trace.go
+++ b/src/semantic-router/pkg/extproc/req_filter_looper_trace.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extproc
+
+import (
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/looper"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/routerreplay"
+)
+
+func looperReplayDiagnostics(trace looper.ExecutionTrace) *routerreplay.LooperDiagnostics {
+	if trace.Version == 0 {
+		return nil
+	}
+	diagnostics := &routerreplay.LooperDiagnostics{
+		Version:             trace.Version,
+		TraceID:             trace.TraceID,
+		Algorithm:           trace.Algorithm,
+		FinalAttemptOrdinal: trace.FinalAttemptOrdinal,
+		AttemptsTruncated:   trace.AttemptsTruncated,
+		DroppedAttemptCount: trace.DroppedAttemptCount,
+		DroppedUsage:        replayLooperUsage(trace.DroppedUsage),
+		Attempts:            make([]routerreplay.LooperAttempt, len(trace.Attempts)),
+	}
+	for index, attempt := range trace.Attempts {
+		diagnostics.Attempts[index] = routerreplay.LooperAttempt{
+			Ordinal: attempt.Ordinal, Stage: attempt.Stage,
+			Role: attempt.Role, Model: attempt.Model, Status: string(attempt.Status),
+			Reason: string(attempt.Reason), Usable: cloneReplayValue(attempt.Usable),
+			Accepted: cloneReplayValue(attempt.Accepted), Selected: attempt.Selected,
+			Synthesized: attempt.Synthesized, Discarded: attempt.Discarded,
+			VerifierType: attempt.VerifierType, VerifierVersion: attempt.VerifierVersion,
+			Score: cloneReplayValue(attempt.Score), Threshold: cloneReplayValue(attempt.Threshold),
+			ReservedTokens:  cloneReplayValue(attempt.ReservedTokens),
+			EstimatedTokens: cloneReplayValue(attempt.EstimatedTokens),
+			Usage:           replayLooperUsage(attempt.Usage),
+			EstimatedCost:   cloneReplayValue(attempt.EstimatedCost),
+			ActualCost:      cloneReplayValue(attempt.ActualCost), Currency: attempt.Currency,
+			QueueLatencyMs:     cloneReplayValue(attempt.QueueLatencyMs),
+			FirstByteLatencyMs: cloneReplayValue(attempt.FirstByteLatencyMs),
+			TotalLatencyMs:     attempt.TotalLatencyMs,
+		}
+	}
+	return diagnostics
+}
+
+func replayLooperUsage(usage looper.TokenUsage) routerreplay.LooperUsage {
+	return routerreplay.LooperUsage{
+		PromptTokens: usage.PromptTokens, CompletionTokens: usage.CompletionTokens, TotalTokens: usage.TotalTokens,
+	}
+}
+
+func cloneReplayValue[T any](value *T) *T {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}

--- a/src/semantic-router/pkg/extproc/req_filter_looper_trace.go
+++ b/src/semantic-router/pkg/extproc/req_filter_looper_trace.go
@@ -21,6 +21,7 @@ import (
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/routerreplay"
 )
 
+// looperReplayDiagnostics projects runtime attempt evidence into the Replay schema.
 func looperReplayDiagnostics(trace looper.ExecutionTrace) *routerreplay.LooperDiagnostics {
 	if trace.Version == 0 {
 		return nil

--- a/src/semantic-router/pkg/extproc/req_filter_looper_trace_test.go
+++ b/src/semantic-router/pkg/extproc/req_filter_looper_trace_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extproc
+
+import (
+	"testing"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/looper"
+)
+
+func TestLooperReplayDiagnosticsProjectsContentFreeTrace(t *testing.T) {
+	accepted := true
+	score := 0.9
+	diagnostics := looperReplayDiagnostics(looper.ExecutionTrace{
+		Version:             looper.ExecutionTraceVersion,
+		TraceID:             "trace-1",
+		Algorithm:           "confidence",
+		FinalAttemptOrdinal: 1,
+		Attempts: []looper.AttemptTrace{{
+			Ordinal: 1, Stage: "candidate", Role: "generator",
+			Model: "large", Status: looper.AttemptStatusSucceeded,
+			Reason: looper.AttemptReasonThresholdMet, Accepted: &accepted, Selected: true,
+			Score: &score, Usage: looper.TokenUsage{PromptTokens: 3, CompletionTokens: 2, TotalTokens: 5},
+		}},
+	})
+	if diagnostics == nil || diagnostics.TraceID != "trace-1" || diagnostics.FinalAttemptOrdinal != 1 || len(diagnostics.Attempts) != 1 {
+		t.Fatalf("projected diagnostics = %+v", diagnostics)
+	}
+	attempt := diagnostics.Attempts[0]
+	if !attempt.Selected || attempt.Accepted == nil || !*attempt.Accepted || attempt.Usage.TotalTokens != 5 {
+		t.Fatalf("projected attempt = %+v", attempt)
+	}
+}

--- a/src/semantic-router/pkg/extproc/request_context.go
+++ b/src/semantic-router/pkg/extproc/request_context.go
@@ -137,6 +137,7 @@ type RequestContext struct {
 	VSRSelectionMethod              string                                      // Model selection algorithm used (e.g., "elo", "static", "router_dc")
 	VSRSelectionReasoning           string                                      // Bounded human-readable selector rationale for replay
 	VSRFusionQuorum                 *routerreplay.FusionQuorumDiagnostics       // Content-free Fusion panel quorum evidence for replay
+	VSRLooperDiagnostics            *routerreplay.LooperDiagnostics             // Content-free Looper attempt evidence for replay
 	VSRPromptHelperModel            string                                      // Concrete prompt-selector helper model
 	VSRPromptHelperPromptTokens     int64                                       // Prompt tokens consumed by the helper
 	VSRPromptHelperCompletionTokens int64                                       // Completion tokens consumed by the helper

--- a/src/semantic-router/pkg/looper/attempt_trace.go
+++ b/src/semantic-router/pkg/looper/attempt_trace.go
@@ -43,8 +43,10 @@ const (
 	maxTraceStringBytes   = 256
 )
 
+// AttemptStatus is the bounded terminal state of one dispatched Looper attempt.
 type AttemptStatus string
 
+// AttemptReason explains the bounded outcome of one Looper attempt.
 type AttemptReason string
 
 const (
@@ -62,6 +64,7 @@ const (
 	AttemptReasonDeadline        AttemptReason = "deadline_exceeded"
 )
 
+// AttemptTrace contains bounded, content-free evidence for one Looper attempt.
 type AttemptTrace struct {
 	Ordinal int    `json:"ordinal"`
 	Stage   string `json:"stage"`
@@ -94,6 +97,7 @@ type AttemptTrace struct {
 	TotalLatencyMs     int64  `json:"total_latency_ms"`
 }
 
+// ExecutionTrace groups bounded attempt evidence for one Looper execution.
 type ExecutionTrace struct {
 	Version             int            `json:"version"`
 	TraceID             string         `json:"trace_id,omitempty"`
@@ -105,6 +109,7 @@ type ExecutionTrace struct {
 	DroppedUsage        TokenUsage     `json:"dropped_usage,omitempty"`
 }
 
+// attemptSpec contains metadata known before an upstream dispatch starts.
 type attemptSpec struct {
 	stage           string
 	role            string
@@ -114,6 +119,7 @@ type attemptSpec struct {
 	pricing         modelpricing.Rates
 }
 
+// attemptResult contains terminal observations used to finish an attempt.
 type attemptResult struct {
 	response        *ModelResponse
 	err             error
@@ -128,12 +134,14 @@ type attemptResult struct {
 
 type attemptTrackerKey struct{}
 
+// attemptTracker owns ordered attempt evidence for one Looper execution.
 type attemptTracker struct {
 	mu          sync.Mutex
 	trace       ExecutionTrace
 	nextOrdinal int
 }
 
+// attemptHandle coordinates timing, span completion, and trace recording.
 type attemptHandle struct {
 	tracker   *attemptTracker
 	ordinal   int
@@ -148,6 +156,7 @@ type attemptHandle struct {
 	once        sync.Once
 }
 
+// newAttemptTracker starts the parent execution span and attaches its tracker to context.
 func newAttemptTracker(ctx context.Context, algorithm string) (*attemptTracker, context.Context, oteltrace.Span) {
 	algorithm = boundedTraceString(algorithm)
 	ctx, span := tracing.StartSpan(ctx, "looper.execute", oteltrace.WithSpanKind(oteltrace.SpanKindInternal))
@@ -166,6 +175,7 @@ func attemptTrackerFromContext(ctx context.Context) *attemptTracker {
 	return tracker
 }
 
+// modelAttemptSpec derives bounded dispatch metadata and optional accounting estimates.
 func modelAttemptSpec(req *Request, stageReq *openai.ChatCompletionNewParams, stage, role, model string) attemptSpec {
 	spec := attemptSpec{stage: stage, role: role, model: model}
 	if reserve := looperOutputTokenReserve(stageReq); reserve > 0 {
@@ -209,6 +219,7 @@ func modelPricingRates(pricing config.ModelPricing) modelpricing.Rates {
 	}
 }
 
+// startAttempt allocates an ordinal, starts a child span, and reserves trace storage.
 func startAttempt(ctx context.Context, spec attemptSpec) (context.Context, *attemptHandle) {
 	tracker := attemptTrackerFromContext(ctx)
 	if tracker == nil {
@@ -253,6 +264,7 @@ func startAttempt(ctx context.Context, spec attemptSpec) (context.Context, *atte
 	return context.WithValue(ctx, attemptTimingKey{}, handle), handle
 }
 
+// finish records one terminal result, emits metrics, and ends the child span exactly once.
 func (a *attemptHandle) finish(result attemptResult) {
 	if a == nil {
 		return
@@ -364,6 +376,7 @@ func (t *attemptTracker) attemptCount() int {
 	return t.nextOrdinal
 }
 
+// snapshot returns an ordered, bounded copy suitable for Replay persistence.
 func (t *attemptTracker) snapshot() ExecutionTrace {
 	if t == nil {
 		return ExecutionTrace{Version: ExecutionTraceVersion}
@@ -387,6 +400,7 @@ func (t *attemptTracker) attemptLocked(ordinal int) *AttemptTrace {
 
 type attemptTimingKey struct{}
 
+// recordAttemptFirstByte records the first response byte once for the active attempt.
 func recordAttemptFirstByte(ctx context.Context) {
 	handle, _ := ctx.Value(attemptTimingKey{}).(*attemptHandle)
 	if handle == nil {
@@ -399,6 +413,7 @@ func recordAttemptFirstByte(ctx context.Context) {
 	handle.mu.Unlock()
 }
 
+// classifyAttemptError maps transport failures to bounded status and reason values.
 func classifyAttemptError(err error) (AttemptStatus, AttemptReason) {
 	switch {
 	case errors.Is(err, context.Canceled):
@@ -410,6 +425,7 @@ func classifyAttemptError(err error) (AttemptStatus, AttemptReason) {
 	}
 }
 
+// attemptReasonFromError maps an error to a bounded reason without storing its text.
 func attemptReasonFromError(err error) AttemptReason {
 	if err == nil {
 		return ""
@@ -426,6 +442,7 @@ func attemptReasonFromError(err error) AttemptReason {
 	}
 }
 
+// boundExecutionTrace enforces attempt count and serialized-size limits.
 func boundExecutionTrace(trace ExecutionTrace) ExecutionTrace {
 	bounded := trace
 	bounded.Attempts = nil
@@ -488,6 +505,7 @@ func attemptCurrency(spec attemptSpec) string {
 	return spec.pricing.Currency
 }
 
+// estimatedAttemptCost prices the estimated input and reserved output tokens.
 func estimatedAttemptCost(spec attemptSpec) *float64 {
 	if !spec.pricing.IsConfigured() || spec.estimatedTokens == nil {
 		return nil

--- a/src/semantic-router/pkg/looper/attempt_trace.go
+++ b/src/semantic-router/pkg/looper/attempt_trace.go
@@ -1,0 +1,515 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package looper
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/openai/openai-go"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	oteltrace "go.opentelemetry.io/otel/trace"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/modelpricing"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/metrics"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/tracing"
+)
+
+const (
+	ExecutionTraceVersion = 1
+	maxTraceAttempts      = 100
+	maxTraceBytes         = 64 * 1024
+	maxTraceStringBytes   = 256
+)
+
+type AttemptStatus string
+
+type AttemptReason string
+
+const (
+	AttemptStatusSucceeded AttemptStatus = "succeeded"
+	AttemptStatusFailed    AttemptStatus = "failed"
+	AttemptStatusCancelled AttemptStatus = "cancelled"
+	AttemptStatusTimedOut  AttemptStatus = "timed_out"
+
+	AttemptReasonThresholdMet    AttemptReason = "threshold_met"
+	AttemptReasonThresholdNotMet AttemptReason = "threshold_not_met"
+	AttemptReasonUnusable        AttemptReason = "unusable_response"
+	AttemptReasonUpstreamError   AttemptReason = "upstream_error"
+	AttemptReasonInvalidResponse AttemptReason = "invalid_response"
+	AttemptReasonCancelled       AttemptReason = "request_cancelled"
+	AttemptReasonDeadline        AttemptReason = "deadline_exceeded"
+)
+
+type AttemptTrace struct {
+	Ordinal int    `json:"ordinal"`
+	Stage   string `json:"stage"`
+	Role    string `json:"role,omitempty"`
+	Model   string `json:"model,omitempty"`
+
+	Status      AttemptStatus `json:"status"`
+	Reason      AttemptReason `json:"reason,omitempty"`
+	Usable      *bool         `json:"usable,omitempty"`
+	Accepted    *bool         `json:"accepted,omitempty"`
+	Selected    bool          `json:"selected,omitempty"`
+	Synthesized bool          `json:"synthesized,omitempty"`
+	Discarded   bool          `json:"discarded,omitempty"`
+
+	VerifierType    string   `json:"verifier_type,omitempty"`
+	VerifierVersion string   `json:"verifier_version,omitempty"`
+	Score           *float64 `json:"score,omitempty"`
+	Threshold       *float64 `json:"threshold,omitempty"`
+
+	ReservedTokens  *int64     `json:"reserved_tokens,omitempty"`
+	EstimatedTokens *int64     `json:"estimated_tokens,omitempty"`
+	Usage           TokenUsage `json:"usage,omitempty"`
+
+	EstimatedCost *float64 `json:"estimated_cost,omitempty"`
+	ActualCost    *float64 `json:"actual_cost,omitempty"`
+	Currency      string   `json:"currency,omitempty"`
+
+	QueueLatencyMs     *int64 `json:"queue_latency_ms,omitempty"`
+	FirstByteLatencyMs *int64 `json:"first_byte_latency_ms,omitempty"`
+	TotalLatencyMs     int64  `json:"total_latency_ms"`
+}
+
+type ExecutionTrace struct {
+	Version             int            `json:"version"`
+	TraceID             string         `json:"trace_id,omitempty"`
+	Algorithm           string         `json:"algorithm"`
+	Attempts            []AttemptTrace `json:"attempts,omitempty"`
+	FinalAttemptOrdinal int            `json:"final_attempt_ordinal,omitempty"`
+	AttemptsTruncated   bool           `json:"attempts_truncated,omitempty"`
+	DroppedAttemptCount int            `json:"dropped_attempt_count,omitempty"`
+	DroppedUsage        TokenUsage     `json:"dropped_usage,omitempty"`
+}
+
+type attemptSpec struct {
+	stage           string
+	role            string
+	model           string
+	reservedTokens  *int64
+	estimatedTokens *int64
+	pricing         modelpricing.Rates
+}
+
+type attemptResult struct {
+	response        *ModelResponse
+	err             error
+	reason          AttemptReason
+	usable          *bool
+	accepted        *bool
+	score           *float64
+	threshold       *float64
+	verifierType    string
+	verifierVersion string
+}
+
+type attemptTrackerKey struct{}
+
+type attemptTracker struct {
+	mu          sync.Mutex
+	trace       ExecutionTrace
+	nextOrdinal int
+}
+
+type attemptHandle struct {
+	tracker   *attemptTracker
+	ordinal   int
+	startedAt time.Time
+	span      oteltrace.Span
+	pricing   modelpricing.Rates
+	stored    bool
+	trace     AttemptTrace
+
+	mu          sync.Mutex
+	firstByteAt time.Time
+	once        sync.Once
+}
+
+func newAttemptTracker(ctx context.Context, algorithm string) (*attemptTracker, context.Context, oteltrace.Span) {
+	algorithm = boundedTraceString(algorithm)
+	ctx, span := tracing.StartSpan(ctx, "looper.execute", oteltrace.WithSpanKind(oteltrace.SpanKindInternal))
+	traceID := ""
+	if span.SpanContext().IsValid() {
+		traceID = span.SpanContext().TraceID().String()
+	}
+	tracker := &attemptTracker{trace: ExecutionTrace{
+		Version: ExecutionTraceVersion, TraceID: traceID, Algorithm: algorithm,
+	}}
+	return tracker, context.WithValue(ctx, attemptTrackerKey{}, tracker), span
+}
+
+func attemptTrackerFromContext(ctx context.Context) *attemptTracker {
+	tracker, _ := ctx.Value(attemptTrackerKey{}).(*attemptTracker)
+	return tracker
+}
+
+func modelAttemptSpec(req *Request, stageReq *openai.ChatCompletionNewParams, stage, role, model string) attemptSpec {
+	spec := attemptSpec{stage: stage, role: role, model: model}
+	if reserve := looperOutputTokenReserve(stageReq); reserve > 0 {
+		value := int64(reserve)
+		spec.reservedTokens = &value
+	}
+	if req != nil && req.BaseContextTokens > 0 {
+		if added, err := looperStageAddedMessageTokens(req.OriginalRequest, stageReq); err == nil {
+			estimated := saturatingAddContextTokens(req.BaseContextTokens, added)
+			if reserve := looperOutputTokenReserve(stageReq) - looperOutputTokenReserve(req.OriginalRequest); reserve > 0 {
+				estimated = saturatingAddContextTokens(estimated, reserve)
+			}
+			value := int64(estimated)
+			spec.estimatedTokens = &value
+		}
+	}
+	spec.pricing = attemptPricing(req, model)
+	return spec
+}
+
+func attemptPricing(req *Request, model string) modelpricing.Rates {
+	if req == nil {
+		return modelpricing.Rates{}
+	}
+	if params, ok := req.ModelParams[model]; ok {
+		return modelPricingRates(params.Pricing)
+	}
+	for _, ref := range req.ModelRefs {
+		if ref.LoRAName == model {
+			return modelPricingRates(req.ModelParams[ref.Model].Pricing)
+		}
+	}
+	return modelpricing.Rates{}
+}
+
+func modelPricingRates(pricing config.ModelPricing) modelpricing.Rates {
+	return modelpricing.Rates{
+		Currency: pricing.Currency, PromptPer1M: pricing.PromptPer1M,
+		CachedInputPer1M: pricing.CachedInputPer1M, CacheWritePer1M: pricing.CacheWritePer1M,
+		CompletionPer1M: pricing.CompletionPer1M,
+	}
+}
+
+func startAttempt(ctx context.Context, spec attemptSpec) (context.Context, *attemptHandle) {
+	tracker := attemptTrackerFromContext(ctx)
+	if tracker == nil {
+		return ctx, nil
+	}
+	tracker.mu.Lock()
+	tracker.nextOrdinal++
+	ordinal := tracker.nextOrdinal
+	tracker.mu.Unlock()
+
+	spec.stage = boundedTraceString(spec.stage)
+	spec.role = boundedTraceString(spec.role)
+	spec.model = boundedTraceString(spec.model)
+	ctx, span := tracing.StartSpan(ctx, "looper.attempt",
+		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
+		oteltrace.WithAttributes(
+			attribute.String("looper.algorithm", tracker.trace.Algorithm),
+			attribute.Int("looper.attempt.ordinal", ordinal),
+			attribute.String("looper.attempt.stage", spec.stage),
+			attribute.String("looper.attempt.role", spec.role),
+			attribute.String("looper.attempt.model", spec.model),
+		),
+	)
+	record := AttemptTrace{
+		Ordinal: ordinal, Stage: spec.stage, Role: spec.role, Model: spec.model,
+		ReservedTokens: cloneInt64Ptr(spec.reservedTokens), EstimatedTokens: cloneInt64Ptr(spec.estimatedTokens),
+		EstimatedCost: estimatedAttemptCost(spec), Currency: attemptCurrency(spec),
+	}
+	handle := &attemptHandle{
+		tracker: tracker, ordinal: ordinal, startedAt: time.Now(), span: span,
+		pricing: spec.pricing, trace: record,
+	}
+	tracker.mu.Lock()
+	if len(tracker.trace.Attempts) < maxTraceAttempts {
+		tracker.trace.Attempts = append(tracker.trace.Attempts, record)
+		handle.stored = true
+	} else {
+		tracker.trace.AttemptsTruncated = true
+		tracker.trace.DroppedAttemptCount++
+	}
+	tracker.mu.Unlock()
+	return context.WithValue(ctx, attemptTimingKey{}, handle), handle
+}
+
+func (a *attemptHandle) finish(result attemptResult) {
+	if a == nil {
+		return
+	}
+	a.once.Do(func() {
+		status, reason := classifyAttemptError(result.err)
+		if result.err == nil {
+			status = AttemptStatusSucceeded
+		}
+		if result.reason != "" {
+			reason = result.reason
+		}
+		a.mu.Lock()
+		firstByteAt := a.firstByteAt
+		a.mu.Unlock()
+		totalLatency := time.Since(a.startedAt).Milliseconds()
+
+		a.tracker.mu.Lock()
+		attempt := &a.trace
+		if a.stored {
+			attempt = a.tracker.attemptLocked(a.ordinal)
+		}
+		if attempt != nil {
+			attempt.Status = status
+			attempt.Reason = reason
+			attempt.Usable = cloneBoolPtr(result.usable)
+			attempt.Accepted = cloneBoolPtr(result.accepted)
+			attempt.Score = cloneFloat64Ptr(result.score)
+			attempt.Threshold = cloneFloat64Ptr(result.threshold)
+			attempt.VerifierType = boundedTraceString(result.verifierType)
+			attempt.VerifierVersion = boundedTraceString(result.verifierVersion)
+			attempt.TotalLatencyMs = totalLatency
+			if !firstByteAt.IsZero() {
+				latency := firstByteAt.Sub(a.startedAt).Milliseconds()
+				attempt.FirstByteLatencyMs = &latency
+			}
+			if result.response != nil {
+				attempt.Usage = result.response.Usage
+				attempt.ActualCost = actualAttemptCost(a.pricing, result.response.Usage)
+			}
+			attempt.Discarded = (result.usable != nil && !*result.usable) ||
+				(result.accepted != nil && !*result.accepted)
+			if !a.stored {
+				a.tracker.trace.DroppedUsage = a.tracker.trace.DroppedUsage.Add(&ModelResponse{Usage: attempt.Usage})
+			}
+			metrics.RecordLooperAttempt(
+				a.tracker.trace.Algorithm, attempt.Stage, string(status), string(reason),
+				attempt.TotalLatencyMs, attempt.FirstByteLatencyMs,
+				attempt.Usage.PromptTokens, attempt.Usage.CompletionTokens,
+				attempt.ActualCost, attempt.Currency,
+			)
+		}
+		a.tracker.mu.Unlock()
+
+		attrs := []attribute.KeyValue{
+			attribute.String("looper.attempt.status", string(status)),
+			attribute.String("looper.attempt.reason", string(reason)),
+			attribute.Int64("looper.attempt.total_latency_ms", totalLatency),
+		}
+		if !firstByteAt.IsZero() {
+			attrs = append(attrs, attribute.Int64("looper.attempt.first_byte_latency_ms", firstByteAt.Sub(a.startedAt).Milliseconds()))
+		}
+		if result.response != nil {
+			attrs = append(attrs,
+				attribute.Int64("looper.attempt.prompt_tokens", result.response.Usage.PromptTokens),
+				attribute.Int64("looper.attempt.completion_tokens", result.response.Usage.CompletionTokens),
+			)
+		}
+		if result.usable != nil {
+			attrs = append(attrs, attribute.Bool("looper.attempt.usable", *result.usable))
+		}
+		if result.accepted != nil {
+			attrs = append(attrs, attribute.Bool("looper.attempt.accepted", *result.accepted))
+		}
+		if result.score != nil {
+			attrs = append(attrs, attribute.Float64("looper.attempt.score", *result.score))
+		}
+		if result.threshold != nil {
+			attrs = append(attrs, attribute.Float64("looper.attempt.threshold", *result.threshold))
+		}
+		tracing.SetSpanAttributes(a.span, attrs...)
+		if result.err != nil {
+			tracing.SetSpanAttributes(a.span, attribute.String("error.type", string(reason)))
+			a.span.SetStatus(codes.Error, string(reason))
+		}
+		a.span.End()
+	})
+}
+
+func (t *attemptTracker) markSelected(ordinal int) {
+	if t == nil || ordinal <= 0 {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if attempt := t.attemptLocked(ordinal); attempt != nil {
+		attempt.Selected = true
+		attempt.Discarded = false
+	}
+	t.trace.FinalAttemptOrdinal = ordinal
+}
+
+func (t *attemptTracker) attemptCount() int {
+	if t == nil {
+		return 0
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.nextOrdinal
+}
+
+func (t *attemptTracker) snapshot() ExecutionTrace {
+	if t == nil {
+		return ExecutionTrace{Version: ExecutionTraceVersion}
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	result := t.trace
+	result.Attempts = append([]AttemptTrace(nil), t.trace.Attempts...)
+	sort.Slice(result.Attempts, func(i, j int) bool { return result.Attempts[i].Ordinal < result.Attempts[j].Ordinal })
+	return boundExecutionTrace(result)
+}
+
+func (t *attemptTracker) attemptLocked(ordinal int) *AttemptTrace {
+	for i := range t.trace.Attempts {
+		if t.trace.Attempts[i].Ordinal == ordinal {
+			return &t.trace.Attempts[i]
+		}
+	}
+	return nil
+}
+
+type attemptTimingKey struct{}
+
+func recordAttemptFirstByte(ctx context.Context) {
+	handle, _ := ctx.Value(attemptTimingKey{}).(*attemptHandle)
+	if handle == nil {
+		return
+	}
+	handle.mu.Lock()
+	if handle.firstByteAt.IsZero() {
+		handle.firstByteAt = time.Now()
+	}
+	handle.mu.Unlock()
+}
+
+func classifyAttemptError(err error) (AttemptStatus, AttemptReason) {
+	switch {
+	case errors.Is(err, context.Canceled):
+		return AttemptStatusCancelled, AttemptReasonCancelled
+	case errors.Is(err, context.DeadlineExceeded):
+		return AttemptStatusTimedOut, AttemptReasonDeadline
+	default:
+		return AttemptStatusFailed, attemptReasonFromError(err)
+	}
+}
+
+func attemptReasonFromError(err error) AttemptReason {
+	if err == nil {
+		return ""
+	}
+	switch {
+	case errors.Is(err, context.Canceled):
+		return AttemptReasonCancelled
+	case errors.Is(err, context.DeadlineExceeded):
+		return AttemptReasonDeadline
+	case strings.Contains(err.Error(), "parse response"):
+		return AttemptReasonInvalidResponse
+	default:
+		return AttemptReasonUpstreamError
+	}
+}
+
+func boundExecutionTrace(trace ExecutionTrace) ExecutionTrace {
+	bounded := trace
+	bounded.Attempts = nil
+	bounded.DroppedUsage = trace.DroppedUsage
+	attemptBytes := 2 // JSON array brackets.
+	for _, attempt := range trace.Attempts {
+		encoded, _ := json.Marshal(attempt)
+		additional := len(encoded)
+		if len(bounded.Attempts) > 0 {
+			additional++ // comma
+		}
+		if len(bounded.Attempts) >= maxTraceAttempts || attemptBytes+additional > maxTraceBytes {
+			bounded.AttemptsTruncated = true
+			bounded.DroppedAttemptCount++
+			bounded.DroppedUsage = bounded.DroppedUsage.Add(&ModelResponse{Usage: attempt.Usage})
+			continue
+		}
+		bounded.Attempts = append(bounded.Attempts, attempt)
+		attemptBytes += additional
+	}
+	return bounded
+}
+
+func boundedTraceString(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) > maxTraceStringBytes {
+		return value[:maxTraceStringBytes]
+	}
+	return value
+}
+
+func cloneInt64Ptr(value *int64) *int64 {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}
+
+func cloneBoolPtr(value *bool) *bool {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}
+
+func cloneFloat64Ptr(value *float64) *float64 {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}
+
+func attemptCurrency(spec attemptSpec) string {
+	if !spec.pricing.IsConfigured() {
+		return ""
+	}
+	return spec.pricing.Currency
+}
+
+func estimatedAttemptCost(spec attemptSpec) *float64 {
+	if !spec.pricing.IsConfigured() || spec.estimatedTokens == nil {
+		return nil
+	}
+	reserved := int64(0)
+	if spec.reservedTokens != nil {
+		reserved = *spec.reservedTokens
+	}
+	input := max(*spec.estimatedTokens-reserved, 0)
+	cost := modelpricing.Cost(modelpricing.Usage{
+		PromptTokens: saturatingInt64ToInt(input), CompletionTokens: saturatingInt64ToInt(reserved),
+	}, spec.pricing)
+	return &cost
+}
+
+func actualAttemptCost(pricing modelpricing.Rates, usage TokenUsage) *float64 {
+	if !pricing.IsConfigured() {
+		return nil
+	}
+	cost := modelpricing.Cost(modelpricing.Usage{
+		PromptTokens:     saturatingInt64ToInt(usage.PromptTokens),
+		CompletionTokens: saturatingInt64ToInt(usage.CompletionTokens),
+	}, pricing)
+	return &cost
+}

--- a/src/semantic-router/pkg/looper/attempt_trace_test.go
+++ b/src/semantic-router/pkg/looper/attempt_trace_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package looper
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/openai/openai-go"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	oteltrace "go.opentelemetry.io/otel/trace"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
+)
+
+func TestExecuteWithLatencyRecordsConfidenceAttemptTrace(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	previous := otel.GetTracerProvider()
+	otel.SetTracerProvider(provider)
+	t.Cleanup(func() {
+		_ = provider.Shutdown(context.Background())
+		otel.SetTracerProvider(previous)
+	})
+
+	server, _ := newConfidenceLogprobBackend(t, map[string]int{"small": 0, "large": 1})
+	defer server.Close()
+
+	cfg := config.LooperConfig{Endpoint: server.URL}
+	request := confidenceLogprobRequest("skip")
+	request.BaseContextTokens = 50
+	request.OriginalRequest.MaxTokens = openai.Int(10)
+	request.ModelParams["small"] = config.ModelParams{ParamSize: "1b", Pricing: config.ModelPricing{Currency: "USD", PromptPer1M: 1, CompletionPer1M: 2}}
+	request.ModelParams["large"] = config.ModelParams{ParamSize: "10b", Pricing: config.ModelPricing{Currency: "USD", PromptPer1M: 1, CompletionPer1M: 2}}
+	response, err := ExecuteWithLatency(
+		context.Background(),
+		NewConfidenceLooper(&cfg),
+		request,
+	)
+	if err != nil {
+		t.Fatalf("ExecuteWithLatency: %v", err)
+	}
+	trace := response.ExecutionTrace
+	if trace.Version != ExecutionTraceVersion || trace.TraceID == "" {
+		t.Fatalf("execution trace identity = version %d trace %q", trace.Version, trace.TraceID)
+	}
+	if len(trace.Attempts) != 2 || trace.FinalAttemptOrdinal != 2 {
+		t.Fatalf("attempt trace = %+v, want two attempts and final ordinal 2", trace)
+	}
+	if trace.Attempts[0].Status != AttemptStatusSucceeded ||
+		trace.Attempts[0].Reason != AttemptReasonUnusable ||
+		!trace.Attempts[0].Discarded {
+		t.Fatalf("first attempt = %+v, want discarded unusable response", trace.Attempts[0])
+	}
+	if !trace.Attempts[1].Selected || trace.Attempts[1].Accepted == nil || !*trace.Attempts[1].Accepted {
+		t.Fatalf("second attempt = %+v, want accepted selection", trace.Attempts[1])
+	}
+	if trace.Attempts[1].ReservedTokens == nil || *trace.Attempts[1].ReservedTokens != 10 ||
+		trace.Attempts[1].EstimatedTokens == nil || trace.Attempts[1].ActualCost == nil || trace.Attempts[1].Currency != "USD" {
+		t.Fatalf("second attempt accounting = %+v", trace.Attempts[1])
+	}
+	if trace.Attempts[0].Usage.TotalTokens+trace.Attempts[1].Usage.TotalTokens != response.Usage.TotalTokens {
+		t.Fatalf("attempt usage does not reconcile with response: %+v vs %+v", trace.Attempts, response.Usage)
+	}
+
+	encoded, err := json.Marshal(trace)
+	if err != nil {
+		t.Fatalf("marshal trace: %v", err)
+	}
+	if strings.Contains(string(encoded), "small answer") || strings.Contains(string(encoded), server.URL) {
+		t.Fatalf("execution trace leaked content or endpoint: %s", encoded)
+	}
+
+	spans := exporter.GetSpans()
+	if len(spans) != 3 {
+		t.Fatalf("ended spans = %d, want parent plus two attempts", len(spans))
+	}
+	var parentSpanID oteltrace.SpanID
+	children := 0
+	for _, span := range spans {
+		if span.Name == "looper.execute" {
+			parentSpanID = span.SpanContext.SpanID()
+		}
+	}
+	if !parentSpanID.IsValid() {
+		t.Fatal("looper.execute span missing")
+	}
+	for _, span := range spans {
+		if span.Name == "looper.attempt" {
+			children++
+			if span.Parent.SpanID() != parentSpanID {
+				t.Fatalf("attempt parent = %s, want %s", span.Parent.SpanID(), parentSpanID)
+			}
+		}
+	}
+	if children != 2 {
+		t.Fatalf("attempt spans = %d, want 2", children)
+	}
+}
+
+func TestBoundExecutionTracePreservesDroppedUsage(t *testing.T) {
+	trace := ExecutionTrace{Version: ExecutionTraceVersion, Algorithm: "confidence"}
+	for ordinal := 1; ordinal <= maxTraceAttempts+1; ordinal++ {
+		trace.Attempts = append(trace.Attempts, AttemptTrace{
+			Ordinal: ordinal, Stage: "candidate",
+			Status: AttemptStatusSucceeded, Usage: TokenUsage{TotalTokens: 1},
+		})
+	}
+
+	bounded := boundExecutionTrace(trace)
+	if !bounded.AttemptsTruncated || bounded.DroppedAttemptCount != 1 || bounded.DroppedUsage.TotalTokens != 1 {
+		t.Fatalf("bounded trace = %+v, want one dropped attempt and token", bounded)
+	}
+}

--- a/src/semantic-router/pkg/looper/client.go
+++ b/src/semantic-router/pkg/looper/client.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/httptrace"
 	"strings"
 	"time"
 
@@ -29,6 +30,7 @@ import (
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/logging"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/tracing"
 )
 
 // Client handles HTTP requests to OpenAI-compatible endpoints
@@ -188,6 +190,12 @@ func (c *Client) CallModel(ctx context.Context, req *openai.ChatCompletionNewPar
 		"logprobs":  logprobsEnabled,
 	})
 
+	// Capture first-byte timing for an active Looper attempt without wrapping
+	// response bodies or changing transport behavior.
+	ctx = httptrace.WithClientTrace(ctx, &httptrace.ClientTrace{
+		GotFirstResponseByte: func() { recordAttemptFirstByte(ctx) },
+	})
+
 	// Create HTTP request
 	httpReq, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewReader(body))
 	if err != nil {
@@ -198,6 +206,11 @@ func (c *Client) CallModel(ctx context.Context, req *openai.ChatCompletionNewPar
 	httpReq.Header.Set("Content-Type", "application/json")
 	for k, v := range c.headers {
 		httpReq.Header.Set(k, v)
+	}
+	traceHeaders := make(map[string]string)
+	tracing.InjectTraceContext(ctx, traceHeaders)
+	for key, value := range traceHeaders {
+		httpReq.Header.Set(key, value)
 	}
 
 	// Set Authorization header if access key is provided

--- a/src/semantic-router/pkg/looper/confidence.go
+++ b/src/semantic-router/pkg/looper/confidence.go
@@ -638,9 +638,14 @@ func (l *ConfidenceLooper) Execute(ctx context.Context, req *Request) (*Response
 	var allResponses []*ModelResponse
 	var modelsUsed []string
 	var lastEvaluationErr error
+	lastAttemptOrdinal := 0
 	attempts := 0
 	partialExecutionError := func(cause error) error {
-		return newConfidencePartialExecutionError(cause, allResponses, modelsUsed, attempts)
+		trace := ExecutionTrace{Version: ExecutionTraceVersion}
+		if tracker := attemptTrackerFromContext(ctx); tracker != nil {
+			trace = tracker.snapshot()
+		}
+		return newConfidencePartialExecutionError(cause, allResponses, modelsUsed, attempts, trace)
 	}
 
 	for _, modelRef := range sortedRefs {
@@ -665,11 +670,13 @@ func (l *ConfidenceLooper) Execute(ctx context.Context, req *Request) (*Response
 		})
 
 		attempts++
-		resp, err := l.callModelWithContextGate(
+		resp, attempt, err := l.startConfidenceModelAttempt(
 			ctx,
 			req,
 			req.OriginalRequest,
 			modelName,
+			"candidate",
+			"generator",
 			confidenceModelCallStreaming(req.IsStreaming, evaluator),
 			attempts,
 			logprobsCfg,
@@ -698,6 +705,8 @@ func (l *ConfidenceLooper) Execute(ctx context.Context, req *Request) (*Response
 
 		var confidence float64
 		var meetsThreshold bool
+		usable := true
+		attemptReason := AttemptReasonThresholdNotMet
 
 		// Evaluate confidence using configured method
 		switch {
@@ -707,6 +716,8 @@ func (l *ConfidenceLooper) Execute(ctx context.Context, req *Request) (*Response
 			var verifyErr error
 			confidence, meetsThreshold, verifyErr = l.performAutoMixEntailment(ctx, req, evaluator, modelName, resp.Content)
 			if verifyErr != nil {
+				usable = false
+				attemptReason = AttemptReasonInvalidResponse
 				logging.ComponentWarnEvent("looper", "automix_entailment_failed", map[string]interface{}{
 					"looper":    "confidence",
 					"decision":  req.DecisionName,
@@ -714,6 +725,9 @@ func (l *ConfidenceLooper) Execute(ctx context.Context, req *Request) (*Response
 					"error":     verifyErr.Error(),
 				})
 				if onError == "fail" {
+					if attempt != nil {
+						attempt.finish(attemptResult{response: resp, reason: attemptReason, usable: &usable})
+					}
 					return nil, partialExecutionError(fmt.Errorf(
 						"automix_entailment verification for %s failed: %w",
 						modelName,
@@ -749,6 +763,8 @@ func (l *ConfidenceLooper) Execute(ctx context.Context, req *Request) (*Response
 				allResponses = append(allResponses, verification.Response)
 			}
 			if verifyErr != nil {
+				usable = false
+				attemptReason = AttemptReasonInvalidResponse
 				lastEvaluationErr = fmt.Errorf("self verification for model %q failed: %w", modelName, verifyErr)
 				logging.ComponentWarnEvent("looper", "self_verification_failed", map[string]interface{}{
 					"looper":    "confidence",
@@ -758,6 +774,9 @@ func (l *ConfidenceLooper) Execute(ctx context.Context, req *Request) (*Response
 					"attempted": verification.Attempted,
 					"error":     verifyErr.Error(),
 				})
+				if attempt != nil {
+					attempt.finish(attemptResult{response: resp, reason: attemptReason, usable: &usable})
+				}
 				if onError == "fail" {
 					return nil, partialExecutionError(lastEvaluationErr)
 				}
@@ -777,6 +796,8 @@ func (l *ConfidenceLooper) Execute(ctx context.Context, req *Request) (*Response
 			var evaluateErr error
 			confidence, meetsThreshold, evaluateErr = evaluator.evaluate(resp)
 			if evaluateErr != nil {
+				usable = false
+				attemptReason = AttemptReasonUnusable
 				lastEvaluationErr = fmt.Errorf("confidence evaluation for model %q failed: %w", modelName, evaluateErr)
 				logging.ComponentWarnEvent("looper", "confidence_evaluation_failed", map[string]interface{}{
 					"looper":    "confidence",
@@ -786,6 +807,9 @@ func (l *ConfidenceLooper) Execute(ctx context.Context, req *Request) (*Response
 					"method":    evaluator.Method,
 					"error":     evaluateErr.Error(),
 				})
+				if attempt != nil {
+					attempt.finish(attemptResult{response: resp, reason: attemptReason, usable: &usable})
+				}
 				if onError == "fail" {
 					return nil, partialExecutionError(lastEvaluationErr)
 				}
@@ -816,6 +840,17 @@ func (l *ConfidenceLooper) Execute(ctx context.Context, req *Request) (*Response
 			}
 		}
 
+		if meetsThreshold {
+			attemptReason = AttemptReasonThresholdMet
+		}
+		if attempt != nil {
+			attempt.finish(attemptResult{
+				response: resp, reason: attemptReason, usable: &usable,
+				accepted: &meetsThreshold, score: &confidence, threshold: &evaluator.Threshold,
+				verifierType: evaluator.Method,
+			})
+			lastAttemptOrdinal = attempt.ordinal
+		}
 		lastResponse = resp
 
 		if meetsThreshold {
@@ -846,6 +881,10 @@ func (l *ConfidenceLooper) Execute(ctx context.Context, req *Request) (*Response
 		return nil, partialExecutionError(fmt.Errorf("all models failed"))
 	}
 
+	if tracker := attemptTrackerFromContext(ctx); tracker != nil {
+		tracker.markSelected(lastAttemptOrdinal)
+	}
+
 	// Publish only the last confidence-evaluated response. Usage and models-used
 	// retain every paid attempt, including a skipped response with missing
 	// logprob evidence.
@@ -859,15 +898,22 @@ func (l *ConfidenceLooper) Execute(ctx context.Context, req *Request) (*Response
 		HasToolCalls:    lastResponse.HasToolCalls,
 	}
 
+	var response *Response
+	var err error
 	if req.IsStreaming {
-		return l.formatConfidenceStreamingResponse(
+		response, err = l.formatConfidenceStreamingResponse(
 			agg,
 			modelsUsed,
 			attempts,
 			confidenceStreamUsageRequested(req),
 		)
+	} else {
+		response, err = l.formatConfidenceJSONResponse(agg, modelsUsed, attempts)
 	}
-	return l.formatConfidenceJSONResponse(agg, modelsUsed, attempts)
+	if err != nil {
+		return nil, partialExecutionError(err)
+	}
+	return response, nil
 }
 
 func confidenceStreamUsageRequested(req *Request) bool {
@@ -908,7 +954,9 @@ func (l *ConfidenceLooper) performSelfVerification(
 	})
 
 	// Call the same model to evaluate its answer
-	verifyResp, err := l.callModelWithContextGate(ctx, req, verifyRequest, modelName, false, iteration, nil, accessKey)
+	verifyResp, attempt, err := l.startConfidenceModelAttempt(
+		ctx, req, verifyRequest, modelName, "self_verifier", "verifier", false, iteration, nil, accessKey,
+	)
 	if err != nil {
 		return selfVerificationExecution{Attempted: true}, fmt.Errorf("verifier model call failed: %w", err)
 	}
@@ -916,10 +964,27 @@ func (l *ConfidenceLooper) performSelfVerification(
 	// Parse the self-verification result
 	result, err := parseSelfVerification(verifyResp.Content)
 	if err != nil {
+		if attempt != nil {
+			usable := false
+			attempt.finish(attemptResult{response: verifyResp, err: err, reason: AttemptReasonInvalidResponse, usable: &usable})
+		}
 		return selfVerificationExecution{
 			Response:  verifyResp,
 			Attempted: true,
 		}, fmt.Errorf("could not parse verifier result: %w", err)
+	}
+	accepted := result.Confidence >= threshold
+	if attempt != nil {
+		usable := true
+		attemptReason := AttemptReasonThresholdNotMet
+		if accepted {
+			attemptReason = AttemptReasonThresholdMet
+		}
+		attempt.finish(attemptResult{
+			response: verifyResp, reason: attemptReason, usable: &usable,
+			accepted: &accepted, score: &result.Confidence, threshold: &threshold,
+			verifierType: "self_verify",
+		})
 	}
 
 	logging.ComponentDebugEvent("looper", "self_verification_result_parsed", map[string]interface{}{
@@ -931,7 +996,7 @@ func (l *ConfidenceLooper) performSelfVerification(
 
 	return selfVerificationExecution{
 		Confidence: result.Confidence,
-		Accepted:   result.Confidence >= threshold,
+		Accepted:   accepted,
 		Response:   verifyResp,
 		Attempted:  true,
 	}, nil
@@ -1081,10 +1146,14 @@ func (l *ConfidenceLooper) performAutoMixEntailment(
 	})
 
 	// Verify through the shared verifier contract so the AutoMix HTTP adapter
-	// is the single verifier seam (issue #2857). Public behavior is unchanged:
-	// the returned confidence and accept decision are identical.
+	// remains the single verifier seam (issue #2857).
+	attemptCtx, attempt := startAttempt(ctx, attemptSpec{
+		stage: "external_verifier",
+		role:  "verifier",
+		model: modelName,
+	})
 	verifier := NewAutoMixVerifier(evaluator.VerifierServerURL, evaluator.VerifierTimeoutSeconds, evaluator.MaxResponseBytes, evaluator.Threshold)
-	result, err := verifier.Verify(ctx, &VerifierRequest{
+	result, err := verifier.Verify(attemptCtx, &VerifierRequest{
 		Task: question,
 		Candidates: []VerifierCandidate{
 			{ID: modelName, Content: responseContent},
@@ -1093,12 +1162,38 @@ func (l *ConfidenceLooper) performAutoMixEntailment(
 	if err != nil {
 		var verr *VerifierError
 		if errors.As(err, &verr) && verr.Code == VerifierFailureTimeout {
+			if attempt != nil {
+				attempt.finish(attemptResult{err: context.DeadlineExceeded})
+			}
 			return 0, false, fmt.Errorf("verifier call failed (timeout): %w", err)
+		}
+		if attempt != nil {
+			attempt.finish(attemptResult{err: err})
 		}
 		return 0, false, fmt.Errorf("verifier call failed: %w", err)
 	}
 	if result.Confidence == nil {
-		return 0, false, fmt.Errorf("verifier returned no confidence")
+		err := errors.New("verifier returned no confidence")
+		if attempt != nil {
+			usable := false
+			attempt.finish(attemptResult{err: err, reason: AttemptReasonInvalidResponse, usable: &usable})
+		}
+		return 0, false, err
 	}
-	return *result.Confidence, result.Disposition == DispositionApprove, nil
+
+	confidence := *result.Confidence
+	accepted := result.Disposition == DispositionApprove
+	if attempt != nil {
+		usable := true
+		reason := AttemptReasonThresholdNotMet
+		if accepted {
+			reason = AttemptReasonThresholdMet
+		}
+		attempt.finish(attemptResult{
+			reason: reason, usable: &usable, accepted: &accepted,
+			score: &confidence, threshold: &evaluator.Threshold,
+			verifierType: MethodAutoMixEntailment,
+		})
+	}
+	return confidence, accepted, nil
 }

--- a/src/semantic-router/pkg/looper/confidence_response.go
+++ b/src/semantic-router/pkg/looper/confidence_response.go
@@ -29,9 +29,10 @@ import (
 // It deliberately excludes ModelResponse and response bodies so transporting
 // the error through extproc cannot disclose candidate or verifier text.
 type ConfidenceExecutionEvidence struct {
-	ModelsUsed []string
-	Iterations int
-	Usage      TokenUsage
+	ModelsUsed     []string
+	Iterations     int
+	Usage          TokenUsage
+	ExecutionTrace ExecutionTrace
 }
 
 // ConfidencePartialExecutionError preserves paid execution evidence while
@@ -62,6 +63,7 @@ func (e *ConfidencePartialExecutionError) Evidence() ConfidenceExecutionEvidence
 	}
 	evidence := e.evidence
 	evidence.ModelsUsed = append([]string(nil), evidence.ModelsUsed...)
+	evidence.ExecutionTrace.Attempts = append([]AttemptTrace(nil), evidence.ExecutionTrace.Attempts...)
 	return evidence
 }
 
@@ -80,13 +82,15 @@ func newConfidencePartialExecutionError(
 	responses []*ModelResponse,
 	modelsUsed []string,
 	iterations int,
+	trace ExecutionTrace,
 ) error {
 	return &ConfidencePartialExecutionError{
 		cause: cause,
 		evidence: ConfidenceExecutionEvidence{
-			ModelsUsed: append([]string(nil), modelsUsed...),
-			Iterations: iterations,
-			Usage:      SumUsage(responses...),
+			ModelsUsed:     append([]string(nil), modelsUsed...),
+			Iterations:     iterations,
+			Usage:          SumUsage(responses...),
+			ExecutionTrace: trace,
 		},
 	}
 }

--- a/src/semantic-router/pkg/looper/execute_latency.go
+++ b/src/semantic-router/pkg/looper/execute_latency.go
@@ -19,6 +19,12 @@ package looper
 import (
 	"context"
 	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/metrics"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/tracing"
 )
 
 // ExecuteWithLatency runs l.Execute and records the wall-clock latency of the
@@ -34,11 +40,58 @@ func ExecuteWithLatency(ctx context.Context, l Looper, req *Request) (*Response,
 	if req != nil {
 		ctx = contextWithRoutingRecipe(ctx, req.RecipeName)
 	}
+	algorithm := looperAlgorithm(req)
+	tracker, ctx, span := newAttemptTracker(ctx, algorithm)
+	tracing.SetSpanAttributes(span,
+		attribute.String("looper.algorithm", algorithm),
+		attribute.Int("looper.candidate_count", looperCandidateCount(req)),
+		attribute.Bool("looper.streaming", req != nil && req.IsStreaming),
+	)
+
 	start := time.Now()
 	resp, err := l.Execute(ctx, req)
-	if err != nil || resp == nil {
-		return resp, err
+	duration := time.Since(start)
+	status := "succeeded"
+	if err != nil {
+		status = string(classifyExecutionStatus(err))
+		tracing.SetSpanAttributes(span, attribute.String("error.type", status))
+		span.SetStatus(codes.Error, status)
 	}
-	resp.LatencyMs = time.Since(start).Milliseconds()
-	return resp, nil
+	tracing.SetSpanAttributes(span,
+		attribute.String("looper.status", status),
+		attribute.Int("looper.attempt_count", tracker.attemptCount()),
+	)
+	if resp != nil {
+		resp.LatencyMs = duration.Milliseconds()
+		resp.ExecutionTrace = tracker.snapshot()
+		tracing.SetSpanAttributes(span,
+			attribute.Int("looper.final_attempt.ordinal", resp.ExecutionTrace.FinalAttemptOrdinal),
+			attribute.String("looper.final_model", resp.Model),
+			attribute.Int64("looper.prompt_tokens", resp.Usage.PromptTokens),
+			attribute.Int64("looper.completion_tokens", resp.Usage.CompletionTokens),
+			attribute.Int64("looper.total_tokens", resp.Usage.TotalTokens),
+		)
+	}
+	metrics.RecordLooperExecution(algorithm, status, duration.Seconds())
+	span.End()
+	return resp, err
+}
+
+func looperAlgorithm(req *Request) string {
+	if req == nil || req.Algorithm == nil {
+		return "unknown"
+	}
+	return req.Algorithm.Type
+}
+
+func looperCandidateCount(req *Request) int {
+	if req == nil {
+		return 0
+	}
+	return len(req.ModelRefs)
+}
+
+func classifyExecutionStatus(err error) AttemptStatus {
+	status, _ := classifyAttemptError(err)
+	return status
 }

--- a/src/semantic-router/pkg/looper/looper.go
+++ b/src/semantic-router/pkg/looper/looper.go
@@ -116,6 +116,10 @@ type Response struct {
 	// so it reflects real elapsed time regardless of whether the algorithm
 	// dispatches its model calls sequentially or concurrently.
 	LatencyMs int64 `json:"latency_ms,omitempty"`
+
+	// ExecutionTrace is bounded, content-free diagnostic evidence for tracing
+	// and Router Replay. It is not included in the client response body.
+	ExecutionTrace ExecutionTrace `json:"-"`
 }
 
 // Looper defines the interface for multi-model execution strategies

--- a/src/semantic-router/pkg/looper/stage_context.go
+++ b/src/semantic-router/pkg/looper/stage_context.go
@@ -68,6 +68,7 @@ func (l *BaseLooper) callModelWithContextGate(
 	)
 }
 
+// startConfidenceModelAttempt validates and dispatches one traced Confidence model call.
 func (l *BaseLooper) startConfidenceModelAttempt(
 	ctx context.Context,
 	baseReq *Request,

--- a/src/semantic-router/pkg/looper/stage_context.go
+++ b/src/semantic-router/pkg/looper/stage_context.go
@@ -68,6 +68,31 @@ func (l *BaseLooper) callModelWithContextGate(
 	)
 }
 
+func (l *BaseLooper) startConfidenceModelAttempt(
+	ctx context.Context,
+	baseReq *Request,
+	stageReq *openai.ChatCompletionNewParams,
+	modelName, stage, role string,
+	streaming bool,
+	iteration int,
+	logprobsConfig *LogprobsConfig,
+	accessKey string,
+) (*ModelResponse, *attemptHandle, error) {
+	if err := validateLooperStageContext(baseReq, stageReq, modelName); err != nil {
+		return nil, nil, err
+	}
+	attemptCtx, attempt := startAttempt(ctx, modelAttemptSpec(
+		baseReq, stageReq, stage, role, modelName,
+	))
+	response, err := l.client.CallModel(
+		attemptCtx, stageReq, modelName, streaming, iteration, logprobsConfig, accessKey,
+	)
+	if err != nil && attempt != nil {
+		attempt.finish(attemptResult{err: err, reason: attemptReasonFromError(err)})
+	}
+	return response, attempt, err
+}
+
 func validateLooperStageContext(
 	baseReq *Request,
 	stageReq *openai.ChatCompletionNewParams,

--- a/src/semantic-router/pkg/observability/metrics/looper_metrics.go
+++ b/src/semantic-router/pkg/observability/metrics/looper_metrics.go
@@ -22,33 +22,39 @@ import (
 )
 
 var (
+	// LooperAttemptsTotal counts terminal attempts by bounded outcome.
 	LooperAttemptsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "llm_looper_attempts_total",
 		Help: "Total Looper attempts by bounded execution outcome.",
 	}, []string{"algorithm", "stage", "status", "reason"})
 
+	// LooperAttemptDuration records end-to-end attempt duration.
 	LooperAttemptDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "llm_looper_attempt_duration_seconds",
 		Help:    "Looper attempt duration in seconds.",
 		Buckets: prometheus.DefBuckets,
 	}, []string{"algorithm", "stage", "status"})
 
+	// LooperAttemptFirstByte records time to the first upstream response byte.
 	LooperAttemptFirstByte = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "llm_looper_attempt_first_byte_seconds",
 		Help:    "Looper attempt time to first response byte in seconds.",
 		Buckets: prometheus.DefBuckets,
 	}, []string{"algorithm", "stage"})
 
+	// LooperAttemptTokens counts prompt and completion tokens by attempt stage.
 	LooperAttemptTokens = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "llm_looper_attempt_tokens_total",
 		Help: "Total prompt and completion tokens consumed by Looper attempts.",
 	}, []string{"algorithm", "stage", "token_type"})
 
+	// LooperAttemptCost sums configured attempt cost by currency.
 	LooperAttemptCost = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "llm_looper_attempt_cost_total",
 		Help: "Total configured cost of Looper attempts by currency.",
 	}, []string{"algorithm", "stage", "currency"})
 
+	// LooperExecutionDuration records end-to-end Looper execution duration.
 	LooperExecutionDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "llm_looper_execution_duration_seconds",
 		Help:    "End-to-end Looper execution duration in seconds.",
@@ -82,6 +88,7 @@ func RecordLooperAttempt(
 	}
 }
 
+// RecordLooperExecution records one terminal Looper execution.
 func RecordLooperExecution(algorithm, status string, durationSeconds float64) {
 	LooperExecutionDuration.WithLabelValues(algorithm, status).Observe(durationSeconds)
 }

--- a/src/semantic-router/pkg/observability/metrics/looper_metrics.go
+++ b/src/semantic-router/pkg/observability/metrics/looper_metrics.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	LooperAttemptsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "llm_looper_attempts_total",
+		Help: "Total Looper attempts by bounded execution outcome.",
+	}, []string{"algorithm", "stage", "status", "reason"})
+
+	LooperAttemptDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "llm_looper_attempt_duration_seconds",
+		Help:    "Looper attempt duration in seconds.",
+		Buckets: prometheus.DefBuckets,
+	}, []string{"algorithm", "stage", "status"})
+
+	LooperAttemptFirstByte = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "llm_looper_attempt_first_byte_seconds",
+		Help:    "Looper attempt time to first response byte in seconds.",
+		Buckets: prometheus.DefBuckets,
+	}, []string{"algorithm", "stage"})
+
+	LooperAttemptTokens = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "llm_looper_attempt_tokens_total",
+		Help: "Total prompt and completion tokens consumed by Looper attempts.",
+	}, []string{"algorithm", "stage", "token_type"})
+
+	LooperAttemptCost = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "llm_looper_attempt_cost_total",
+		Help: "Total configured cost of Looper attempts by currency.",
+	}, []string{"algorithm", "stage", "currency"})
+
+	LooperExecutionDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "llm_looper_execution_duration_seconds",
+		Help:    "End-to-end Looper execution duration in seconds.",
+		Buckets: prometheus.DefBuckets,
+	}, []string{"algorithm", "status"})
+)
+
+// RecordLooperAttempt records one terminal attempt. All labels are bounded by
+// the Looper package; request-specific identifiers intentionally stay out.
+func RecordLooperAttempt(
+	algorithm, stage, status, reason string,
+	totalLatencyMs int64,
+	firstByteLatencyMs *int64,
+	promptTokens, completionTokens int64,
+	actualCost *float64,
+	currency string,
+) {
+	LooperAttemptsTotal.WithLabelValues(algorithm, stage, status, reason).Inc()
+	LooperAttemptDuration.WithLabelValues(algorithm, stage, status).Observe(float64(totalLatencyMs) / 1000)
+	if firstByteLatencyMs != nil {
+		LooperAttemptFirstByte.WithLabelValues(algorithm, stage).Observe(float64(*firstByteLatencyMs) / 1000)
+	}
+	if promptTokens > 0 {
+		LooperAttemptTokens.WithLabelValues(algorithm, stage, "prompt").Add(float64(promptTokens))
+	}
+	if completionTokens > 0 {
+		LooperAttemptTokens.WithLabelValues(algorithm, stage, "completion").Add(float64(completionTokens))
+	}
+	if actualCost != nil && currency != "" {
+		LooperAttemptCost.WithLabelValues(algorithm, stage, currency).Add(*actualCost)
+	}
+}
+
+func RecordLooperExecution(algorithm, status string, durationSeconds float64) {
+	LooperExecutionDuration.WithLabelValues(algorithm, status).Observe(durationSeconds)
+}

--- a/src/semantic-router/pkg/observability/metrics/looper_metrics_test.go
+++ b/src/semantic-router/pkg/observability/metrics/looper_metrics_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestLooperMetricsRecordBoundedDimensions(t *testing.T) {
+	firstByte := int64(125)
+	cost := 0.004
+	before := testutil.ToFloat64(LooperAttemptsTotal.WithLabelValues(
+		"confidence", "candidate", "succeeded", "threshold_met",
+	))
+
+	RecordLooperAttempt(
+		"confidence", "candidate", "succeeded", "threshold_met",
+		250, &firstByte, 10, 5, &cost, "USD",
+	)
+
+	after := testutil.ToFloat64(LooperAttemptsTotal.WithLabelValues(
+		"confidence", "candidate", "succeeded", "threshold_met",
+	))
+	if after != before+1 {
+		t.Fatalf("attempt counter = %v, want %v", after, before+1)
+	}
+	if got := testutil.ToFloat64(LooperAttemptTokens.WithLabelValues("confidence", "candidate", "prompt")); got < 10 {
+		t.Fatalf("prompt token counter = %v, want at least 10", got)
+	}
+
+	assertMetricHasNoLabels(t, LooperAttemptsTotal, "model", "decision", "recipe", "ordinal", "request_id", "trace_id")
+}
+
+func assertMetricHasNoLabels(t *testing.T, collector prometheus.Collector, forbidden ...string) {
+	t.Helper()
+	descriptions := make(chan *prometheus.Desc, 10)
+	go func() {
+		collector.Describe(descriptions)
+		close(descriptions)
+	}()
+	for description := range descriptions {
+		text := description.String()
+		for _, label := range forbidden {
+			if strings.Contains(text, "variableLabels: {"+label+",") ||
+				strings.Contains(text, ","+label+",") || strings.Contains(text, ","+label+"}") {
+				t.Fatalf("metric descriptor contains forbidden label %q: %s", label, text)
+			}
+		}
+	}
+}

--- a/src/semantic-router/pkg/routerreplay/recorder.go
+++ b/src/semantic-router/pkg/routerreplay/recorder.go
@@ -47,6 +47,9 @@ type (
 	Outcome                       = store.Outcome
 	FusionPanelAttemptDiagnostics = store.FusionPanelAttemptDiagnostics
 	FusionQuorumDiagnostics       = store.FusionQuorumDiagnostics
+	LooperUsage                   = store.LooperUsage
+	LooperAttempt                 = store.LooperAttempt
+	LooperDiagnostics             = store.LooperDiagnostics
 	RouteDiagnostics              = store.RouteDiagnostics
 	RoutingRecord                 = store.Record
 	ToolTrace                     = store.ToolTrace

--- a/src/semantic-router/pkg/routerreplay/redaction/looper_diagnostics_test.go
+++ b/src/semantic-router/pkg/routerreplay/redaction/looper_diagnostics_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package redaction
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestRedactResponseBodyRemovesLooperAttemptDetails(t *testing.T) {
+	body := []byte(`{"route_diagnostics":{"selected_model":"large","looper":{"version":1,"trace_id":"trace-1","attempts":[{"ordinal":1,"model":"small"}],"final_attempt_ordinal":1}}}`)
+
+	redacted, changed, err := RedactResponseBody(body)
+	if err != nil || !changed {
+		t.Fatalf("RedactResponseBody() = changed %v, err %v", changed, err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(redacted, &payload); err != nil {
+		t.Fatalf("decode redacted response: %v", err)
+	}
+	diagnostics := payload["route_diagnostics"].(map[string]any)
+	looper := diagnostics["looper"].(map[string]any)
+	if len(looper) != 0 {
+		t.Fatalf("viewer response retained Looper attempt details: %+v", looper)
+	}
+	if diagnostics["selected_model"] != "large" {
+		t.Fatalf("viewer response removed selected model: %+v", diagnostics)
+	}
+}

--- a/src/semantic-router/pkg/routerreplay/redaction/redaction.go
+++ b/src/semantic-router/pkg/routerreplay/redaction/redaction.go
@@ -222,7 +222,7 @@ func redactRouteDiagnosticsMap(diagnostics map[string]any) bool {
 			changed = true
 		}
 	}
-	for _, field := range []string{"annotations", "signal_errors"} {
+	for _, field := range []string{"annotations", "signal_errors", "looper"} {
 		if clearObjectField(diagnostics, field) {
 			changed = true
 		}

--- a/src/semantic-router/pkg/routerreplay/store/looper_diagnostics_test.go
+++ b/src/semantic-router/pkg/routerreplay/store/looper_diagnostics_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2025 vLLM Semantic Router.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package store
+
+import "testing"
+
+func TestCloneRecordClonesLooperDiagnostics(t *testing.T) {
+	accepted := true
+	record := Record{RouteDiagnostics: &RouteDiagnostics{Looper: &LooperDiagnostics{
+		Version:   1,
+		TraceID:   "trace-1",
+		Algorithm: "confidence",
+		Attempts: []LooperAttempt{{
+			Ordinal: 1, Stage: "candidate",
+			Status: "succeeded", Accepted: &accepted, Selected: true,
+			Usage: LooperUsage{PromptTokens: 3, CompletionTokens: 2, TotalTokens: 5},
+		}},
+		FinalAttemptOrdinal: 1,
+	}}}
+
+	cloned := cloneRecord(record)
+	cloned.RouteDiagnostics.Looper.Attempts[0].Model = "changed"
+	*cloned.RouteDiagnostics.Looper.Attempts[0].Accepted = false
+
+	original := record.RouteDiagnostics.Looper.Attempts[0]
+	if original.Model != "" || original.Accepted == nil || !*original.Accepted {
+		t.Fatalf("clone mutated original Looper diagnostics: %+v", original)
+	}
+}

--- a/src/semantic-router/pkg/routerreplay/store/store.go
+++ b/src/semantic-router/pkg/routerreplay/store/store.go
@@ -111,6 +111,55 @@ type ToolTraceStep struct {
 	Truncated bool `json:"truncated,omitempty"`
 }
 
+// LooperUsage is content-free token accounting for one Looper attempt.
+type LooperUsage struct {
+	PromptTokens     int64 `json:"prompt_tokens,omitempty"`
+	CompletionTokens int64 `json:"completion_tokens,omitempty"`
+	TotalTokens      int64 `json:"total_tokens,omitempty"`
+}
+
+// LooperAttempt records one bounded model or verifier attempt without content.
+type LooperAttempt struct {
+	Ordinal int    `json:"ordinal"`
+	Stage   string `json:"stage"`
+	Role    string `json:"role,omitempty"`
+	Model   string `json:"model,omitempty"`
+
+	Status      string `json:"status"`
+	Reason      string `json:"reason,omitempty"`
+	Usable      *bool  `json:"usable,omitempty"`
+	Accepted    *bool  `json:"accepted,omitempty"`
+	Selected    bool   `json:"selected,omitempty"`
+	Synthesized bool   `json:"synthesized,omitempty"`
+	Discarded   bool   `json:"discarded,omitempty"`
+
+	VerifierType       string      `json:"verifier_type,omitempty"`
+	VerifierVersion    string      `json:"verifier_version,omitempty"`
+	Score              *float64    `json:"score,omitempty"`
+	Threshold          *float64    `json:"threshold,omitempty"`
+	ReservedTokens     *int64      `json:"reserved_tokens,omitempty"`
+	EstimatedTokens    *int64      `json:"estimated_tokens,omitempty"`
+	Usage              LooperUsage `json:"usage,omitempty"`
+	EstimatedCost      *float64    `json:"estimated_cost,omitempty"`
+	ActualCost         *float64    `json:"actual_cost,omitempty"`
+	Currency           string      `json:"currency,omitempty"`
+	QueueLatencyMs     *int64      `json:"queue_latency_ms,omitempty"`
+	FirstByteLatencyMs *int64      `json:"first_byte_latency_ms,omitempty"`
+	TotalLatencyMs     int64       `json:"total_latency_ms"`
+}
+
+// LooperDiagnostics is the versioned, bounded execution trace retained by Replay.
+type LooperDiagnostics struct {
+	Version             int             `json:"version"`
+	TraceID             string          `json:"trace_id,omitempty"`
+	Algorithm           string          `json:"algorithm"`
+	Attempts            []LooperAttempt `json:"attempts,omitempty"`
+	FinalAttemptOrdinal int             `json:"final_attempt_ordinal,omitempty"`
+	AttemptsTruncated   bool            `json:"attempts_truncated,omitempty"`
+	DroppedAttemptCount int             `json:"dropped_attempt_count,omitempty"`
+	DroppedUsage        LooperUsage     `json:"dropped_usage,omitempty"`
+}
+
 // RouteDiagnostics summarizes the final route, Router Learning protection,
 // and memory outcome in a stable replay-facing shape. Detailed per-candidate
 // learning diagnostics live in the typed Learning block.
@@ -121,6 +170,7 @@ type RouteDiagnostics struct {
 	SelectionMethod                string                   `json:"selection_method,omitempty"`
 	SelectionReasoning             string                   `json:"selection_reasoning,omitempty"`
 	FusionQuorum                   *FusionQuorumDiagnostics `json:"fusion_quorum,omitempty"`
+	Looper                         *LooperDiagnostics       `json:"looper,omitempty"`
 	PromptHelperModel              string                   `json:"prompt_helper_model,omitempty"`
 	PromptHelperPromptTokens       int64                    `json:"prompt_helper_prompt_tokens,omitempty"`
 	PromptHelperCompletionTokens   int64                    `json:"prompt_helper_completion_tokens,omitempty"`
@@ -536,9 +586,25 @@ func cloneRouteDiagnostics(value *RouteDiagnostics) *RouteDiagnostics {
 	}
 	cloned := *value
 	cloned.FusionQuorum = cloneFusionQuorumDiagnostics(value.FusionQuorum)
+	cloned.Looper = cloneLooperDiagnostics(value.Looper)
 	cloned.Annotations = cloneInterfaceMap(value.Annotations)
 	cloned.SignalErrors = cloneStringMap(value.SignalErrors)
 	cloned.AppliedUnknownPolicies = cloneStringMap(value.AppliedUnknownPolicies)
+	return &cloned
+}
+
+func cloneLooperDiagnostics(value *LooperDiagnostics) *LooperDiagnostics {
+	if value == nil {
+		return nil
+	}
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return nil
+	}
+	var cloned LooperDiagnostics
+	if err := json.Unmarshal(encoded, &cloned); err != nil {
+		return nil
+	}
 	return &cloned
 }
 

--- a/website/docs/tutorials/algorithm/looper/confidence.md
+++ b/website/docs/tutorials/algorithm/looper/confidence.md
@@ -126,6 +126,19 @@ Both implement the AutoMix paper's cascade idea but differ in how the verificati
 | Extra infra | None | Requires running [`automix_verifier.py`](https://github.com/vllm-project/semantic-router/blob/main/src/training/model_selection/rl_model_selection/automix_verifier.py) |
 | When to pick | Single-deployment setups; no extra server | Production routes where verifier model can be smaller/specialized |
 
+## Attempt observability
+
+Confidence executions create a `looper.execute` trace span with one
+`looper.attempt` child for each dispatched candidate or verifier call. Router
+Replay stores the corresponding bounded, content-free attempt records under
+`route_diagnostics.looper`, including status, threshold outcome, token usage,
+latency, and the final attempt ordinal. Prompts, responses, reasoning, endpoint
+URLs, credentials, and raw errors are never included in this structure.
+
+The first detailed-attempt implementation covers Confidence. Other Looper
+algorithms continue to expose their existing aggregate diagnostics until they
+adopt the shared attempt lifecycle.
+
 Every escalation sends the request and accumulated answer context to another
 candidate model. Make sure every candidate is allowed by the route's data
 policy, and bound latency and cost for the worst-case chain. See a complete example:

--- a/website/docs/tutorials/global/api-and-observability.md
+++ b/website/docs/tutorials/global/api-and-observability.md
@@ -113,10 +113,17 @@ Common Prometheus metric families:
 | Tokens and cost | `llm_model_tokens_total`, `llm_model_prompt_tokens_total`, `llm_model_completion_tokens_total`, `llm_model_cost_total` |
 | Routing | `llm_model_routing_modifications_total`, `llm_routing_reason_codes_total` |
 | Selection | `llm_model_selection_total`, `llm_model_selection_duration_seconds`, `llm_model_inflight_requests` |
+| Looper | `llm_looper_attempts_total`, `llm_looper_attempt_duration_seconds`, `llm_looper_attempt_first_byte_seconds`, `llm_looper_attempt_tokens_total`, `llm_looper_attempt_cost_total`, `llm_looper_execution_duration_seconds` |
 | Cache | `llm_cache_plugin_hits_total`, `llm_cache_plugin_misses_total`, `llm_cache_warmth_estimate` |
 | RAG | `rag_retrieval_attempts_total`, `rag_retrieval_latency_seconds`, `rag_cache_hits_total`, `rag_cache_misses_total` |
 | Session | `llm_session_model_transitions_total`, `llm_session_turn_prompt_tokens`, `llm_session_turn_completion_tokens`, `llm_session_turn_cost` |
 | Translation and request-parameter policy | `llm_translation_lossy_total`, `sr_request_params_blocked_total`, `sr_request_params_unknown_field_stripped_total` |
+
+Looper metric labels are restricted to bounded algorithm, stage, status,
+reason, token-type, and currency values. Request IDs, trace IDs, ordinals,
+decision names, model names, scores, and thresholds are available through
+traces or detailed Router Replay rather than Prometheus labels. Detailed
+attempt metrics currently cover the Confidence algorithm.
 
 ### Profiling
 

--- a/website/docs/tutorials/plugin/router-replay.md
+++ b/website/docs/tutorials/plugin/router-replay.md
@@ -45,6 +45,20 @@ plugins:
       max_tool_trace_steps: 100
 ```
 
+## Looper diagnostics
+
+Confidence Looper records include a versioned `route_diagnostics.looper`
+object. It contains bounded attempt metadata, token and cost accounting,
+latencies, disposition reason codes, the OpenTelemetry trace ID when tracing is
+active, and `final_attempt_ordinal`. Attempt details are omitted from
+viewer-redacted responses and remain available to principals with replay-detail
+permission.
+
+Looper diagnostics never contain prompts, responses, hidden reasoning, tool
+arguments, endpoint URLs, credentials, or raw errors. Attempt count and encoded
+size are capped; truncation is explicit and dropped token usage remains
+accounted for.
+
 Request bodies, response bodies, and tool traces can contain secrets or personal
 data. Capture the minimum needed, set retention in the shared replay service,
 and restrict replay read permissions. See a complete example:


### PR DESCRIPTION
Closes #2855
Related #2336

## Purpose

Add the first bounded per-attempt Looper observability vertical for Confidence:

- create `looper.execute` parent spans and correlated child attempt spans;
- propagate W3C trace context through internal Looper calls;
- record bounded status, disposition, latency, token, and configured-cost evidence;
- persist versioned, content-free attempt diagnostics in Router Replay;
- expose low-cardinality Prometheus counters and histograms;
- keep prompts, responses, reasoning, credentials, endpoints, and raw errors out of telemetry.

The shared envelope is reusable by later Fusion, ReMoM, Ratings, and Workflow migrations without including those migrations in this PR.

## Test Plan

- `go test ./pkg/looper ./pkg/observability/metrics ./pkg/routerreplay/... ./pkg/extproc`
- `go test ./testcases ./profiles/looper` from `e2e/`
- changed-package `golangci-lint` for router and E2E packages
- `make verify PROFILE=looper`

## Test Result

All listed checks passed. The Looper profile passed all three cases, including the new Confidence Replay and metrics contract.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category
- [x] The title does not stack prefixes
- [x] The PR links accepted issue #2855 and parent #2336
- [x] Commits are signed off
- [x] Purpose, test plan, and results reflect this PR

</details>
