### PR TITLE
[Bug] Restore ONNX text-window API parity

### DIFF
--- a/onnx-binding/semantic-router.go
+++ b/onnx-binding/semantic-router.go
@@ -61,6 +61,12 @@ typedef struct {
     bool error;
 } EmbeddingModelsInfoResult;
 
+typedef struct {
+    int* offsets;
+    int window_count;
+    bool error;
+} TextWindowsResult;
+
 // ============================================================================
 // Classification Types
 // ============================================================================
@@ -105,6 +111,8 @@ extern int calculate_embedding_similarity(const char* text1, const char* text2, 
 extern int calculate_similarity_batch(const char* query, const char** candidates, int num_candidates, int top_k, int target_layer, int target_dim, BatchSimilarityResult* result);
 extern int get_embedding_models_info(EmbeddingModelsInfoResult* result);
 extern int embedding_text_exceeds_window(const char* text, const char* model_type);
+extern TextWindowsResult get_text_windows(const char* text, int max_length);
+extern void free_text_windows(TextWindowsResult result);
 extern void free_embedding(float* data, int length);
 extern void free_batch_similarity_result(BatchSimilarityResult* result);
 extern void free_embedding_models_info(EmbeddingModelsInfoResult* result);
@@ -495,6 +503,43 @@ func EmbeddingTextExceedsWindow(text, modelType string) (bool, error) {
 	default:
 		return false, fmt.Errorf("embedding model %q not loaded", modelType)
 	}
+}
+
+// TextWindow is one byte range of a text that fits the embedding window.
+type TextWindow struct {
+	Start int
+	End   int
+}
+
+// TextWindows returns byte ranges covering the full text. Each range fits the
+// loaded embedding model and consecutive ranges overlap by half a window.
+func TextWindows(text string, maxLength int) ([]TextWindow, error) {
+	if !IsMmBertModelInitialized() {
+		return nil, fmt.Errorf("mmBERT model not initialized")
+	}
+
+	cText := C.CString(text)
+	defer C.free(unsafe.Pointer(cText))
+
+	result := C.get_text_windows(cText, C.int(maxLength))
+	defer C.free_text_windows(result)
+	if bool(result.error) {
+		return nil, fmt.Errorf("failed to window text")
+	}
+
+	count := int(result.window_count)
+	if count == 0 || result.offsets == nil {
+		return nil, nil
+	}
+	offsets := (*[1 << 28]C.int)(unsafe.Pointer(result.offsets))[: count*2 : count*2]
+	windows := make([]TextWindow, count)
+	for i := range windows {
+		windows[i] = TextWindow{
+			Start: int(offsets[i*2]),
+			End:   int(offsets[i*2+1]),
+		}
+	}
+	return windows, nil
 }
 
 // ============================================================================

--- a/onnx-binding/src/ffi/embedding.rs
+++ b/onnx-binding/src/ffi/embedding.rs
@@ -13,7 +13,7 @@ use std::ffi::{c_char, CStr, CString};
 use std::sync::OnceLock;
 
 /// Global singleton for MmBertEmbeddingModel (wrapped in Mutex for mutable access)
-static GLOBAL_MMBERT_MODEL: OnceLock<Mutex<MmBertEmbeddingModel>> = OnceLock::new();
+pub(crate) static GLOBAL_MMBERT_MODEL: OnceLock<Mutex<MmBertEmbeddingModel>> = OnceLock::new();
 
 // ============================================================================
 // Initialization Functions

--- a/onnx-binding/src/ffi/mod.rs
+++ b/onnx-binding/src/ffi/mod.rs
@@ -6,6 +6,7 @@ pub mod memory;
 #[cfg(test)]
 mod memory_test;
 pub mod multimodal;
+pub mod text_windows;
 pub mod types;
 pub mod unified;
 
@@ -13,5 +14,6 @@ pub use classification::*;
 pub use embedding::*;
 pub use memory::*;
 pub use multimodal::*;
+pub use text_windows::*;
 pub use types::*;
 pub use unified::*;

--- a/onnx-binding/src/ffi/text_windows.rs
+++ b/onnx-binding/src/ffi/text_windows.rs
@@ -1,0 +1,151 @@
+//! FFI for splitting input into byte ranges that fit the ONNX embedding model.
+
+use crate::ffi::embedding::GLOBAL_MMBERT_MODEL;
+use std::ffi::{c_char, CStr};
+
+/// Byte ranges laid out as consecutive start/end pairs in `offsets`.
+#[repr(C)]
+#[derive(Debug)]
+pub struct TextWindowsResult {
+    pub offsets: *mut i32,
+    pub window_count: i32,
+    pub error: bool,
+}
+
+fn failed_windows() -> TextWindowsResult {
+    TextWindowsResult {
+        offsets: std::ptr::null_mut(),
+        window_count: 0,
+        error: true,
+    }
+}
+
+fn window_ranges(offsets: &[(usize, usize)], budget: usize, stride: usize) -> Vec<(usize, usize)> {
+    if offsets.is_empty() || budget == 0 {
+        return Vec::new();
+    }
+
+    let stride = stride.clamp(1, budget);
+    let mut ranges = Vec::new();
+    let mut start = 0;
+    while start < offsets.len() {
+        let end = (start + budget).min(offsets.len());
+        ranges.push((offsets[start].0, offsets[end - 1].1));
+        if end == offsets.len() {
+            break;
+        }
+        start += stride;
+    }
+    ranges
+}
+
+/// Return overlapping byte ranges that each fit the loaded mmBERT model.
+///
+/// `max_length <= 0` selects the model's configured context length. Two token
+/// positions are reserved for the special tokens added during embedding.
+///
+/// # Safety
+/// `text` must point to a valid, null-terminated C string.
+#[no_mangle]
+pub unsafe extern "C" fn get_text_windows(
+    text: *const c_char,
+    max_length: i32,
+) -> TextWindowsResult {
+    if text.is_null() {
+        return failed_windows();
+    }
+    let text = match unsafe { CStr::from_ptr(text) }.to_str() {
+        Ok(text) => text,
+        Err(_) => return failed_windows(),
+    };
+    let Some(model_lock) = GLOBAL_MMBERT_MODEL.get() else {
+        eprintln!("mmBERT model not initialized");
+        return failed_windows();
+    };
+    let model = model_lock.lock();
+    let window = if max_length <= 0 {
+        model.config().max_position_embeddings
+    } else {
+        max_length as usize
+    };
+    let mut tokenizer = model.tokenizer().clone();
+    if let Err(error) = tokenizer.with_truncation(None) {
+        eprintln!("Failed to disable tokenizer truncation for windowing: {error}");
+        return failed_windows();
+    }
+    let encoding = match tokenizer.encode(text, false) {
+        Ok(encoding) => encoding,
+        Err(error) => {
+            eprintln!("Failed to tokenize text for windowing: {error}");
+            return failed_windows();
+        }
+    };
+    let offsets: Vec<(usize, usize)> = encoding
+        .get_offsets()
+        .iter()
+        .copied()
+        .filter(|(start, end)| end > start)
+        .collect();
+    let budget = window.saturating_sub(2).max(1);
+    let ranges = window_ranges(&offsets, budget, budget.div_ceil(2));
+
+    let mut flat = Vec::with_capacity(ranges.len() * 2);
+    for (start, end) in &ranges {
+        let (Ok(start), Ok(end)) = (i32::try_from(*start), i32::try_from(*end)) else {
+            return failed_windows();
+        };
+        flat.push(start);
+        flat.push(end);
+    }
+    let Ok(window_count) = i32::try_from(ranges.len()) else {
+        return failed_windows();
+    };
+    let offsets = Box::into_raw(flat.into_boxed_slice()).cast::<i32>();
+    TextWindowsResult {
+        offsets,
+        window_count,
+        error: false,
+    }
+}
+
+/// Free ranges returned by `get_text_windows`.
+///
+/// # Safety
+/// `result` must originate from `get_text_windows` and must not be freed twice.
+#[no_mangle]
+pub unsafe extern "C" fn free_text_windows(result: TextWindowsResult) {
+    if result.offsets.is_null() || result.window_count <= 0 {
+        return;
+    }
+    let length = result.window_count as usize * 2;
+    let slice = std::ptr::slice_from_raw_parts_mut(result.offsets, length);
+    let _ = unsafe { Box::from_raw(slice) };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::window_ranges;
+
+    #[test]
+    fn ranges_cover_all_tokens() {
+        let offsets = [(0, 2), (3, 5), (6, 8), (9, 11), (12, 14)];
+        assert_eq!(
+            window_ranges(&offsets, 2, 2),
+            vec![(0, 5), (6, 11), (12, 14)]
+        );
+        assert_eq!(window_ranges(&offsets, 8, 4), vec![(0, 14)]);
+    }
+
+    #[test]
+    fn ranges_overlap_when_stride_is_shorter_than_budget() {
+        let offsets = [(0, 2), (3, 5), (6, 8), (9, 11), (12, 14)];
+        assert_eq!(window_ranges(&offsets, 4, 2), vec![(0, 11), (6, 14)]);
+    }
+
+    #[test]
+    fn ranges_handle_empty_and_zero_budget() {
+        assert!(window_ranges(&[], 4, 2).is_empty());
+        assert!(window_ranges(&[(0, 2)], 0, 1).is_empty());
+        assert_eq!(window_ranges(&[(0, 2)], 1, 0), vec![(0, 2)]);
+    }
+}


### PR DESCRIPTION
Related #3385

## Purpose

Commit 1e0140c7d introduced long-query RAG windowing through the candle_binding.TextWindows API, but the ONNX drop-in replacement did not expose that API. ONNX-backed router images therefore failed to compile before E2E tests could start.

This change adds the matching Go and Rust FFI contract to onnx-binding. It uses the loaded mmBERT tokenizer and configured context length, reserves space for special tokens, returns UTF-8-safe byte ranges, and overlaps adjacent windows by half of the token budget.

## Test Plan

- cargo test --manifest-path onnx-binding/Cargo.toml text_windows --lib
- cargo build --release --manifest-path onnx-binding/Cargo.toml
- Compile pkg/extproc with go.onnx.mod and the onnx,milvus build tags
- Build the complete ONNX router command
- make check with the four changed files

## Test Result

- Three focused Rust window-range tests passed.
- ONNX release library built successfully.
- pkg/extproc and the complete ONNX router compiled successfully through go.onnx.mod.
- Repository changed-file checks passed.