### PR TITLE
[Docs] Add nanasis to MoM Workgroup roster

### DIFF
--- a/website/src/data/workGroups.ts
+++ b/website/src/data/workGroups.ts
@@ -75,6 +75,11 @@ export const workGroups: WorkGroup[] = [
         avatar: 'https://github.com/daii-0818.png',
         profile: 'https://github.com/daii-0818',
       },
+      {
+        name: 'Nanasis',
+        avatar: 'https://github.com/nanasis.png',
+        profile: 'https://github.com/nanasis',
+      },
     ],
   },
   {


### PR DESCRIPTION
<!-- workgroup-operations:roster -->

## Summary

Add @nanasis as a Member of the MoM & Routing Workgroup.

Related #2965

| Applicant | Workgroup | Role | Application | Qualifying contribution |
| --- | --- | --- | --- | --- |
| [@nanasis](https://github.com/nanasis) | MoM & Routing | Member | [charter application](https://github.com/vllm-project/semantic-router/issues/2965#issuecomment-5599512872) | [#3652](https://github.com/vllm-project/semantic-router/pull/3652) |

Membership becomes canonical only after this PR merges.