### PR TITLE
[Bug] Restore ONNX RAG text windowing API

### DIFF
--- a/.github/workflows/ci-changes.yml
+++ b/.github/workflows/ci-changes.yml
@@ -33,6 +33,8 @@ on:
         value: ${{ jobs.classify.outputs.operator }}
       openvino:
         value: ${{ jobs.classify.outputs.openvino }}
+      onnx:
+        value: ${{ jobs.classify.outputs.onnx }}
       performance:
         value: ${{ jobs.classify.outputs.performance }}
       router_learning:
@@ -69,6 +71,7 @@ jobs:
       publish_images: ${{ steps.classify.outputs.publish_images }}
       operator: ${{ steps.classify.outputs.operator }}
       openvino: ${{ steps.classify.outputs.openvino }}
+      onnx: ${{ steps.classify.outputs.onnx }}
       performance: ${{ steps.classify.outputs.performance }}
       router_learning: ${{ steps.classify.outputs.router_learning }}
       recipe_conformance: ${{ steps.classify.outputs.recipe_conformance }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,6 +68,11 @@ jobs:
     if: needs.changes.outputs.openvino == 'true'
     uses: ./.github/workflows/openvino-binding-ci.yml
 
+  onnx:
+    needs: changes
+    if: needs.changes.outputs.onnx == 'true'
+    uses: ./.github/workflows/onnx-binding-ci.yml
+
   gate:
     name: Main validation gate
     if: always()
@@ -82,6 +87,7 @@ jobs:
       - cli
       - recipe-conformance
       - openvino
+      - onnx
     runs-on: ubuntu-latest
     steps:
       - name: Verify affected domains

--- a/.github/workflows/onnx-binding-ci.yml
+++ b/.github/workflows/onnx-binding-ci.yml
@@ -1,0 +1,50 @@
+name: ONNX Binding CI
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    name: Binding tests and router build
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      CARGO_BUILD_JOBS: "2"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.90"
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+          cache-dependency-path: src/semantic-router/go.onnx.sum
+
+      - name: Install native dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential pkg-config libssl-dev
+
+      - name: Cache Rust dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-onnx-cargo-${{ hashFiles('onnx-binding/Cargo.lock', 'ml-binding/Cargo.lock', 'nlp-binding/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-onnx-cargo-
+
+      - name: Test ONNX tokenizer windows and Go FFI
+        run: make test-onnx-binding
+
+      - name: Build router with the ONNX replacement module
+        run: make test-onnx-router-build

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -132,6 +132,15 @@ jobs:
       && needs.changes.outputs.openvino == 'true'
     uses: ./.github/workflows/openvino-binding-ci.yml
 
+  onnx:
+    name: ONNX
+    needs: changes
+    if: >-
+      (!github.event.pull_request.draft
+        || startsWith(github.head_ref, 'mergify/merge-queue/'))
+      && needs.changes.outputs.onnx == 'true'
+    uses: ./.github/workflows/onnx-binding-ci.yml
+
   images:
     name: Images
     needs: changes
@@ -187,6 +196,7 @@ jobs:
       - memory
       - recipe-conformance
       - openvino
+      - onnx
       - images
       - performance
       - router-learning

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ _run:
 		-f tools/make/envoy.mk \
 		-f tools/make/golang.mk \
 		-f tools/make/rust.mk \
+		-f tools/make/onnx.mk \
                 -f tools/make/openvino.mk \
 		-f tools/make/build-run-test.mk \
 		-f tools/make/docs.mk \

--- a/onnx-binding/semantic-router.go
+++ b/onnx-binding/semantic-router.go
@@ -105,6 +105,13 @@ extern int calculate_embedding_similarity(const char* text1, const char* text2, 
 extern int calculate_similarity_batch(const char* query, const char** candidates, int num_candidates, int top_k, int target_layer, int target_dim, BatchSimilarityResult* result);
 extern int get_embedding_models_info(EmbeddingModelsInfoResult* result);
 extern int embedding_text_exceeds_window(const char* text, const char* model_type);
+typedef struct {
+    int* offsets;
+    int window_count;
+    bool error;
+} TextWindowsResult;
+extern TextWindowsResult get_text_windows(const char* text, int max_length);
+extern void free_text_windows(TextWindowsResult result);
 extern void free_embedding(float* data, int length);
 extern void free_batch_similarity_result(BatchSimilarityResult* result);
 extern void free_embedding_models_info(EmbeddingModelsInfoResult* result);
@@ -148,6 +155,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"strings"
 	"sync"
@@ -378,6 +386,39 @@ func GetEmbedding(text string, maxLength int) ([]float32, error) {
 		return nil, err
 	}
 	return output.Embedding, nil
+}
+
+// TextWindow is one byte range of a text that fits the embedding window.
+type TextWindow struct {
+	Start int
+	End   int
+}
+
+// TextWindows returns overlapping byte ranges using the loaded ONNX embedding
+// model's tokenizer and context limit. A positive maxLength can lower that limit.
+func TextWindows(text string, maxLength int) ([]TextWindow, error) {
+	if len(text) > math.MaxInt32 || maxLength > math.MaxInt32 || strings.IndexByte(text, 0) >= 0 {
+		return nil, errors.New("invalid text or maximum length for ONNX text windows")
+	}
+	if maxLength < 0 {
+		maxLength = 0
+	}
+	cText := C.CString(text)
+	defer C.free(unsafe.Pointer(cText))
+	result := C.get_text_windows(cText, C.int(maxLength))
+	defer C.free_text_windows(result)
+	if result.error {
+		return nil, errors.New("ONNX embedding model unavailable or text windowing failed")
+	}
+	if result.window_count == 0 {
+		return nil, nil
+	}
+	offsets := unsafe.Slice(result.offsets, int(result.window_count)*2)
+	windows := make([]TextWindow, int(result.window_count))
+	for i := range windows {
+		windows[i] = TextWindow{Start: int(offsets[2*i]), End: int(offsets[2*i+1])}
+	}
+	return windows, nil
 }
 
 // GetEmbeddingDefault generates an embedding with default settings

--- a/onnx-binding/src/core/mod.rs
+++ b/onnx-binding/src/core/mod.rs
@@ -1,6 +1,7 @@
 //! Core utilities and error handling
 
 pub mod gpu_memory;
+pub mod text_windows;
 pub mod unified_error;
 
 pub use unified_error::{UnifiedError, UnifiedResult};

--- a/onnx-binding/src/core/text_windows.rs
+++ b/onnx-binding/src/core/text_windows.rs
@@ -1,0 +1,69 @@
+//! Tokenizer-owned byte ranges for embedding a complete RAG query.
+
+use tokenizers::{PostProcessor, Tokenizer};
+
+pub fn text_windows(
+    tokenizer: &Tokenizer,
+    text: &str,
+    model_window: usize,
+    max_length: Option<usize>,
+) -> tokenizers::Result<Vec<(usize, usize)>> {
+    let window = tokenizer
+        .get_truncation()
+        .map_or(model_window, |params| model_window.min(params.max_length));
+    let window = max_length.map_or(window, |limit| window.min(limit));
+    let special_tokens = tokenizer
+        .get_post_processor()
+        .map_or(0, |processor| processor.added_tokens(false));
+    let budget = window
+        .checked_sub(special_tokens)
+        .filter(|budget| *budget > 0)
+        .ok_or("embedding window has no room for text after special tokens")?;
+
+    let mut tokenizer = tokenizer.clone();
+    tokenizer.with_truncation(None)?;
+    tokenizer.with_padding(None);
+    let encoding = tokenizer.encode(text, false)?;
+    let offsets: Vec<_> = encoding
+        .get_offsets()
+        .iter()
+        .copied()
+        .filter(|(start, end)| end > start)
+        .collect();
+    if offsets.is_empty() {
+        return Ok(Vec::new());
+    }
+    if tokenizer.encode(text, true)?.len() <= window {
+        return Ok(vec![(0, text.len())]);
+    }
+
+    let mut ranges = Vec::new();
+    let mut start = 0;
+    while start < offsets.len() {
+        let mut end = start.saturating_add(budget).min(offsets.len());
+        loop {
+            if end == start {
+                return Err("embedding window cannot fit one text boundary".into());
+            }
+            let range = (offsets[start].0, offsets[end - 1].1);
+            let slice = text
+                .get(range.0..range.1)
+                .ok_or("tokenizer returned invalid UTF-8 byte boundaries")?;
+            // A substring can tokenize differently at its new leading boundary.
+            if tokenizer.encode(slice, true)?.len() <= window {
+                ranges.push(range);
+                break;
+            }
+            end -= 1;
+        }
+        if end == offsets.len() {
+            break;
+        }
+        start += (end - start).div_ceil(2);
+    }
+    Ok(ranges)
+}
+
+#[cfg(test)]
+#[path = "text_windows_test.rs"]
+mod tests;

--- a/onnx-binding/src/core/text_windows_test.rs
+++ b/onnx-binding/src/core/text_windows_test.rs
@@ -1,0 +1,173 @@
+use super::text_windows;
+use tokenizers::models::wordlevel::WordLevel;
+use tokenizers::pre_tokenizers::whitespace::Whitespace;
+use tokenizers::processors::template::TemplateProcessing;
+use tokenizers::{PaddingParams, PaddingStrategy, Tokenizer, TruncationParams};
+
+fn tokenizer() -> Tokenizer {
+    let model = WordLevel::builder()
+        .vocab(
+            [
+                ("[UNK]".to_string(), 0),
+                ("[CLS]".to_string(), 1),
+                ("[SEP]".to_string(), 2),
+            ]
+            .into_iter()
+            .collect(),
+        )
+        .unk_token("[UNK]".to_string())
+        .build()
+        .unwrap();
+    let mut tokenizer = Tokenizer::new(model);
+    tokenizer.with_pre_tokenizer(Some(Whitespace));
+    tokenizer.with_post_processor(Some(
+        TemplateProcessing::builder()
+            .try_single("[CLS] $A [SEP]")
+            .unwrap()
+            .special_tokens(vec![("[CLS]", 1), ("[SEP]", 2)])
+            .build()
+            .unwrap(),
+    ));
+    tokenizer
+}
+
+#[test]
+fn text_windows_cover_tail_and_overlap() {
+    let tokenizer = tokenizer();
+    let text = "one two three four five six seven";
+    let ranges = text_windows(&tokenizer, text, 6, None).unwrap();
+    let chunks: Vec<_> = ranges
+        .iter()
+        .map(|&(start, end)| &text[start..end])
+        .collect();
+    assert_eq!(
+        chunks,
+        [
+            "one two three four",
+            "three four five six",
+            "five six seven"
+        ]
+    );
+    for chunk in chunks {
+        assert!(tokenizer.encode(chunk, true).unwrap().len() <= 6);
+    }
+}
+
+#[test]
+fn text_windows_preserve_short_and_empty_inputs() {
+    let tokenizer = tokenizer();
+    for text in ["word", "  two words  "] {
+        assert_eq!(
+            text_windows(&tokenizer, text, 6, None).unwrap(),
+            [(0, text.len())]
+        );
+    }
+    for text in ["", "   "] {
+        assert!(text_windows(&tokenizer, text, 6, None).unwrap().is_empty());
+    }
+}
+
+#[test]
+fn text_windows_use_utf8_byte_offsets() {
+    let tokenizer = tokenizer();
+    let text = "你好 世界 café 😀 再见";
+    let ranges = text_windows(&tokenizer, text, 4, None).unwrap();
+    assert_eq!(ranges.first().unwrap().0, 0);
+    assert_eq!(ranges.last().unwrap().1, text.len());
+    for &(start, end) in &ranges {
+        assert!(text.is_char_boundary(start));
+        assert!(text.is_char_boundary(end));
+        assert!(tokenizer.encode(&text[start..end], true).unwrap().len() <= 4);
+    }
+    for pair in ranges.windows(2) {
+        assert!(pair[1].0 < pair[0].1);
+    }
+}
+
+#[test]
+fn text_windows_respect_model_tokenizer_and_requested_limits() {
+    let text = "one two three four five six seven";
+    let mut tokenizer = tokenizer();
+    tokenizer
+        .with_truncation(Some(TruncationParams {
+            max_length: 6,
+            ..Default::default()
+        }))
+        .unwrap();
+    tokenizer.with_padding(Some(PaddingParams {
+        strategy: PaddingStrategy::Fixed(12),
+        ..Default::default()
+    }));
+    for (model_window, requested, expected_first) in [
+        (32, None, "one two three four"),
+        (5, None, "one two three"),
+        (32, Some(4), "one two"),
+        (32, Some(64), "one two three four"),
+    ] {
+        let ranges = text_windows(&tokenizer, text, model_window, requested).unwrap();
+        assert_eq!(&text[ranges[0].0..ranges[0].1], expected_first);
+        assert_eq!(ranges.last().unwrap().1, text.len());
+    }
+    assert_eq!(tokenizer.get_truncation().unwrap().max_length, 6);
+    assert!(matches!(
+        tokenizer.get_padding().unwrap().strategy,
+        PaddingStrategy::Fixed(12)
+    ));
+}
+
+#[test]
+fn text_windows_reject_limits_without_content_budget() {
+    let tokenizer = tokenizer();
+    for window in [0, 1, 2] {
+        assert!(text_windows(&tokenizer, "word", window, None).is_err());
+    }
+    assert_eq!(
+        text_windows(&tokenizer, "one two", 3, None).unwrap(),
+        [(0, 3), (4, 7)]
+    );
+}
+
+#[test]
+fn text_windows_use_model_limit_and_actual_special_token_count() {
+    let mut tokenizer = tokenizer();
+    let text = "word ".repeat(600);
+    assert_eq!(
+        text_windows(&tokenizer, &text, 1024, None).unwrap(),
+        [(0, text.len())]
+    );
+    tokenizer.with_post_processor(Some(
+        TemplateProcessing::builder()
+            .try_single("[CLS] $A [SEP] [SEP]")
+            .unwrap()
+            .special_tokens(vec![("[CLS]", 1), ("[SEP]", 2)])
+            .build()
+            .unwrap(),
+    ));
+    let ranges = text_windows(&tokenizer, "one two three", 5, None).unwrap();
+    assert_eq!(ranges, [(0, 7), (4, 13)]);
+}
+
+#[test]
+fn text_windows_recheck_substring_tokenization() {
+    use tokenizers::models::wordpiece::WordPiece;
+    let mut tokenizer = tokenizer();
+    let vocab = [
+        ("[UNK]", 0),
+        ("[CLS]", 1),
+        ("[SEP]", 2),
+        ("abc", 3),
+        ("##de", 4),
+        ("##f", 5),
+        ("d", 6),
+        ("##e", 7),
+        ("f", 8),
+    ]
+    .map(|(token, id)| (token.to_string(), id));
+    tokenizer.with_model(WordPiece::builder().vocab(vocab).build().unwrap());
+    let text = "abcdef";
+    let ranges = text_windows(&tokenizer, text, 4, None).unwrap();
+    assert_eq!(ranges, [(0, 5), (3, 5), (5, 6)]);
+    for (start, end) in ranges {
+        assert!(tokenizer.encode(&text[start..end], true).unwrap().len() <= 4);
+    }
+}

--- a/onnx-binding/src/ffi/embedding.rs
+++ b/onnx-binding/src/ffi/embedding.rs
@@ -13,7 +13,7 @@ use std::ffi::{c_char, CStr, CString};
 use std::sync::OnceLock;
 
 /// Global singleton for MmBertEmbeddingModel (wrapped in Mutex for mutable access)
-static GLOBAL_MMBERT_MODEL: OnceLock<Mutex<MmBertEmbeddingModel>> = OnceLock::new();
+pub(super) static GLOBAL_MMBERT_MODEL: OnceLock<Mutex<MmBertEmbeddingModel>> = OnceLock::new();
 
 // ============================================================================
 // Initialization Functions

--- a/onnx-binding/src/ffi/mod.rs
+++ b/onnx-binding/src/ffi/mod.rs
@@ -6,6 +6,7 @@ pub mod memory;
 #[cfg(test)]
 mod memory_test;
 pub mod multimodal;
+pub mod text_windows;
 pub mod types;
 pub mod unified;
 
@@ -13,5 +14,6 @@ pub use classification::*;
 pub use embedding::*;
 pub use memory::*;
 pub use multimodal::*;
+pub use text_windows::*;
 pub use types::*;
 pub use unified::*;

--- a/onnx-binding/src/ffi/text_windows.rs
+++ b/onnx-binding/src/ffi/text_windows.rs
@@ -1,0 +1,141 @@
+//! RAG windowing through the same loaded mmBERT model used by `get_embedding`.
+
+use super::embedding::GLOBAL_MMBERT_MODEL;
+use std::ffi::{c_char, CStr};
+
+#[repr(C)]
+pub struct TextWindowsResult {
+    pub offsets: *mut i32,
+    pub window_count: i32,
+    pub error: bool,
+}
+
+fn failed_windows() -> TextWindowsResult {
+    TextWindowsResult {
+        offsets: std::ptr::null_mut(),
+        window_count: 0,
+        error: true,
+    }
+}
+
+/// Return overlapping byte ranges that fit the loaded embedding model.
+///
+/// # Safety
+/// `text` must be null or a valid null-terminated C string. Free a successful
+/// result exactly once with `free_text_windows`.
+#[no_mangle]
+pub unsafe extern "C" fn get_text_windows(
+    text: *const c_char,
+    max_length: i32,
+) -> TextWindowsResult {
+    if text.is_null() {
+        return failed_windows();
+    }
+    let text = match unsafe { CStr::from_ptr(text) }.to_str() {
+        Ok(text) if text.len() <= i32::MAX as usize => text,
+        _ => return failed_windows(),
+    };
+    let Some(model_lock) = GLOBAL_MMBERT_MODEL.get() else {
+        return failed_windows();
+    };
+    let model = model_lock.lock();
+    let limit = (max_length > 0).then_some(max_length as usize);
+    match crate::core::text_windows::text_windows(
+        model.tokenizer(),
+        text,
+        model.config().max_position_embeddings,
+        limit,
+    ) {
+        Ok(ranges) => pack_windows(ranges),
+        Err(error) => {
+            eprintln!("Failed to window ONNX embedding text: {error}");
+            failed_windows()
+        }
+    }
+}
+
+fn pack_windows(ranges: Vec<(usize, usize)>) -> TextWindowsResult {
+    let Ok(window_count) = i32::try_from(ranges.len()) else {
+        return failed_windows();
+    };
+    let offsets: Result<Vec<i32>, _> = ranges
+        .into_iter()
+        .flat_map(|(start, end)| [start, end])
+        .map(i32::try_from)
+        .collect();
+    let Ok(offsets) = offsets else {
+        return failed_windows();
+    };
+    TextWindowsResult {
+        offsets: if offsets.is_empty() {
+            std::ptr::null_mut()
+        } else {
+            Box::into_raw(offsets.into_boxed_slice()) as *mut i32
+        },
+        window_count,
+        error: false,
+    }
+}
+
+/// Release a window array using its original boxed-slice allocation layout.
+///
+/// # Safety
+/// `result` must come from `get_text_windows` and must not be freed twice.
+#[no_mangle]
+pub unsafe extern "C" fn free_text_windows(result: TextWindowsResult) {
+    if !result.offsets.is_null() && result.window_count > 0 {
+        let slice =
+            std::ptr::slice_from_raw_parts_mut(result.offsets, result.window_count as usize * 2);
+        drop(unsafe { Box::from_raw(slice) });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn text_windows_reject_invalid_input_and_unloaded_model() {
+        for text in [
+            std::ptr::null(),
+            c"query".as_ptr(),
+            c"".as_ptr(),
+            c"\xff".as_ptr(),
+        ] {
+            let result = unsafe { get_text_windows(text, 0) };
+            assert!(result.error);
+            assert!(result.offsets.is_null());
+            assert_eq!(result.window_count, 0);
+            unsafe { free_text_windows(result) };
+        }
+    }
+
+    #[test]
+    fn text_windows_round_trip_empty_and_multiple_ranges() {
+        for ranges in [vec![], vec![(0, 4), (2, 8), (6, 12)]] {
+            let expected: Vec<_> = ranges
+                .iter()
+                .flat_map(|&(start, end)| [start as i32, end as i32])
+                .collect();
+            let result = pack_windows(ranges);
+            assert!(!result.error);
+            assert_eq!(result.window_count as usize * 2, expected.len());
+            if expected.is_empty() {
+                assert!(result.offsets.is_null());
+            } else {
+                assert_eq!(
+                    unsafe { std::slice::from_raw_parts(result.offsets, expected.len()) },
+                    expected
+                );
+            }
+            unsafe { free_text_windows(result) };
+        }
+    }
+
+    #[test]
+    fn text_windows_reject_offset_overflow() {
+        let result = pack_windows(vec![(0, i32::MAX as usize + 1)]);
+        assert!(result.error);
+        assert!(result.offsets.is_null());
+    }
+}

--- a/onnx-binding/text_windows_test.go
+++ b/onnx-binding/text_windows_test.go
@@ -1,0 +1,45 @@
+//go:build !windows && cgo && (amd64 || arm64)
+
+package onnx_binding
+
+import (
+	"math"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+func TestTextWindowsWithoutModel(t *testing.T) {
+	const childEnv = "SR_ONNX_TEXT_WINDOWS_CHILD"
+	if os.Getenv(childEnv) != "1" {
+		cmd := exec.Command(os.Args[0], "-test.run=^TestTextWindowsWithoutModel$")
+		cmd.Env = append(os.Environ(), childEnv+"=1")
+		if output, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("uninitialized binding: %v\n%s", err, output)
+		}
+		return
+	}
+	for _, text := range []string{"query", "", "你好"} {
+		for _, limit := range []int{0, -1, 32} {
+			windows, err := TextWindows(text, limit)
+			if err == nil || windows != nil {
+				t.Fatalf("TextWindows(%q, %d) = %v, %v; want nil, error", text, limit, windows, err)
+			}
+		}
+	}
+}
+
+func TestTextWindowsInvalidInput(t *testing.T) {
+	for _, input := range []struct {
+		text  string
+		limit int
+	}{
+		{"before\x00after", 0},
+		{"\xff", 0},
+		{"query", math.MaxInt32 + 1},
+	} {
+		if windows, err := TextWindows(input.text, input.limit); err == nil || windows != nil {
+			t.Fatalf("TextWindows(%q, %d) = %v, %v; want nil, error", input.text, input.limit, windows, err)
+		}
+	}
+}

--- a/tools/agent/domains.yaml
+++ b/tools/agent/domains.yaml
@@ -16,6 +16,10 @@ jobs:
     workflow: .github/workflows/test-and-build.yml
     output: core_test
     full: true
+  onnx:
+    workflow: .github/workflows/onnx-binding-ci.yml
+    output: onnx
+    full: true
   dashboard:
     workflow: .github/workflows/dashboard-test.yml
     output: dashboard
@@ -111,10 +115,21 @@ domains:
       - candle-binding/**
       - ml-binding/**
       - nlp-binding/**
-      - onnx-binding/**
     checks: [make test-binding-minimal]
     verify: [make test-binding-lora]
     ci_jobs: [core-tests]
+
+  onnx-binding:
+    owner: native-bindings
+    paths:
+      - onnx-binding/**
+      - candle-binding/semantic-router.go
+      - src/semantic-router/go.onnx.mod
+      - src/semantic-router/go.onnx.sum
+      - e2e/testcases/testdata/image-fixtures/*.jpg
+      - tools/make/onnx.mk
+    checks: [make test-onnx-binding]
+    ci_jobs: [onnx]
 
   ck-flash-attn-rewriter:
     owner: native-bindings

--- a/tools/ci/tests/test_pr_change_classifier.py
+++ b/tools/ci/tests/test_pr_change_classifier.py
@@ -64,6 +64,7 @@ class PRChangeClassifierTests(unittest.TestCase):
             ".github/workflows/operator-ci.yml": "operator",
             ".github/workflows/integration-test-memory.yml": "memory",
             ".github/workflows/openvino-binding-ci.yml": "openvino",
+            ".github/workflows/onnx-binding-ci.yml": "onnx",
         }
         for path, selected in fixtures.items():
             with self.subTest(path=path):
@@ -84,6 +85,29 @@ class PRChangeClassifierTests(unittest.TestCase):
         self.assertEqual(result.profiles, ())
         self.assertEqual(result.pr_images, ())
         self.assertEqual(result.publish_images, ())
+
+    def test_onnx_source_and_unit_tests_select_binding_ci_without_images(self) -> None:
+        for path in (
+            "onnx-binding/src/core/text_windows.rs",
+            "onnx-binding/src/core/text_windows_test.rs",
+            "onnx-binding/text_windows_test.go",
+            "onnx-binding/Cargo.lock",
+            "tools/make/onnx.mk",
+        ):
+            with self.subTest(path=path):
+                self.assert_classification(path, ("quality", "security", "onnx"))
+                self.assertTrue(classify([path]).signals["onnx"])
+
+    def test_candle_api_and_onnx_module_changes_keep_replacement_coverage(self) -> None:
+        for path in (
+            "candle-binding/semantic-router.go",
+            "src/semantic-router/go.onnx.mod",
+            "src/semantic-router/go.onnx.sum",
+        ):
+            with self.subTest(path=path):
+                self.assert_classification(
+                    path, ("quality", "security", "core-tests", "onnx")
+                )
 
     def test_actual_e2e_test_selects_its_named_profile(self) -> None:
         result = classify(["e2e/testcases/istio_routes_test.go"])
@@ -125,7 +149,7 @@ class PRChangeClassifierTests(unittest.TestCase):
 
         self.assertEqual(
             result.selected_jobs,
-            ("quality", "security", "core-tests", "e2e", "recipe-conformance"),
+            ("quality", "security", "core-tests", "onnx", "e2e", "recipe-conformance"),
         )
         self.assertEqual(
             result.profiles,

--- a/tools/make/onnx.mk
+++ b/tools/make/onnx.mk
@@ -1,0 +1,18 @@
+# Focused CPU checks for the ONNX replacement of the Candle Go API.
+
+.PHONY: test-onnx-binding test-onnx-router-build
+
+test-onnx-binding: build-onnx-binding ## Test ONNX tokenizer windows and the real Go/FFI boundary without models
+	@cd onnx-binding && \
+		cargo test --release --locked --no-default-features --lib text_windows
+	@cd onnx-binding && \
+		LD_LIBRARY_PATH="$(CURDIR)/onnx-binding/target/release:$${LD_LIBRARY_PATH:-}" \
+		CGO_ENABLED=1 go test -count=1 -v semantic-router.go text_windows_test.go
+
+test-onnx-router-build: build-onnx-binding build-ml-binding ## Compile the router against the ONNX replacement module
+	@cd nlp-binding && cargo build --release --locked
+	@mkdir -p bin
+	@cd src/semantic-router && \
+		CGO_ENABLED=1 \
+		CGO_LDFLAGS="-L$(CURDIR)/onnx-binding/target/release -L$(CURDIR)/ml-binding/target/release -L$(CURDIR)/nlp-binding/target/release" \
+		go build -modfile=go.onnx.mod -tags=onnx -o ../../bin/router-onnx ./cmd


### PR DESCRIPTION
Closes #3672

## Purpose

Restore the ONNX `TextWindows` / `TextWindow` API required by RAG after #3650. With `go.onnx.mod` replacing the Candle binding, these missing exports prevent the ONNX router from compiling.

Use the loaded mmBERT tokenizer and context limit to produce overlapping UTF-8 byte ranges. Respect tokenizer truncation, a smaller caller limit, and the actual special-token budget; re-encode each substring to keep boundary changes within that budget. The Go wrapper validates inputs, and the Rust FFI owns and releases each returned offset array.

Add a dedicated ONNX CI workflow and Make targets for model-free tokenizer/FFI/Go regressions and an ONNX router build. The domain registry selects this workflow for ONNX source/tests, the shared Candle Go API, and ONNX module changes. Both PR and main validation gates include its result. Production Dockerfiles and Docker build-context rules are unchanged.

## Test Plan

```bash
make test-onnx-binding
make test-onnx-router-build
make harness-check
```

The binding target runs 10 Rust tokenizer/FFI regressions and the focused Go tests against the real native library. The router target builds the ONNX, ML, and NLP libraries and compiles the router with `go.onnx.mod` and the `onnx` tag. No model assets or external services are required. The focused Go command selects the new regression file; the broader legacy ONNX Go suite remains tracked by #2477.

## Test Result

- PASS locally: `make harness-check`, including 163 CI/harness tests, workflow contract validation, and actionlint.
- PASS locally: Make target dry-run, YAML lint, Black formatting, spelling, and `git diff --check`.
- PASS in GitHub CI on `306f785e`: [ONNX binding tests and router build](https://github.com/vllm-project/semantic-router/actions/runs/34364645592/job/102512963077) — 10 Rust regressions, both Go regressions against the native library, and the ONNX router build.
- PASS: the [final PR workflow](https://github.com/vllm-project/semantic-router/actions/runs/34364645592), including full pre-commit checks, both security scans, and PR Gate.
- Full native execution and router linking were run in GitHub CI. No full local suite was run.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category.
- [x] The title does not stack prefixes; affected modules are described above.
- [ ] The PR links an `accepted` issue with exactly one owner. (#3672 has the proposed Workgroup and awaits acceptance.)
- [x] Commits in this PR are signed off with `git commit -s`.
- [x] Purpose, Test Plan, and Test Result reflect the actual scope and validation boundaries.

</details>

