### PR TITLE
[Feature] Add GPT-6 Astra to OpenRouter built-in support

### DIFF
--- a/config/catalog/resources/providers/openrouter.yaml
+++ b/config/catalog/resources/providers/openrouter.yaml
@@ -547,3 +547,23 @@ models:
     status: claimed
     verified_at: 2026-09-05
     source: https://openrouter.ai/api/v1/models
+- catalog: openai/gpt-6-astra
+  relationship: gateway
+  id: openai/gpt-6-astra
+  protocols:
+  - openai/chat-completions@1
+  reasoning_modes: [enabled]
+  reasoning_efforts: [low, medium, high, xhigh]
+  reasoning_efforts_by_protocol:
+    openai/chat-completions@1: [low, medium, high, xhigh]
+  pricing:
+    currency: USD
+    prompt_per_1m: 10.0
+    cached_input_per_1m: 1.0
+    cache_write_per_1m: 12.5
+    completion_per_1m: 50.0
+  lifecycle: active
+  verification:
+    status: claimed
+    verified_at: 2026-09-08
+    source: https://openrouter.ai/openai/gpt-6-astra

--- a/config/recipes/built-in/latest/catalog.yaml
+++ b/config/recipes/built-in/latest/catalog.yaml
@@ -2219,6 +2219,35 @@ providers:
       status: claimed
       verified_at: '2026-09-05'
       source: https://openrouter.ai/api/v1/models
+  - catalog: openai/gpt-6-astra
+    relationship: gateway
+    id: openai/gpt-6-astra
+    protocols:
+    - openai/chat-completions@1
+    reasoning_modes:
+    - enabled
+    reasoning_efforts:
+    - low
+    - medium
+    - high
+    - xhigh
+    reasoning_efforts_by_protocol:
+      openai/chat-completions@1:
+      - low
+      - medium
+      - high
+      - xhigh
+    pricing:
+      currency: USD
+      prompt_per_1m: 10.0
+      cached_input_per_1m: 1.0
+      cache_write_per_1m: 12.5
+      completion_per_1m: 50.0
+    lifecycle: active
+    verification:
+      status: claimed
+      verified_at: '2026-09-08'
+      source: https://openrouter.ai/openai/gpt-6-astra
 - id: perplexity
   display_name: Perplexity
   description: Search-grounded models and online answers.

--- a/src/semantic-router/pkg/catalog/zz_generated_catalog.go
+++ b/src/semantic-router/pkg/catalog/zz_generated_catalog.go
@@ -2,7 +2,7 @@
 
 package catalog
 
-const builtInCatalogDigest = "sha256:023210b43682c690f9285426614e45140e3064cbee521d9bf5650a654edd3e16"
+const builtInCatalogDigest = "sha256:b9deeb347f4f1eb7f3e0282abfd599133bf8f05f18d309b87a68451c44cb3d66"
 
 const builtInCatalogJSON = `{
   "benchmarks": [
@@ -43899,6 +43899,44 @@ const builtInCatalogJSON = `{
             "source": "https://openrouter.ai/api/v1/models",
             "status": "claimed",
             "verified_at": "2026-09-05"
+          }
+        },
+        {
+          "catalog": "openai/gpt-6-astra",
+          "id": "openai/gpt-6-astra",
+          "lifecycle": "active",
+          "pricing": {
+            "cache_write_per_1m": 12.5,
+            "cached_input_per_1m": 1.0,
+            "completion_per_1m": 50.0,
+            "currency": "USD",
+            "prompt_per_1m": 10.0
+          },
+          "protocols": [
+            "openai/chat-completions@1"
+          ],
+          "reasoning_efforts": [
+            "low",
+            "medium",
+            "high",
+            "xhigh"
+          ],
+          "reasoning_efforts_by_protocol": {
+            "openai/chat-completions@1": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          },
+          "reasoning_modes": [
+            "enabled"
+          ],
+          "relationship": "gateway",
+          "verification": {
+            "source": "https://openrouter.ai/openai/gpt-6-astra",
+            "status": "claimed",
+            "verified_at": "2026-09-08"
           }
         }
       ],

--- a/src/semantic-router/pkg/extproc/provider_request_catalog_contract_test.go
+++ b/src/semantic-router/pkg/extproc/provider_request_catalog_contract_test.go
@@ -230,6 +230,12 @@ func TestBuiltInCatalogSpecializedReasoningWireContracts(t *testing.T) {
 			wantTransport: modelcatalog.ReasoningTransportReasoningObject,
 			wantControls:  map[string]interface{}{"reasoning": map[string]interface{}{"effort": "medium"}},
 		},
+		{
+			name: "OpenRouter GPT-6 Astra Chat reasoning object", catalog: "openai/gpt-6-astra", provider: "openrouter",
+			enabled: true, mode: config.ReasoningModeEnabled, effort: "high",
+			wantTransport: modelcatalog.ReasoningTransportReasoningObject,
+			wantControls:  map[string]interface{}{"reasoning": map[string]interface{}{"effort": "high"}},
+		},
 	}
 	runCatalogReasoningWireCases(t, tests)
 }

--- a/website/static/model-catalog/catalog.json
+++ b/website/static/model-catalog/catalog.json
@@ -43894,6 +43894,44 @@
             "status": "claimed",
             "verified_at": "2026-09-05"
           }
+        },
+        {
+          "catalog": "openai/gpt-6-astra",
+          "id": "openai/gpt-6-astra",
+          "lifecycle": "active",
+          "pricing": {
+            "cache_write_per_1m": 12.5,
+            "cached_input_per_1m": 1.0,
+            "completion_per_1m": 50.0,
+            "currency": "USD",
+            "prompt_per_1m": 10.0
+          },
+          "protocols": [
+            "openai/chat-completions@1"
+          ],
+          "reasoning_efforts": [
+            "low",
+            "medium",
+            "high",
+            "xhigh"
+          ],
+          "reasoning_efforts_by_protocol": {
+            "openai/chat-completions@1": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          },
+          "reasoning_modes": [
+            "enabled"
+          ],
+          "relationship": "gateway",
+          "verification": {
+            "source": "https://openrouter.ai/openai/gpt-6-astra",
+            "status": "claimed",
+            "verified_at": "2026-09-08"
+          }
         }
       ],
       "presentation": {


### PR DESCRIPTION
Closes #3564.

## Purpose

Expose `openai/gpt-6-astra` through the built-in `openrouter` provider. OpenRouter publishes the model as a **Chat Completions-only** gateway route; the direct OpenAI version added by #3561 additionally speaks Responses, but the gateway's own contract is the authority for its own protocol list, so this binding does not advertise Responses.

Key deliberate choices (each raised in the commit message for review):

- **Protocols** — only `openai/chat-completions@1`. OpenRouter's model page and models API list no Responses endpoint for this model.
- **Reasoning transport** — inherits the provider-level `reasoning_object` transport already declared on OpenRouter (mirrors `qwen/qwen3.8-max`).
- **Reasoning efforts** — capped at `[low, medium, high, xhigh]`, **no `max`**. Neither the model page nor the models API distinguishes a `max` tier for this gateway route, and asserting one without provider evidence would turn routed traffic into an upstream 4xx.
- **Pricing** — base tier from https://openrouter.ai/api/v1/models on 2026-09-08 (`$10 / $50 / $1 / $12.5 per 1M`). The 272k long-context override tier is intentionally omitted; the current pricing schema exposes one flat tier per binding, and the schema extension that would represent the second tier is tracked separately in #3348.
- **Restrictions** — `tools_protocols` and `unsupported_request_fields` are intentionally omitted. OpenRouter's page lists `tools` / `tool_choice` under `supported_parameters`, but does not document how the gateway reconciles them with GPT-6 Astra's direct-OpenAI Chat contract, which disallows tools on that protocol. Declaring either shape without confirmed gateway behaviour would misroute tool-calling traffic or silently accept requests the upstream will reject. Follow-up work can add both fields when the gateway behaviour is verified end-to-end.

The contract test extends `TestBuiltInCatalogSpecializedReasoningWireContracts` with a new `"OpenRouter GPT-6 Astra Chat reasoning object"` case that proves the final provider-boundary request body carries a `reasoning.effort` object, matching the provider's `reasoning_object` transport.

## Test Plan

```bash
# 1. Regenerate downstream projections from the authored provider yaml
make model-catalog-generate

# 2. Catalog validation + all catalog-test lanes
make model-catalog-check

# 3. Go tests on the packages touched by this binding
CGO_LDFLAGS="-L$PWD/candle-binding/target/release \
             -L$PWD/nlp-binding/target/release \
             -L$PWD/ml-binding/target/release" \
CGO_CFLAGS="-Wno-nullability-completeness -Wno-error" \
  (cd src/semantic-router && \
    go test ./pkg/catalog/... ./pkg/config/... ./pkg/extproc/ \
      -count=1 -timeout 300s)
```

## Test Result

- `model-catalog-generate`: clean regeneration; only expected downstream diffs (`config/recipes/built-in/latest/catalog.yaml`, `src/semantic-router/pkg/catalog/zz_generated_catalog.go`, `website/static/model-catalog/catalog.json`).
- `model-catalog-check`: **57/58 pass.** The single failing test is `test_model_layout_stays_inside_catalog_and_uses_one_file_per_creator`, which reproduces unchanged on clean `upstream/main` on macOS — the same pre-existing `/private/var` vs `/var` symlink issue reported in #3626.
- Go tests: `pkg/catalog`, `pkg/config`, `pkg/extproc` all pass. The new `OpenRouter GPT-6 Astra Chat reasoning object` case runs green under `TestBuiltInCatalogSpecializedReasoningWireContracts`.

Local platform: macOS (Darwin 24.6.0, arm64 via Rosetta binding for `candle-binding`).

## Follow-ups

- Once the gateway behaviour of `tools` / `tool_choice` on OpenRouter for GPT-6 Astra is verified, add `restrictions.tools_protocols` and any `restrictions.unsupported_request_fields` in a follow-up.
- Once #3348's tiered pricing schema lands, the 272k long-context override can be represented in this binding.

<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category (`[Feature]`)
- [x] The title does not stack prefixes
- [x] The PR links an `accepted` issue with exactly one owner (`wg/data-plane-networking` on #3564)
- [x] Commits in this PR are signed off with `git commit -s`
- [x] Purpose, Test Plan, and Test Result sections reflect actual scope, commands, and blockers

</details>