### PR TITLE
[Bug] Divide evaluation batch latency by the row count instead of the column count

### DIFF
--- a/src/training/model_eval/mom_collection_eval.py
+++ b/src/training/model_eval/mom_collection_eval.py
@@ -31,7 +31,6 @@ import re
 import time
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from pathlib import Path
-from typing import Dict, List, Tuple
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -39,7 +38,6 @@ import requests
 import seaborn as sns
 import torch
 from datasets import Dataset, load_dataset
-from transformers import AutoConfig
 from peft import PeftModel
 from seqeval.metrics import accuracy_score as seqe_accuracy_score
 from seqeval.metrics import classification_report as seq_classification_report
@@ -52,8 +50,6 @@ from sklearn.metrics import (
 )
 from tqdm import tqdm
 from transformers import (
-    AutoModelForSequenceClassification,
-    AutoModelForTokenClassification,
     AutoTokenizer,
     ModernBertConfig,
     ModernBertForSequenceClassification,
@@ -65,7 +61,6 @@ try:
 except ImportError:
     from constants import BASE_MODEL_ID, LANGUAGE_CODES, MODEL_REGISTRY
 import warnings
-from sklearn.metrics._classification import _check_targets
 
 # suppress prf warnings
 warnings.filterwarnings(
@@ -212,7 +207,7 @@ def load_eval_data(model_name: str, args) -> Dataset:
             for split in ["test", "validation", "eval", "train"]:
                 try:
                     ds = retry_operation(
-                        lambda: load_custom_ds(split),
+                        lambda split=split: load_custom_ds(split),
                         max_retries=args.max_retries,
                     )
                     logger.info(
@@ -281,7 +276,7 @@ def load_eval_data(model_name: str, args) -> Dataset:
             ds = ds.filter(lambda x: x["category"] in config["labels"])
             if args.limit:
                 ds = ds.select(range(min(len(ds), args.limit)))
-            l2id = {l: i for i, l in enumerate(config["labels"])}
+            l2id = {label: i for i, label in enumerate(config["labels"])}
             ds = ds.map(lambda x: {"label": l2id[x["category"]]})
             ds = ds.rename_column("question", "text")
             return ds
@@ -340,7 +335,7 @@ def load_eval_data(model_name: str, args) -> Dataset:
                 ds = ds.remove_columns(["label"])
             ds = ds.rename_column(config["label_col"], "label")
 
-        label2id = {l: i for i, l in enumerate(config["labels"])}
+        label2id = {label: i for i, label in enumerate(config["labels"])}
 
         def map_to_int(example):
             label = example["label"]
@@ -391,8 +386,8 @@ def load_model_and_tokenizer(model_name: str, args):
 
         # Build config from base model
         clean_labels = config_reg["labels"]
-        id2label = {i: str(l) for i, l in enumerate(clean_labels)}
-        label2id = {str(l): i for i, l in enumerate(clean_labels)}
+        id2label = {i: str(label) for i, label in enumerate(clean_labels)}
+        label2id = {str(label): i for i, label in enumerate(clean_labels)}
 
         hf_config = ModernBertConfig.from_pretrained(
             BASE_MODEL_ID,
@@ -424,7 +419,7 @@ def load_model_and_tokenizer(model_name: str, args):
         raise
 
 
-def evaluate_single_model(model_name: str, args) -> Tuple[str, Dict]:
+def evaluate_single_model(model_name: str, args) -> tuple[str, dict]:
     """Evaluate a single model with comprehensive error handling."""
     config = MODEL_REGISTRY[model_name]
     logger = logging.getLogger("MoMEval")
@@ -472,7 +467,7 @@ def evaluate_single_model(model_name: str, args) -> Tuple[str, Dict]:
                         pred_ids = torch.argmax(out.logits, dim=-1).cpu().tolist()
 
                     for idx, (p_seq, true_labels) in enumerate(
-                        zip(pred_ids, batch["labels"])
+                        zip(pred_ids, batch["labels"], strict=False)
                     ):
                         word_ids = inputs.word_ids(batch_index=idx)
                         p_labels = []
@@ -494,11 +489,8 @@ def evaluate_single_model(model_name: str, args) -> Tuple[str, Dict]:
                             logger.warning(
                                 f"Length mismatch sample {i+idx}: pred={len(p_labels)}, gt={len(true_labels)} → truncating"
                             )
-                        p_labels = p_labels[:min_len]
-                        true_labels = true_labels[:min_len]
-
-                        all_preds.append(p_labels)
-                        all_truths.append(true_labels)
+                        all_preds.append(p_labels[:min_len])
+                        all_truths.append(true_labels[:min_len])
 
                 batch_time = (time.time() - start) * 1000
                 lats.extend([batch_time / len(batch)] * len(batch))
@@ -532,7 +524,7 @@ def evaluate_single_model(model_name: str, args) -> Tuple[str, Dict]:
         if config["type"] == "text_classification":
             unique_labels = sorted(set(all_truths) | set(all_preds))
             stats["accuracy"] = float(accuracy_score(all_truths, all_preds))
-            p, r, f1, sup = precision_recall_fscore_support(
+            p, r, f1, _sup = precision_recall_fscore_support(
                 all_truths,
                 all_preds,
                 labels=unique_labels,
@@ -558,7 +550,7 @@ def evaluate_single_model(model_name: str, args) -> Tuple[str, Dict]:
         else:
             # Align sequence lengths
             aligned_t, aligned_p = [], []
-            for t, p in zip(all_truths, all_preds):
+            for t, p in zip(all_truths, all_preds, strict=False):
                 m_len = min(len(t), len(p))
                 aligned_t.append(t[:m_len])
                 aligned_p.append(p[:m_len])

--- a/src/training/model_eval/mom_collection_eval.py
+++ b/src/training/model_eval/mom_collection_eval.py
@@ -419,6 +419,17 @@ def load_model_and_tokenizer(model_name: str, args):
         raise
 
 
+def batch_row_count(batch: dict) -> int:
+    """Return the number of rows in a slice of a HuggingFace ``Dataset``.
+
+    Slicing a ``Dataset`` gives back a dict of column name -> list of values,
+    not a list of rows, so ``len(batch)`` is the column count. Every column
+    carries one entry per row, so any column's length is the row count. This
+    also gives the right answer for a short final batch.
+    """
+    return len(next(iter(batch.values())))
+
+
 def evaluate_single_model(model_name: str, args) -> tuple[str, dict]:
     """Evaluate a single model with comprehensive error handling."""
     config = MODEL_REGISTRY[model_name]
@@ -493,7 +504,8 @@ def evaluate_single_model(model_name: str, args) -> tuple[str, dict]:
                         all_truths.append(true_labels[:min_len])
 
                 batch_time = (time.time() - start) * 1000
-                lats.extend([batch_time / len(batch)] * len(batch))
+                rows = batch_row_count(batch)
+                lats.extend([batch_time / rows] * rows)
 
             except torch.cuda.OutOfMemoryError:
                 logger.error(

--- a/src/training/model_eval/tests/test_batch_row_count.py
+++ b/src/training/model_eval/tests/test_batch_row_count.py
@@ -1,0 +1,167 @@
+"""Contract tests pinning the divisor the evaluation uses for per-sample latency.
+
+Slicing a HuggingFace ``Dataset`` returns a dict of column name -> list of
+values rather than a list of rows, so ``len(batch)`` counts columns. The
+inference loop used it as the batch size, which made every reported latency
+wrong by rows/columns: 5.33x too high for jailbreak at the default batch size,
+8x for pii, and too *low* once the batch grew past the column count. Nothing
+failed, because a plausible number still came out the other end.
+
+See https://github.com/vllm-project/semantic-router/issues/3642.
+
+``mom_collection_eval`` imports torch, datasets and transformers, so it cannot
+be imported by the stdlib-only python3 that ``make test-training-contracts``
+runs. ``batch_row_count`` is lifted out of the source with ``ast`` and executed
+on its own instead, which needs no third-party module.
+"""
+
+from __future__ import annotations
+
+import ast
+import unittest
+from collections.abc import Callable
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[4]
+EVAL_SOURCE = REPOSITORY_ROOT / "src/training/model_eval/mom_collection_eval.py"
+
+# Column names the registry's datasets actually arrive with, so the fixtures
+# below are the shapes the loop really sees rather than invented ones.
+JAILBREAK_COLUMNS = ["text", "label", "label_text"]
+PII_COLUMNS = ["tokens", "labels"]
+INTENT_COLUMNS = [
+    "question_id",
+    "text",
+    "options",
+    "answer",
+    "answer_index",
+    "cot_content",
+    "category",
+    "src",
+    "label",
+]
+
+
+def load_module() -> ast.Module:
+    """Parse the evaluation script without importing it."""
+    return ast.parse(EVAL_SOURCE.read_text(encoding="utf-8"))
+
+
+def load_function(name: str) -> ast.FunctionDef:
+    """Return the top-level function definition named `name`."""
+    for node in load_module().body:
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"{EVAL_SOURCE} defines no function named {name!r}")
+
+
+def compile_function(name: str) -> Callable:
+    """Execute one function on its own, free of the script's imports."""
+    namespace: dict = {}
+    exec(
+        compile(ast.Module([load_function(name)], []), str(EVAL_SOURCE), "exec"),
+        namespace,
+    )
+    return namespace[name]
+
+
+def make_batch(columns: list[str], rows: int) -> dict:
+    """Build a slice shaped the way `Dataset.__getitem__` returns one."""
+    return {column: list(range(rows)) for column in columns}
+
+
+class BatchRowCountTest(unittest.TestCase):
+    """`batch_row_count` has to report rows even when columns look like a count."""
+
+    def setUp(self) -> None:
+        self.batch_row_count = compile_function("batch_row_count")
+
+    def test_counts_rows_not_columns(self):
+        batch = make_batch(JAILBREAK_COLUMNS, rows=16)
+        self.assertEqual(self.batch_row_count(batch), 16)
+        self.assertNotEqual(self.batch_row_count(batch), len(batch))
+
+    def test_token_classification_shape(self):
+        # The pii path was the worst of them: 2 columns against 16 rows.
+        self.assertEqual(self.batch_row_count(make_batch(PII_COLUMNS, rows=16)), 16)
+
+    def test_intent_shape(self):
+        self.assertEqual(self.batch_row_count(make_batch(INTENT_COLUMNS, rows=16)), 16)
+
+    def test_short_final_batch(self):
+        # A trailing batch is shorter than --batch_size and has to say so, or
+        # avg_ms stops being total time over rows evaluated.
+        self.assertEqual(self.batch_row_count(make_batch(JAILBREAK_COLUMNS, rows=5)), 5)
+
+    def test_single_row_batch(self):
+        self.assertEqual(self.batch_row_count(make_batch(INTENT_COLUMNS, rows=1)), 1)
+
+    def test_batch_smaller_than_column_count(self):
+        # Below the column count the old divisor made latency look too low
+        # rather than too high, which is why a run cannot be corrected after
+        # the fact without knowing the batch size it used.
+        self.assertEqual(self.batch_row_count(make_batch(INTENT_COLUMNS, rows=4)), 4)
+
+
+class LatencyDivisorTest(unittest.TestCase):
+    """The loop has to divide by the row count, not by the slice's length."""
+
+    def setUp(self) -> None:
+        self.loop = load_function("evaluate_single_model")
+        self.extend_call = self.find_latency_extend()
+
+    def find_latency_extend(self) -> ast.Call:
+        for node in ast.walk(self.loop):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "extend"
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "lats"
+            ):
+                return node
+        raise AssertionError("evaluate_single_model no longer collects latencies")
+
+    def test_latency_does_not_divide_by_the_slice_length(self):
+        for node in ast.walk(self.loop):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "len"
+                and node.args
+                and isinstance(node.args[0], ast.Name)
+                and node.args[0].id == "batch"
+            ):
+                self.fail(
+                    "len(batch) is the column count of a Dataset slice, not the "
+                    "batch size; use batch_row_count(batch)"
+                )
+
+    def test_latency_is_spread_over_the_row_count(self):
+        source = ast.unparse(self.extend_call)
+        rows = {
+            target.id
+            for node in ast.walk(self.loop)
+            if isinstance(node, ast.Assign)
+            and isinstance(node.value, ast.Call)
+            and isinstance(node.value.func, ast.Name)
+            and node.value.func.id == "batch_row_count"
+            for target in node.targets
+            if isinstance(target, ast.Name)
+        }
+        self.assertTrue(rows, "evaluate_single_model never calls batch_row_count")
+        # Both the divisor and the number of entries appended come from it, so
+        # lats holds one entry per row and avg_ms averages over samples.
+        self.assertEqual(
+            sum(name in rows for name in _names(self.extend_call)),
+            2,
+            f"expected the row count on both sides of the latency spread: {source}",
+        )
+
+
+def _names(node: ast.AST) -> list[str]:
+    return [child.id for child in ast.walk(node) if isinstance(child, ast.Name)]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- markdownlint-disable -->

Closes #3642

## Purpose

The eval script timed each batch and divided by `len(batch)`. Slicing a HuggingFace `Dataset`
gives you a dict of column -> values, not a list of rows, so that was the column count. Every
latency it reported was off by rows/columns: 5.33x too high for jailbreak at the default batch
size, 8x for pii, and too low once the batch got bigger than the column count. `lats` also
ended up with one entry per column per batch instead of one per row.


## Test Plan

```bash
make check BASE_REF=origin/main
make test-training-contracts

# real run, jailbreak detector on the cached test set, two batch sizes
for BS in 16 4; do
  HF_HUB_OFFLINE=1 MPLBACKEND=Agg TOKENIZERS_PARALLELISM=false \
  python src/training/model_eval/mom_collection_eval.py \
    --model jailbreak --limit 48 --batch_size $BS --device cpu --output_dir /tmp/eval-$BS
done
```

Also reverted the source and re-ran the new tests, to check they actually catch it.

## Test Result

`make check` exits 0. `make test-training-contracts` passes, model_eval goes from 13 to 21 tests.

48 rows on CPU:

| run | latency it reports | wall clock / 48 rows | |
|---|---|---|---|
| before, bs 16 | 1103.40 ms/row | 206.9 ms/row | **5.33x too high** |
| after, bs 16 | 198.43 ms/row | 199.0 ms/row | matches |
| after, bs 4 | 163.61 ms/row | 163.3 ms/row | matches |

5.33x is exactly 16 rows / 3 columns, as the issue predicted. `avg_ms` is now total time over
rows at both batch sizes, and accuracy, F1, precision, recall and the confusion matrix are
unchanged. All 8 new tests fail on the old source and pass on the new one.

Worth flagging: only jailbreak was run for real, since that's what's in the local cache. The
other four paths share the same line and their shapes are in the test fixtures, but I didn't
run them. Latency numbers already written into old results JSONs stay wrong.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category, such as `[Feature]`, `[Bug]`, `[Docs]`, `[Test]`, `[Research]`, `[Community]`, or `[CI/Build]`
- [x] The title does not stack prefixes such as `[Router][Docs]`; affected modules belong in labels and the PR body
- [x] The PR links an `accepted` issue with exactly one owner: one `wg/*` label for project work or `owner/maintainers` for repository governance
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.