### PR TITLE
[Feature] Add Databricks as a built-in serving provider

### DIFF
--- a/config/catalog/resources/providers/databricks.yaml
+++ b/config/catalog/resources/providers/databricks.yaml
@@ -1,0 +1,30 @@
+id: databricks
+display_name: Databricks
+description: Foundation models served from a Databricks workspace.
+category: model_api
+support_tier: compatible
+# No default_base_url: the serving root is workspace-specific. Operators set
+# ProviderInstance.base_url to https://<workspace-host>/serving-endpoints
+# (precedent: azure-openai, bedrock, vertex-ai). ResolveOperationPath strips the
+# protocol's /v1 default_base_path whenever a base path is configured, so that
+# base URL resolves create to /serving-endpoints/chat/completions, matching the
+# root Databricks documents for the OpenAI client. The AI Gateway roots
+# (/ai-gateway/mlflow/v1, /ai-gateway/openai/v1) compose the same way.
+protocols:
+- openai/chat-completions@1
+default_protocol: openai/chat-completions@1
+supported_operations:
+- openai/chat-completions@1#create
+# list_models is not declared: endpoint listing lives on /api/2.0/serving-endpoints,
+# a different root from the serving base URL, so it is not reachable by path
+# composition from the configured base_url.
+auth:
+  strategy: bearer
+  header: Authorization
+  prefix: Bearer
+presentation:
+  logo: monogram
+  monogram: DB
+  monochrome: true
+conformance:
+  status: unverified

--- a/config/recipes/built-in/latest/catalog.yaml
+++ b/config/recipes/built-in/latest/catalog.yaml
@@ -783,6 +783,26 @@ providers:
       status: claimed
       verified_at: '2026-09-05'
       source: https://www.alibabacloud.com/help/en/model-studio/text-generation-model
+- id: databricks
+  display_name: Databricks
+  description: Foundation models served from a Databricks workspace.
+  category: model_api
+  support_tier: compatible
+  protocols:
+  - openai/chat-completions@1
+  default_protocol: openai/chat-completions@1
+  supported_operations:
+  - openai/chat-completions@1#create
+  auth:
+    strategy: bearer
+    header: Authorization
+    prefix: Bearer
+  presentation:
+    logo: monogram
+    monogram: DB
+    monochrome: true
+  conformance:
+    status: unverified
 - id: deepinfra
   display_name: DeepInfra
   description: Serverless inference across open models.

--- a/dashboard/backend/handlers/model_catalog_test.go
+++ b/dashboard/backend/handlers/model_catalog_test.go
@@ -451,7 +451,7 @@ func TestGeneratedPublicModelCatalogSatisfiesDashboardContract(t *testing.T) {
 	if unmarshalErr := json.Unmarshal(normalized, &document); unmarshalErr != nil {
 		t.Fatalf("decode normalized public catalog: %v", unmarshalErr)
 	}
-	if len(document.Models) != 101 || len(document.Providers) != 61 || len(document.Evaluations) != 1509 {
+	if len(document.Models) != 101 || len(document.Providers) != 62 || len(document.Evaluations) != 1509 {
 		t.Fatalf(
 			"unexpected generated inventory: models=%d providers=%d evaluations=%d; "+
 				"regenerate the catalog, or update these counts if the change is intended",

--- a/src/semantic-router/pkg/catalog/compiler_test.go
+++ b/src/semantic-router/pkg/catalog/compiler_test.go
@@ -798,3 +798,41 @@ func TestEffectiveModelLookupIsDefensive(t *testing.T) {
 		t.Fatalf("effective registry was mutated through lookup: %+v", second)
 	}
 }
+
+func TestBuiltInRegistryOwnsDatabricksProviderContract(t *testing.T) {
+	registry, err := BuiltIn()
+	if err != nil {
+		t.Fatal(err)
+	}
+	provider, ok := registry.Provider("databricks")
+	if !ok {
+		t.Fatal("databricks provider is missing")
+	}
+	if provider.Category != "model_api" || provider.SupportTier != "compatible" {
+		t.Fatalf("unexpected classification: category = %q, support tier = %q", provider.Category, provider.SupportTier)
+	}
+	if provider.DefaultBaseURL != "" {
+		t.Fatalf("workspace-scoped provider declared a default base URL: %q", provider.DefaultBaseURL)
+	}
+	if len(provider.Protocols) != 1 || provider.Protocols[0] != "openai/chat-completions@1" {
+		t.Fatalf("unexpected protocols: %+v", provider.Protocols)
+	}
+	if provider.DefaultProtocol != "openai/chat-completions@1" {
+		t.Fatalf("default protocol = %q", provider.DefaultProtocol)
+	}
+	if len(provider.SupportedOperations) != 1 || provider.SupportedOperations[0] != "openai/chat-completions@1#create" {
+		t.Fatalf("unexpected operations: %+v", provider.SupportedOperations)
+	}
+	if len(provider.PathOverrides) != 0 {
+		t.Fatalf("path overrides are no-ops for a configured base path: %+v", provider.PathOverrides)
+	}
+	if provider.APIVersionQuery {
+		t.Fatal("databricks serving endpoints take no api-version query parameter")
+	}
+	if provider.Auth.Strategy != "bearer" || provider.Auth.Header != "Authorization" || provider.Auth.Prefix != "Bearer" {
+		t.Fatalf("unexpected auth contract: %+v", provider.Auth)
+	}
+	if provider.Presentation.Logo != "monogram" || provider.Presentation.Monogram != "DB" {
+		t.Fatalf("unexpected presentation: %+v", provider.Presentation)
+	}
+}

--- a/src/semantic-router/pkg/catalog/operations_test.go
+++ b/src/semantic-router/pkg/catalog/operations_test.go
@@ -52,3 +52,22 @@ func TestResolveProtocolOperationPathDoesNotApplyProviderOverrides(t *testing.T)
 		t.Fatalf("protocol create path = %q, err = %v", path, err)
 	}
 }
+
+func TestResolveOperationPathComposesDatabricksWorkspaceRoots(t *testing.T) {
+	registry, err := BuiltIn()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	path, err := registry.ResolveOperationPath("databricks", "", "create", "/serving-endpoints")
+	if err != nil || path != "/serving-endpoints/chat/completions" {
+		t.Fatalf("model serving root path = %q, err = %v", path, err)
+	}
+	path, err = registry.ResolveOperationPath("databricks", "", "create", "/ai-gateway/mlflow/v1")
+	if err != nil || path != "/ai-gateway/mlflow/v1/chat/completions" {
+		t.Fatalf("ai gateway root path = %q, err = %v", path, err)
+	}
+	if _, err := registry.ResolveOperationPath("databricks", "", "list_models", "/serving-endpoints"); err == nil {
+		t.Fatal("undeclared list_models operation was accepted")
+	}
+}

--- a/src/semantic-router/pkg/catalog/zz_generated_catalog.go
+++ b/src/semantic-router/pkg/catalog/zz_generated_catalog.go
@@ -2,7 +2,7 @@
 
 package catalog
 
-const builtInCatalogDigest = "sha256:2a3a1ae9f6a1897dffa998105d74ad37d8b006268077d231277dd1e7728ef22f"
+const builtInCatalogDigest = "sha256:9f12c6f2ab379b26cc86841cf4c008a3acc5ca62bf3646c9fc14d6a63342c331"
 
 const builtInCatalogJSON = `{
   "benchmarks": [
@@ -92871,6 +92871,33 @@ const builtInCatalogJSON = `{
         "openai/chat-completions@1#list_models",
         "openai/responses@1#create",
         "openai/responses@1#list_models"
+      ]
+    },
+    {
+      "auth": {
+        "header": "Authorization",
+        "prefix": "Bearer",
+        "strategy": "bearer"
+      },
+      "category": "model_api",
+      "conformance": {
+        "status": "unverified"
+      },
+      "default_protocol": "openai/chat-completions@1",
+      "description": "Foundation models served from a Databricks workspace.",
+      "display_name": "Databricks",
+      "id": "databricks",
+      "presentation": {
+        "logo": "monogram",
+        "monochrome": true,
+        "monogram": "DB"
+      },
+      "protocols": [
+        "openai/chat-completions@1"
+      ],
+      "support_tier": "compatible",
+      "supported_operations": [
+        "openai/chat-completions@1#create"
       ]
     },
     {

--- a/tools/catalog/tests/test_generate_model_catalog.py
+++ b/tools/catalog/tests/test_generate_model_catalog.py
@@ -744,6 +744,38 @@ class ModelCatalogCompilerTests(unittest.TestCase):
         self.assertEqual(provider["conformance"], {"status": "unverified"})
         self.assertNotIn("models", provider)
 
+    def test_databricks_provider_contract_is_complete(self) -> None:
+        _, resources, _ = catalog.load_and_validate()
+        providers = {provider["id"]: provider for provider in resources["providers"]}
+        provider = providers["databricks"]
+
+        self.assertEqual(provider["display_name"], "Databricks")
+        self.assertEqual(provider["category"], "model_api")
+        self.assertEqual(provider["support_tier"], "compatible")
+        self.assertNotIn("default_base_url", provider)
+        self.assertEqual(provider["protocols"], ["openai/chat-completions@1"])
+        self.assertEqual(provider["default_protocol"], "openai/chat-completions@1")
+        self.assertEqual(
+            provider["supported_operations"],
+            ["openai/chat-completions@1#create"],
+        )
+        self.assertNotIn("path_overrides", provider)
+        self.assertNotIn("api_version_query", provider)
+        self.assertEqual(
+            provider["auth"],
+            {
+                "strategy": "bearer",
+                "header": "Authorization",
+                "prefix": "Bearer",
+            },
+        )
+        self.assertEqual(
+            provider["presentation"],
+            {"logo": "monogram", "monogram": "DB", "monochrome": True},
+        )
+        self.assertEqual(provider["conformance"], {"status": "unverified"})
+        self.assertNotIn("models", provider)
+
     def test_core_reasoning_families_match_native_control_surfaces(self) -> None:
         _, resources, _ = catalog.load_and_validate()
         families = {item["id"]: item for item in resources["reasoning_families"]}

--- a/website/static/model-catalog/catalog.json
+++ b/website/static/model-catalog/catalog.json
@@ -92877,6 +92877,33 @@
       "conformance": {
         "status": "unverified"
       },
+      "default_protocol": "openai/chat-completions@1",
+      "description": "Foundation models served from a Databricks workspace.",
+      "display_name": "Databricks",
+      "id": "databricks",
+      "presentation": {
+        "logo": "monogram",
+        "monochrome": true,
+        "monogram": "DB"
+      },
+      "protocols": [
+        "openai/chat-completions@1"
+      ],
+      "support_tier": "compatible",
+      "supported_operations": [
+        "openai/chat-completions@1#create"
+      ]
+    },
+    {
+      "auth": {
+        "header": "Authorization",
+        "prefix": "Bearer",
+        "strategy": "bearer"
+      },
+      "category": "model_api",
+      "conformance": {
+        "status": "unverified"
+      },
       "default_base_url": "https://api.deepinfra.com/v1/openai",
       "default_protocol": "openai/chat-completions@1",
       "description": "Serverless inference across open models.",


### PR DESCRIPTION
Closes #3609

## Purpose

Adds `databricks` as a built-in serving provider, covering the provider contract only. No model bindings, no endpoint enumeration, no pricing — those stay in the separate bounded issue, per the non-goals in #3609. Owned by `wg/data-plane-networking` via the accepted issue.

**Surface.** Databricks serves foundation models from a workspace-specific root, so the definition declares **no `default_base_url`** and the operator supplies it — same shape as `azure-openai`, `bedrock` and `vertex-ai`. Two OpenAI-compatible roots are live in current docs, and both compose correctly under `ResolveOperationPath` with no `path_overrides`:

| operator `base_url` path | resolved `create` |
|---|---|
| `/serving-endpoints` | `/serving-endpoints/chat/completions` |
| `/ai-gateway/mlflow/v1` | `/ai-gateway/mlflow/v1/chat/completions` |

`joinProtocolOperationPath` strips the protocol's `/v1` `default_base_path` whenever a base path is configured, so a `path_overrides` entry would only affect the empty-base-path case, which cannot occur when the operator must supply a workspace host. The overrides carried by `azure-openai`/`bedrock`/`vertex-ai` are no-ops in that situation; I deliberately did not copy one.

**Auth is `bearer`.** The FM API docs show a `-u token:$DATABRICKS_TOKEN` basic-auth curl sample, but `databricks-ai-bridge`'s own `_resolve_base_url`/`BearerAuth` sends `Authorization: Bearer`, and that is what the serving endpoints accept. Verified against the SDK source rather than the docs prose.

**`list_models` is not declared.** Endpoint listing lives on `/api/2.0/serving-endpoints`, a different root from the serving base URL, so it is not reachable by path composition from the configured `base_url`.

**`logo: monogram` + `DB`.** `@lobehub/icons` 5.18.0 ships no Databricks mark, so a `package:` id would need a new upstream icon; the monogram keeps this PR inside the catalog.

**`conformance.status: unverified`.** Per @Xunzhuo's review: the coverage below pins catalog fields, registry projection and path composition, but does not exercise a provider-bound encoded request/response, so it does not support a `fixture_verified` claim. This matches `cloudflare-workers-ai`, the other data-only compatible provider in the registry.

## Test Plan

```
make model-catalog-generate
python3 tools/catalog/generate_model_catalog.py --check
python3 tools/catalog/audit_model_catalog.py --require-min-evaluations-per-model 5
python3 -m unittest tools.catalog.tests.test_generate_model_catalog
cd src/semantic-router && go test ./pkg/catalog/
cd dashboard/backend && go test ./handlers/ -run TestGeneratedPublicModelCatalogSatisfiesDashboardContract
```

New coverage:

- `TestBuiltInRegistryOwnsDatabricksProviderContract` (`pkg/catalog/compiler_test.go`) — pins id, category, support tier, absent `default_base_url`, protocols, operations, absent `path_overrides`/`api_version_query`, auth and presentation projections.
- `TestResolveOperationPathComposesDatabricksWorkspaceRoots` (`pkg/catalog/operations_test.go`) — pins `create` against both documented roots and asserts undeclared `list_models` is rejected.
- `test_databricks_provider_contract_is_complete` (`tools/catalog/tests/test_generate_model_catalog.py`) — source-resource assertions, mirroring the existing per-provider contract tests.
- `dashboard/backend/handlers/model_catalog_test.go` provider count 61 → 62.

No credentials, tokens, workspace hostnames or endpoint identifiers are used or committed. The only hosts named are the documented public roots.

## Test Result

All of the above pass locally, rebased onto `66ec856e`.

```
ok  github.com/vllm-project/semantic-router/src/semantic-router/pkg/catalog
ok  github.com/vllm-project/semantic-router/dashboard/backend/handlers
Ran 20 tests ... OK          # tools.catalog.tests.test_generate_model_catalog
generate_model_catalog.py --check -> exit 0
audit_model_catalog.py -> exit 0
```

The `openai/responses@1` protocol also composes on this provider (`/serving-endpoints/responses`, per *Query with the OpenAI Responses API*). I left it out to keep the slice to one protocol, and can add it here if you would rather have it in the same PR.
