### PR TITLE
[Feature] Add IBM watsonx.ai as a built-in serving provider

### DIFF
--- a/config/catalog/resources/providers/ibm-watsonx.yaml
+++ b/config/catalog/resources/providers/ibm-watsonx.yaml
@@ -1,0 +1,32 @@
+id: ibm-watsonx
+display_name: IBM watsonx.ai
+description: Foundation models served through an operator-owned IBM watsonx.ai model gateway.
+category: model_api
+support_tier: native
+# No default_base_url: the model gateway is a preview and IBM documents it in the
+# Toronto region only, so operators supply ProviderInstance.base_url as
+# https://ca-tor.ml.cloud.ibm.com/ml/gateway/v1 (same shape as azure-openai,
+# bedrock and vertex-ai). Region availability is expected to widen during the
+# preview; the operator-supplied base_url absorbs that without a catalog change.
+# https://www.ibm.com/docs/en/watsonx/saas?topic=models-model-gateway-preview
+protocols:
+- openai/chat-completions@1
+default_protocol: openai/chat-completions@1
+supported_operations:
+- openai/chat-completions@1#create
+- openai/chat-completions@1#list_models
+# This binds the model gateway, not the native /ml/v1/text/chat API. The native
+# surface needs a body-level tenant id (project_id/space_id) and a model_id key,
+# neither of which openai/chat-completions@1 carries, and it requires ?version=
+# rather than the api-version= that api_version_query emits. The gateway takes a
+# plain OpenAI body and no version parameter.
+auth:
+  strategy: bearer
+  header: Authorization
+  prefix: Bearer
+presentation:
+  logo: monogram
+  monogram: IBM
+  monochrome: true
+conformance:
+  status: unverified

--- a/config/recipes/built-in/latest/catalog.yaml
+++ b/config/recipes/built-in/latest/catalog.yaml
@@ -1067,6 +1067,27 @@ providers:
     monochrome: false
   conformance:
     status: unverified
+- id: ibm-watsonx
+  display_name: IBM watsonx.ai
+  description: Foundation models served through an operator-owned IBM watsonx.ai model gateway.
+  category: model_api
+  support_tier: native
+  protocols:
+  - openai/chat-completions@1
+  default_protocol: openai/chat-completions@1
+  supported_operations:
+  - openai/chat-completions@1#create
+  - openai/chat-completions@1#list_models
+  auth:
+    strategy: bearer
+    header: Authorization
+    prefix: Bearer
+  presentation:
+    logo: monogram
+    monogram: IBM
+    monochrome: true
+  conformance:
+    status: unverified
 - id: inception
   display_name: Inception
   description: Mercury diffusion models through the Inception OpenAI-compatible API.

--- a/dashboard/backend/handlers/model_catalog_test.go
+++ b/dashboard/backend/handlers/model_catalog_test.go
@@ -451,7 +451,7 @@ func TestGeneratedPublicModelCatalogSatisfiesDashboardContract(t *testing.T) {
 	if unmarshalErr := json.Unmarshal(normalized, &document); unmarshalErr != nil {
 		t.Fatalf("decode normalized public catalog: %v", unmarshalErr)
 	}
-	if len(document.Models) != 101 || len(document.Providers) != 61 || len(document.Evaluations) != 1509 {
+	if len(document.Models) != 101 || len(document.Providers) != 62 || len(document.Evaluations) != 1509 {
 		t.Fatalf(
 			"unexpected generated inventory: models=%d providers=%d evaluations=%d; "+
 				"regenerate the catalog, or update these counts if the change is intended",

--- a/src/semantic-router/pkg/catalog/compiler_test.go
+++ b/src/semantic-router/pkg/catalog/compiler_test.go
@@ -798,3 +798,47 @@ func TestEffectiveModelLookupIsDefensive(t *testing.T) {
 		t.Fatalf("effective registry was mutated through lookup: %+v", second)
 	}
 }
+
+func TestBuiltInRegistryOwnsIBMWatsonxProviderContract(t *testing.T) {
+	registry, err := BuiltIn()
+	if err != nil {
+		t.Fatal(err)
+	}
+	provider, ok := registry.Provider("ibm-watsonx")
+	if !ok {
+		t.Fatal("ibm-watsonx provider is missing")
+	}
+	if provider.Category != "model_api" || provider.SupportTier != "native" {
+		t.Fatalf("unexpected classification: category = %q, support tier = %q", provider.Category, provider.SupportTier)
+	}
+	if provider.DefaultBaseURL != "" {
+		t.Fatalf("region-scoped provider declared a default base URL: %q", provider.DefaultBaseURL)
+	}
+	if len(provider.Protocols) != 1 || provider.Protocols[0] != "openai/chat-completions@1" {
+		t.Fatalf("unexpected protocols: %+v", provider.Protocols)
+	}
+	if provider.DefaultProtocol != "openai/chat-completions@1" {
+		t.Fatalf("default protocol = %q", provider.DefaultProtocol)
+	}
+	wantOperations := []string{"openai/chat-completions@1#create", "openai/chat-completions@1#list_models"}
+	if len(provider.SupportedOperations) != len(wantOperations) {
+		t.Fatalf("unexpected operations: %+v", provider.SupportedOperations)
+	}
+	for index, want := range wantOperations {
+		if provider.SupportedOperations[index] != want {
+			t.Fatalf("operation %d = %q, want %q", index, provider.SupportedOperations[index], want)
+		}
+	}
+	if len(provider.PathOverrides) != 0 {
+		t.Fatalf("path overrides are no-ops for a configured base path: %+v", provider.PathOverrides)
+	}
+	if provider.APIVersionQuery {
+		t.Fatal("the watsonx model gateway takes no version query parameter")
+	}
+	if provider.Auth.Strategy != "bearer" || provider.Auth.Header != "Authorization" || provider.Auth.Prefix != "Bearer" {
+		t.Fatalf("unexpected auth contract: %+v", provider.Auth)
+	}
+	if provider.Presentation.Logo != "monogram" || provider.Presentation.Monogram != "IBM" {
+		t.Fatalf("unexpected presentation: %+v", provider.Presentation)
+	}
+}

--- a/src/semantic-router/pkg/catalog/operations_test.go
+++ b/src/semantic-router/pkg/catalog/operations_test.go
@@ -52,3 +52,19 @@ func TestResolveProtocolOperationPathDoesNotApplyProviderOverrides(t *testing.T)
 		t.Fatalf("protocol create path = %q, err = %v", path, err)
 	}
 }
+
+func TestResolveOperationPathComposesIBMWatsonxGatewayRoot(t *testing.T) {
+	registry, err := BuiltIn()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	path, err := registry.ResolveOperationPath("ibm-watsonx", "", "create", "/ml/gateway/v1")
+	if err != nil || path != "/ml/gateway/v1/chat/completions" {
+		t.Fatalf("gateway create path = %q, err = %v", path, err)
+	}
+	path, err = registry.ResolveOperationPath("ibm-watsonx", "", "list_models", "/ml/gateway/v1")
+	if err != nil || path != "/ml/gateway/v1/models" {
+		t.Fatalf("gateway list_models path = %q, err = %v", path, err)
+	}
+}

--- a/src/semantic-router/pkg/catalog/zz_generated_catalog.go
+++ b/src/semantic-router/pkg/catalog/zz_generated_catalog.go
@@ -2,7 +2,7 @@
 
 package catalog
 
-const builtInCatalogDigest = "sha256:2a3a1ae9f6a1897dffa998105d74ad37d8b006268077d231277dd1e7728ef22f"
+const builtInCatalogDigest = "sha256:3b48e6506310bc495f3840a145bbae8290b405dd281d8cb4c5f6238c547f1204"
 
 const builtInCatalogJSON = `{
   "benchmarks": [
@@ -93246,6 +93246,34 @@ const builtInCatalogJSON = `{
         "openai/chat-completions@1"
       ],
       "support_tier": "compatible",
+      "supported_operations": [
+        "openai/chat-completions@1#create",
+        "openai/chat-completions@1#list_models"
+      ]
+    },
+    {
+      "auth": {
+        "header": "Authorization",
+        "prefix": "Bearer",
+        "strategy": "bearer"
+      },
+      "category": "model_api",
+      "conformance": {
+        "status": "unverified"
+      },
+      "default_protocol": "openai/chat-completions@1",
+      "description": "Foundation models served through an operator-owned IBM watsonx.ai model gateway.",
+      "display_name": "IBM watsonx.ai",
+      "id": "ibm-watsonx",
+      "presentation": {
+        "logo": "monogram",
+        "monochrome": true,
+        "monogram": "IBM"
+      },
+      "protocols": [
+        "openai/chat-completions@1"
+      ],
+      "support_tier": "native",
       "supported_operations": [
         "openai/chat-completions@1#create",
         "openai/chat-completions@1#list_models"

--- a/tools/catalog/tests/test_generate_model_catalog.py
+++ b/tools/catalog/tests/test_generate_model_catalog.py
@@ -744,6 +744,41 @@ class ModelCatalogCompilerTests(unittest.TestCase):
         self.assertEqual(provider["conformance"], {"status": "unverified"})
         self.assertNotIn("models", provider)
 
+    def test_ibm_watsonx_provider_contract_is_complete(self) -> None:
+        _, resources, _ = catalog.load_and_validate()
+        providers = {provider["id"]: provider for provider in resources["providers"]}
+        provider = providers["ibm-watsonx"]
+
+        self.assertEqual(provider["display_name"], "IBM watsonx.ai")
+        self.assertEqual(provider["category"], "model_api")
+        self.assertEqual(provider["support_tier"], "native")
+        self.assertNotIn("default_base_url", provider)
+        self.assertEqual(provider["protocols"], ["openai/chat-completions@1"])
+        self.assertEqual(provider["default_protocol"], "openai/chat-completions@1")
+        self.assertEqual(
+            provider["supported_operations"],
+            [
+                "openai/chat-completions@1#create",
+                "openai/chat-completions@1#list_models",
+            ],
+        )
+        self.assertNotIn("path_overrides", provider)
+        self.assertNotIn("api_version_query", provider)
+        self.assertEqual(
+            provider["auth"],
+            {
+                "strategy": "bearer",
+                "header": "Authorization",
+                "prefix": "Bearer",
+            },
+        )
+        self.assertEqual(
+            provider["presentation"],
+            {"logo": "monogram", "monogram": "IBM", "monochrome": True},
+        )
+        self.assertEqual(provider["conformance"], {"status": "unverified"})
+        self.assertNotIn("models", provider)
+
     def test_core_reasoning_families_match_native_control_surfaces(self) -> None:
         _, resources, _ = catalog.load_and_validate()
         families = {item["id"]: item for item in resources["reasoning_families"]}

--- a/website/static/model-catalog/catalog.json
+++ b/website/static/model-catalog/catalog.json
@@ -93255,6 +93255,34 @@
       "conformance": {
         "status": "unverified"
       },
+      "default_protocol": "openai/chat-completions@1",
+      "description": "Foundation models served through an operator-owned IBM watsonx.ai model gateway.",
+      "display_name": "IBM watsonx.ai",
+      "id": "ibm-watsonx",
+      "presentation": {
+        "logo": "monogram",
+        "monochrome": true,
+        "monogram": "IBM"
+      },
+      "protocols": [
+        "openai/chat-completions@1"
+      ],
+      "support_tier": "native",
+      "supported_operations": [
+        "openai/chat-completions@1#create",
+        "openai/chat-completions@1#list_models"
+      ]
+    },
+    {
+      "auth": {
+        "header": "Authorization",
+        "prefix": "Bearer",
+        "strategy": "bearer"
+      },
+      "category": "model_api",
+      "conformance": {
+        "status": "unverified"
+      },
       "default_base_url": "https://api.inceptionlabs.ai/v1",
       "default_protocol": "openai/chat-completions@1",
       "description": "Mercury diffusion models through the Inception OpenAI-compatible API.",


### PR DESCRIPTION
Closes #3607

## Purpose

Adds `ibm-watsonx` as a built-in serving provider, covering the provider contract only. No Granite Model Cards, no catalog mirroring, no pricing — those stay in the separate bounded coverage issue, per the non-goals in #3607. Owned by `wg/data-plane-networking` via the accepted issue. This is the contract I posted on the issue before opening the PR (comment 5605330199), unchanged.

**Which surface this binds.** watsonx.ai has two inference surfaces and only one is declarable as a `ProviderDefinition`:

| surface | wire shape | |
|---|---|---|
| **Model gateway**, `https://ca-tor.ml.cloud.ibm.com/ml/gateway/v1` | `POST /ml/gateway/v1/chat/completions`, plain OpenAI body `{"model", "messages", "stream"}`, `Authorization: Bearer <IAM token>`, no version parameter | **what this declares** |
| Native inference, `POST /ml/v1/text/chat` | body `{"model_id", "messages", "project_id"\|"space_id"}` plus a mandatory `?version=YYYY-MM-DD` | not declarable today |

The native surface needs a body-level tenant id and a renamed model key, neither of which `openai/chat-completions@1` carries, and `appendAPIVersion` emits `api-version=` rather than the `version=` it requires. Binding the OpenAI-compatible routing surface is the same choice the registry already makes for `bedrock` and `vertex-ai`.

Verified against IBM's own SDK rather than docs prose (`ibm-watsonx-ai` 1.7.1): `gateway/gateway.py` builds `{"messages", "model"}` and posts to `get_gateway_chat_completions_href()`; `href_definitions.py` defines `GATEWAY_CHAT_COMPLETIONS = "{}/ml/gateway/v1/chat/completions"` and `GATEWAY_ALL_TENANT_MODELS = "{}/ml/gateway/v1/models"`. Native calls attach `_params()["version"]`; gateway calls do not.

**No `default_base_url`.** Per @Xunzhuo's review, the gateway is a preview that IBM documents in the **Toronto region only**, so operators supply `ProviderInstance.base_url` as `https://ca-tor.ml.cloud.ibm.com/ml/gateway/v1` — same shape as `azure-openai`, `bedrock` and `vertex-ai`. My earlier comment listed the watsonx.ai *runtime* regions, which is the wrong scope for this surface; the YAML now names only the documented preview endpoint and cites [the preview doc](https://www.ibm.com/docs/en/watsonx/saas?topic=models-model-gateway-preview). Availability is expected to widen during the preview, which the operator-supplied `base_url` absorbs without a catalog change.

**No `path_overrides`.** `joinProtocolOperationPath` strips the protocol's `/v1` `default_base_path` whenever a base path is configured, so `/ml/gateway/v1` resolves `create` to `/ml/gateway/v1/chat/completions` and `list_models` to `/ml/gateway/v1/models`, matching the SDK hrefs exactly. An override would only change the empty-base-path case, which cannot occur when the operator must supply a workspace host.

**`list_models` is declared**, unlike `azure-openai`, because `GET /ml/gateway/v1/models` is reachable from the same configured base URL. **No `api_version_query`**, since the gateway takes no version parameter.

**`conformance.status: unverified`.** Per @Xunzhuo's review: the coverage below pins catalog fields, registry projection and path composition, but does not exercise a provider-bound encoded request/response, so it does not support a `fixture_verified` claim.

**`support_tier: native`** on the same reading that makes `bedrock` and `vertex-ai` native — a first-party vendor cloud with an operator-supplied region root — rather than a third-party OpenAI-compatible reseller. Say the word if you would rather classify it `compatible`; it is a one-line change.

## Test Plan

```
make model-catalog-generate
python3 tools/catalog/generate_model_catalog.py --check
python3 tools/catalog/audit_model_catalog.py --require-min-evaluations-per-model 5
python3 -m unittest tools.catalog.tests.test_generate_model_catalog
cd src/semantic-router && go test ./pkg/catalog/
cd dashboard/backend && go test ./handlers/ -run TestGeneratedPublicModelCatalogSatisfiesDashboardContract
```

New coverage:

- `TestBuiltInRegistryOwnsIBMWatsonxProviderContract` (`pkg/catalog/compiler_test.go`) — pins id, category, support tier, absent `default_base_url`, protocols, both operations in order, absent `path_overrides`/`api_version_query`, auth and presentation projections.
- `TestResolveOperationPathComposesIBMWatsonxGatewayRoot` (`pkg/catalog/operations_test.go`) — pins both `create` and `list_models` against the `/ml/gateway/v1` base path.
- `test_ibm_watsonx_provider_contract_is_complete` (`tools/catalog/tests/test_generate_model_catalog.py`) — source-resource assertions, mirroring the existing per-provider contract tests.
- `dashboard/backend/handlers/model_catalog_test.go` provider count 61 → 62.

No IBM Cloud account, API key, project id or tenant id is required by any of it, and none is committed. The only host named is the documented public preview root.

## Test Result

All of the above pass locally, rebased onto `66ec856e`.

```
ok  github.com/vllm-project/semantic-router/src/semantic-router/pkg/catalog
ok  github.com/vllm-project/semantic-router/dashboard/backend/handlers
Ran 20 tests ... OK          # tools.catalog.tests.test_generate_model_catalog
generate_model_catalog.py --check -> exit 0
audit_model_catalog.py -> exit 0
```

One thing worth flagging plainly:

**No live receipt.** #3607's completion signal asks for a sanitized live receipt from a publicly obtainable account. This ships `unverified`. watsonx.ai does have a free Lite plan, but the gateway is a Toronto-only preview and it is not settled that it serves models on Lite without first configuring a provider connection through the `/ml/gateway/v1/providers` management endpoints, so I cannot promise the receipt reproduces for a reviewer. Happy to add one if the project has an account it wants this verified against.

`@lobehub/icons` 5.18.0 does ship an `IBM` mark if you would prefer the brand icon over `logo: monogram`; that needs one import plus one entry in `website/src/components/model-hub/ModelHubMark.tsx`, and I am happy to include it here.

