### PR TITLE
[Test] Add E2E coverage for the reask signal

### DIFF
--- a/.github/workflows/integration-test-k8s.yml
+++ b/.github/workflows/integration-test-k8s.yml
@@ -87,7 +87,7 @@ jobs:
           set +e
           if [ "${{ matrix.profile }}" = "envoy-ai-gateway" ]; then
             # Temporarily skip the stress / pressure coverage until the suite is stable again.
-            ENVOY_AI_GATEWAY_CI_TESTS="chat-completions-request,apiserver-runtime-config-endpoints,domain-classify,semantic-cache,semantic-cache-polarity,pii-detection,pii-entity-offsets,pii-long-text,jailbreak-detection,security-long-text,decision-priority-selection,plugin-chain-execution,tool-selection,rule-condition-logic,decision-fallback-behavior,plugin-config-variations,event-routing,plugin-short-circuit-no-dispatch,language-routing"
+            ENVOY_AI_GATEWAY_CI_TESTS="chat-completions-request,apiserver-runtime-config-endpoints,domain-classify,semantic-cache,semantic-cache-polarity,pii-detection,pii-entity-offsets,pii-long-text,jailbreak-detection,security-long-text,decision-priority-selection,plugin-chain-execution,tool-selection,rule-condition-logic,decision-fallback-behavior,plugin-config-variations,event-routing,plugin-short-circuit-no-dispatch,language-routing,reask-routing"
             make e2e-test E2E_PROFILE=${{ matrix.profile }} E2E_TESTS="${ENVOY_AI_GATEWAY_CI_TESTS}" E2E_VERBOSE=true E2E_KEEP_CLUSTER=false
             TEST_EXIT_CODE=$?
             set -e

--- a/e2e/pkg/testmatrix/testcases.go
+++ b/e2e/pkg/testmatrix/testcases.go
@@ -55,6 +55,8 @@ var BaselineRouterContract = []string{
 	"event-routing",
 	// Language signal rule matching and routing (issue #3178)
 	"language-routing",
+	// Reask signal rule matching and routing (issue #3178)
+	"reask-routing",
 }
 
 // DashboardContract is the canonical E2E contract for the dashboard API surface.

--- a/e2e/profiles/ai-gateway/values.yaml
+++ b/e2e/profiles/ai-gateway/values.yaml
@@ -599,6 +599,24 @@ config:
               enabled: true
               system_prompt: You are responding to a Spanish-language query. Respond in Spanish.
               mode: replace
+      - name: reask_escalation
+        description: User has repeated a similar question across recent turns without resolution
+        priority: 45
+        rules:
+          operator: AND
+          conditions:
+            - type: reask
+              name: repeated_billing_question
+        modelRefs:
+          - model: base-model
+            lora_name: general-expert
+            use_reasoning: false
+        plugins:
+          - type: system_prompt
+            configuration:
+              enabled: true
+              system_prompt: The user has asked a similar question multiple times without a resolution. Acknowledge this and provide a definitive, complete answer.
+              mode: replace
       - name: other_decision
         description: General knowledge and miscellaneous topics
         priority: 1
@@ -690,6 +708,11 @@ config:
       language:
         - name: es
           description: Spanish-language requests.
+      reasks:
+        - name: repeated_billing_question
+          description: Current user turn closely repeats the last two billing complaints.
+          threshold: 0.8
+          lookback_turns: 2
       domains:
         - name: business
           description: Business, corporate strategy, management, finance, marketing

--- a/e2e/testcases/chat_completion_helpers.go
+++ b/e2e/testcases/chat_completion_helpers.go
@@ -19,11 +19,8 @@ type localChatCompletionResponse struct {
 	Body       []byte
 }
 
-// sendLocalChatCompletion sends a chat-completion request to the router. It
-// always sets the x-vsr-debug request header: the v0.4 contract demotes the
-// intermediate decision/classification and matched-signal response headers off
-// the default surface (#2205), and every routing/classification test using this
-// helper asserts those demoted headers, so the debug surface is always required.
+// sendLocalChatCompletion sends a chat-completion request carrying a single
+// user prompt. See sendLocalChatConversation for the request/header details.
 func sendLocalChatCompletion(
 	ctx context.Context,
 	localPort string,
@@ -31,11 +28,29 @@ func sendLocalChatCompletion(
 	prompt string,
 	timeout time.Duration,
 ) (*localChatCompletionResponse, error) {
+	return sendLocalChatConversation(ctx, localPort, model, []map[string]string{
+		{"role": "user", "content": prompt},
+	}, timeout)
+}
+
+// sendLocalChatConversation sends a chat-completion request carrying a full
+// conversation (e.g. alternating user/assistant messages), for signals that
+// need prior-turn context (e.g. reask). It always sets the x-vsr-debug
+// request header: the v0.4 contract demotes the intermediate
+// decision/classification and matched-signal response headers off the
+// default surface (#2205), and every routing/classification test using this
+// helper asserts those demoted headers, so the debug surface is always
+// required.
+func sendLocalChatConversation(
+	ctx context.Context,
+	localPort string,
+	model string,
+	messages []map[string]string,
+	timeout time.Duration,
+) (*localChatCompletionResponse, error) {
 	requestBody := map[string]interface{}{
-		"model": model,
-		"messages": []map[string]string{
-			{"role": "user", "content": prompt},
-		},
+		"model":    model,
+		"messages": messages,
 	}
 
 	jsonData, err := json.Marshal(requestBody)

--- a/e2e/testcases/reask_routing.go
+++ b/e2e/testcases/reask_routing.go
@@ -1,0 +1,194 @@
+package testcases
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"k8s.io/client-go/kubernetes"
+
+	pkgtestcases "github.com/vllm-project/semantic-router/e2e/pkg/testcases"
+)
+
+// targetReaskDecision is the decision configured to route on the
+// repeated_billing_question reask rule (see e2e/profiles/ai-gateway/values.yaml).
+const targetReaskDecision = "reask_escalation"
+
+func init() {
+	pkgtestcases.Register("reask-routing", pkgtestcases.TestCase{
+		Description: "Test reask signal rule matching and routing",
+		Tags:        []string{"kubernetes", "routing", "reask"},
+		Fn:          testReaskRouting,
+	})
+}
+
+// ReaskRoutingCase represents a test case for reask signal routing. Unlike
+// the single-turn signals (event, language), reask needs prior-turn context,
+// so a case carries a full conversation rather than one query string.
+type ReaskRoutingCase struct {
+	Name                  string              `json:"name"`
+	Description           string              `json:"description"`
+	Messages              []map[string]string `json:"messages"`
+	ExpectedDecision      string              `json:"expected_decision"`
+	ExpectedMatchedSignal string              `json:"expected_matched_signal"`
+	ShouldMatch           bool                `json:"should_match"`
+}
+
+// ReaskRoutingResult tracks the result of a single ReaskRoutingCase.
+type ReaskRoutingResult struct {
+	Name                  string
+	ExpectedDecision      string
+	ActualDecision        string
+	ExpectedMatchedSignal string
+	ActualMatchedSignal   string
+	ShouldMatch           bool
+	DecisionCorrect       bool
+	MatchCorrect          bool
+	Error                 string
+}
+
+func testReaskRouting(ctx context.Context, client *kubernetes.Clientset, opts pkgtestcases.TestCaseOptions) error {
+	if opts.Verbose {
+		fmt.Println("[Test] Testing reask signal routing")
+	}
+
+	localPort, stopPortForward, err := setupServiceConnection(ctx, client, opts)
+	if err != nil {
+		return err
+	}
+	defer stopPortForward()
+
+	testCases, err := loadReaskRoutingCases("e2e/testcases/testdata/reask_routing_cases.json")
+	if err != nil {
+		return fmt.Errorf("failed to load test cases: %w", err)
+	}
+
+	var results []ReaskRoutingResult
+	totalTests := 0
+	correctTests := 0
+
+	for _, testCase := range testCases {
+		totalTests++
+		result := testSingleReaskRouting(ctx, testCase, localPort, opts.Verbose)
+		results = append(results, result)
+		if result.DecisionCorrect && result.MatchCorrect {
+			correctTests++
+		}
+	}
+
+	accuracy := float64(correctTests) / float64(totalTests) * 100
+
+	if opts.SetDetails != nil {
+		opts.SetDetails(map[string]interface{}{
+			"total_tests":   totalTests,
+			"correct_tests": correctTests,
+			"accuracy_rate": fmt.Sprintf("%.2f%%", accuracy),
+			"failed_tests":  totalTests - correctTests,
+		})
+	}
+
+	printReaskRoutingResults(results, totalTests, correctTests, accuracy)
+
+	if opts.Verbose {
+		fmt.Printf("[Test] Reask routing test completed: %d/%d correct (%.2f%% accuracy)\n",
+			correctTests, totalTests, accuracy)
+	}
+
+	if correctTests != totalTests {
+		return fmt.Errorf("reask routing test failed: %d/%d correct", correctTests, totalTests)
+	}
+
+	return nil
+}
+
+func loadReaskRoutingCases(filepath string) ([]ReaskRoutingCase, error) {
+	data, err := os.ReadFile(filepath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read test cases file: %w", err)
+	}
+
+	var cases []ReaskRoutingCase
+	if err := json.Unmarshal(data, &cases); err != nil {
+		return nil, fmt.Errorf("failed to parse test cases: %w", err)
+	}
+
+	return cases, nil
+}
+
+func testSingleReaskRouting(ctx context.Context, testCase ReaskRoutingCase, localPort string, verbose bool) ReaskRoutingResult {
+	result := ReaskRoutingResult{
+		Name:                  testCase.Name,
+		ExpectedDecision:      testCase.ExpectedDecision,
+		ExpectedMatchedSignal: testCase.ExpectedMatchedSignal,
+		ShouldMatch:           testCase.ShouldMatch,
+	}
+
+	// testCase.Messages is a full multi-turn conversation (the reask signal
+	// needs prior-turn context, unlike the single-query event/language cases).
+	response, err := sendLocalChatConversation(ctx, localPort, "MoM", testCase.Messages, 30*time.Second)
+	if err != nil {
+		result.Error = err.Error()
+		return result
+	}
+
+	if response.StatusCode != http.StatusOK {
+		result.Error = formatUnexpectedChatCompletionStatus(response)
+		logUnexpectedChatCompletionStatus(verbose, response, "test case: "+testCase.Name,
+			"Should match: "+fmt.Sprintf("%v", testCase.ShouldMatch))
+		return result
+	}
+
+	decision := response.Headers.Get("x-vsr-selected-decision")
+	result.ActualDecision = strings.TrimSuffix(decision, "_decision")
+	result.ActualMatchedSignal = response.Headers.Get("x-vsr-matched-reask")
+
+	if testCase.ShouldMatch {
+		result.DecisionCorrect = result.ActualDecision == testCase.ExpectedDecision
+		result.MatchCorrect = result.ActualMatchedSignal == testCase.ExpectedMatchedSignal
+	} else {
+		result.DecisionCorrect = result.ActualDecision != targetReaskDecision
+		result.MatchCorrect = result.ActualMatchedSignal == ""
+	}
+
+	if verbose && (!result.DecisionCorrect || !result.MatchCorrect) {
+		fmt.Printf("[Test] Test case failed: %s\n", testCase.Name)
+		if !result.DecisionCorrect {
+			fmt.Printf("  Decision mismatch: expected=%s, actual=%s\n",
+				testCase.ExpectedDecision, result.ActualDecision)
+		}
+		if !result.MatchCorrect {
+			fmt.Printf("  Matched-signal mismatch: expected=%q, actual=%q\n",
+				testCase.ExpectedMatchedSignal, result.ActualMatchedSignal)
+		}
+	}
+
+	return result
+}
+
+func printReaskRoutingResults(results []ReaskRoutingResult, totalTests, correctTests int, accuracy float64) {
+	separator := "================================================================================"
+	fmt.Println("\n" + separator)
+	fmt.Println("REASK ROUTING TEST RESULTS")
+	fmt.Println(separator)
+	fmt.Printf("Total Tests: %d\n", totalTests)
+	fmt.Printf("Correct: %d (%.2f%%)\n", correctTests, accuracy)
+	fmt.Println(separator)
+
+	for _, result := range results {
+		if result.Error != "" {
+			fmt.Printf("  - Test: %s\n    Error: %s\n", result.Name, result.Error)
+			continue
+		}
+		if !result.DecisionCorrect || !result.MatchCorrect {
+			fmt.Printf("  - Test: %s\n    Expected decision: %s, actual: %s\n    Expected matched signal: %q, actual: %q\n",
+				result.Name, result.ExpectedDecision, result.ActualDecision,
+				result.ExpectedMatchedSignal, result.ActualMatchedSignal)
+		}
+	}
+
+	fmt.Println(separator + "\n")
+}

--- a/e2e/testcases/signal_routing_contract_test.go
+++ b/e2e/testcases/signal_routing_contract_test.go
@@ -19,6 +19,7 @@ var signalRoutingContracts = []struct {
 }{
 	{profile: "envoy-ai-gateway", testCase: "event-routing"},
 	{profile: "envoy-ai-gateway", testCase: "language-routing"},
+	{profile: "envoy-ai-gateway", testCase: "reask-routing"},
 }
 
 func TestProfilesSelectSignalRoutingContracts(t *testing.T) {

--- a/e2e/testcases/testdata/reask_routing_cases.json
+++ b/e2e/testcases/testdata/reask_routing_cases.json
@@ -1,0 +1,44 @@
+[
+  {
+    "name": "Repeated invoice complaint across 3 turns",
+    "description": "repeated_billing_question matches when the current turn closely repeats the last two turns' billing complaint",
+    "messages": [
+      {"role": "user", "content": "My invoice this month is wrong, can you help me fix it?"},
+      {"role": "assistant", "content": "I'm sorry to hear that. Could you tell me which charge looks incorrect?"},
+      {"role": "user", "content": "The invoice you sent me is still incorrect. Please correct the billing amount."},
+      {"role": "assistant", "content": "I've flagged this for review. Is there anything else incorrect on the invoice?"},
+      {"role": "user", "content": "This bill is still wrong and hasn't been fixed. I need this corrected now."}
+    ],
+    "expected_decision": "reask_escalation",
+    "expected_matched_signal": "repeated_billing_question",
+    "should_match": true
+  },
+  {
+    "name": "Repeated duplicate-charge complaint across 3 turns",
+    "description": "repeated_billing_question matches a second, unrelated repeated billing complaint",
+    "messages": [
+      {"role": "user", "content": "I was charged twice for my subscription this month, can you refund the duplicate charge?"},
+      {"role": "assistant", "content": "Let me look into that duplicate charge for you."},
+      {"role": "user", "content": "You still haven't refunded the duplicate charge on my subscription."},
+      {"role": "assistant", "content": "I apologize for the delay, checking the status now."},
+      {"role": "user", "content": "The duplicate subscription charge is still not refunded, please fix this."}
+    ],
+    "expected_decision": "reask_escalation",
+    "expected_matched_signal": "repeated_billing_question",
+    "should_match": true
+  },
+  {
+    "name": "Unrelated topics across turns",
+    "description": "repeated_billing_question should not trigger when each turn is about a different, unrelated topic. expected_decision is left empty because the test only checks that the actual decision is not reask_escalation, not what it actually is",
+    "messages": [
+      {"role": "user", "content": "What's the weather like in Tokyo in April?"},
+      {"role": "assistant", "content": "Tokyo in April is generally mild with cherry blossoms in bloom."},
+      {"role": "user", "content": "Can you recommend a good beginner recipe for sourdough bread?"},
+      {"role": "assistant", "content": "Sure, a simple sourdough starter involves flour and water fermented over several days."},
+      {"role": "user", "content": "What are some tips for improving my golf swing?"}
+    ],
+    "expected_decision": "",
+    "expected_matched_signal": "",
+    "should_match": false
+  }
+]

--- a/e2e/testcases/testdata/reask_routing_cases.json
+++ b/e2e/testcases/testdata/reask_routing_cases.json
@@ -3,11 +3,11 @@
     "name": "Repeated invoice complaint across 3 turns",
     "description": "repeated_billing_question matches when the current turn closely repeats the last two turns' billing complaint",
     "messages": [
-      {"role": "user", "content": "My invoice this month is wrong, can you help me fix it?"},
-      {"role": "assistant", "content": "I'm sorry to hear that. Could you tell me which charge looks incorrect?"},
-      {"role": "user", "content": "The invoice you sent me is still incorrect. Please correct the billing amount."},
-      {"role": "assistant", "content": "I've flagged this for review. Is there anything else incorrect on the invoice?"},
-      {"role": "user", "content": "This bill is still wrong and hasn't been fixed. I need this corrected now."}
+      {"role": "user", "content": "My invoice this month is wrong, can you help me fix the invoice?"},
+      {"role": "assistant", "content": "I'm sorry to hear that. Could you tell me which charge on the invoice looks incorrect?"},
+      {"role": "user", "content": "The invoice is still wrong. Please fix the invoice amount."},
+      {"role": "assistant", "content": "I've flagged the invoice for review. Is there anything else wrong with the invoice?"},
+      {"role": "user", "content": "The invoice is still wrong and hasn't been fixed. I need the invoice corrected now."}
     ],
     "expected_decision": "reask_escalation",
     "expected_matched_signal": "repeated_billing_question",


### PR DESCRIPTION
Related #3178

## Purpose

Add e2e test for the reask routing signal (config.SignalTypeReask). It
currently has only Go unit tests for its classifier logic
(`reask_classifier_test.go`) and no end-to-end behavioral coverage
through a deployed request path, as required by #3178.

This PR adds:
- A `repeated_billing_question` reask rule (threshold 0.8,
  lookback_turns 2) and a `reask_escalation` decision (priority 45)
  to `e2e/profiles/ai-gateway/values.yaml`.
- `e2e/testcases/reask_routing.go`, following the same load/loop/print
  pattern as `event_routing.go`/`language_routing.go`, but
  self-contained rather than reusing `signal_routing_helpers.go`:
  reask needs prior-turn context (a full conversation) instead of a
  single query, and its harness has exactly one consumer today, so
  there's no real duplication yet to justify generalizing the shared
  struct.
- `e2e/testcases/testdata/reask_routing_cases.json` with two positive
  cases (a repeated billing complaint across 3 turns, phrased two
  different ways) and one negative case (unrelated topics per turn).
- `sendLocalChatCompletion` in `chat_completion_helpers.go` is
  refactored into a thin wrapper around a new
  `sendLocalChatConversation`, which sends a full multi-turn
  conversation instead of a single prompt.
- `reask-routing` registered in `BaselineRouterContract`, a new row in
  `signal_routing_contract_test.go`, and the
  `ENVOY_AI_GATEWAY_CI_TESTS` list in
  `.github/workflows/integration-test-k8s.yml`.

Owning Workgroup: Evaluation & Quality (`wg/evaluation-quality`).

## Test Plan

- `gofmt -l e2e/testcases/reask_routing.go e2e/testcases/chat_completion_helpers.go`
- `go vet ./...` (run from `e2e/`)
- `go build ./...` (run from `e2e/`)
- `golangci-lint run ./pkg/testmatrix ./testcases` (run from `e2e/`, using `tools/linter/go/.golangci.yml`)
- `go test ./testcases/... -run TestProfilesSelectSignalRoutingContracts`
- `make e2e-test-specific E2E_TESTS="reask-routing"` (multiple local attempts)

## Test Result

- gofmt / go vet / go build: pass.
- golangci-lint: 0 issues in the files this PR touches.
- `TestProfilesSelectSignalRoutingContracts`: pass, confirms the
  `envoy-ai-gateway` profile selects `reask-routing`.
- `make e2e-test-specific E2E_TESTS="reask-routing"`: the test executed
  and got real responses from the router, but every local attempt hit
  local Kind cluster instability unrelated to this change (even the
  pre-existing `chat-completions-request` test failed the same way
  alongside it). Deferring final e2e confirmation to CI on this PR,
  consistent with #3399 and #3507.
- Manually verified the priority ordering in `values.yaml`: the new
  `reask_escalation` decision (priority 45) doesn't collide with any
  existing priority, and the test conversations don't contain any
  other decisions' trigger keywords.

---
AI assistance (Claude Code) was used to draft this change, under my review;
I read and understand the diff and take responsibility for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
