### PR TITLE
[Fix] Fix candle-binding `mkl` feature: static link + `hgemm_` shim + probe-based ocipkg discovery

### DIFF
--- a/candle-binding/Cargo.lock
+++ b/candle-binding/Cargo.lock
@@ -470,6 +470,8 @@ dependencies = [
  "candle-transformers",
  "criterion",
  "crossbeam-channel",
+ "gemm",
+ "half",
  "hf-hub",
  "image",
  "libc",

--- a/candle-binding/Cargo.toml
+++ b/candle-binding/Cargo.toml
@@ -21,7 +21,10 @@ flash-attn = ["cuda", "candle-flash-attn"]
 # Intel MKL support for faster CPU inference (Linux/Windows)
 # Enable with: cargo build --no-default-features --features mkl
 # Requires: Intel MKL libraries installed
-mkl = ["candle-core/mkl", "candle-nn/mkl", "candle-transformers/mkl"]
+# gemm/half: candle's mkl path needs hgemm_ (f16 GEMM), which the static
+# MKL 2020.1 package from intel-mkl-src lacks; src/ffi/mkl_shim.rs provides
+# it on top of the gemm crate kernels.
+mkl = ["candle-core/mkl", "candle-nn/mkl", "candle-transformers/mkl", "dep:gemm", "dep:half"]
 # macOS Accelerate framework support for faster CPU inference
 # Enable with: cargo build --no-default-features --features accelerate
 accelerate = ["candle-core/accelerate", "candle-nn/accelerate", "candle-transformers/accelerate"]
@@ -53,6 +56,10 @@ crossbeam-channel = "0.5"  # Efficient multi-channel select for scheduler wakeup
 # Image decode + PIL-equivalent bicubic+antialias resize, used by
 # multimodal_encode_image_from_bytes to match SiglipProcessor preprocessing.
 image = { version = "0.25", default-features = false, features = ["jpeg", "png"] }
+# hgemm_ shim deps (mkl build only): route candle's f16 matmuls around the
+# f16-less static MKL 2020.1 onto the gemm crate kernels.
+gemm = { version = "0.18.2", features = ["f16"], optional = true }
+half = { version = "2.5.0", optional = true }
 
 [dev-dependencies]
 rstest = "0.18"

--- a/candle-binding/build.rs
+++ b/candle-binding/build.rs
@@ -1,17 +1,74 @@
 fn main() {
     #[cfg(feature = "mkl")]
     {
-        // Try MKLROOT first, then common conda paths
-        let mkl_lib_dir = std::env::var("MKLROOT")
-            .map(|root| format!("{}/lib", root))
-            .or_else(|_| std::env::var("CONDA_PREFIX").map(|p| format!("{}/lib", p)))
-            .unwrap_or_else(|_| "/usr/lib/x86_64-linux-gnu".to_string());
+        // MKL: link the static mkl-static-lp64-iomp package from the ocipkg cache.
+        // The package is downloaded automatically by intel-mkl-src's build script
+        // (pulled in via candle-core's mkl feature) on first build, and extracted
+        // to `$HOME/.local/share/ocipkg/ghcr.io/rust-math/rust-mkl/linux/
+        // mkl-static-lp64-iomp/<tag>/`, where <tag> embeds the MKL version plus a
+        // content hash (e.g. `__2020.1-3038006115`) that varies across releases
+        // and machines. Do NOT hardcode <tag> (an earlier revision hardcoded
+        // `__2020.1-3038006115`, which broke builds on any machine whose cache
+        // held a different tag); discover it at build time instead. Any <tag>
+        // directory containing all four archives linked below is a valid
+        // candidate; when several exist the newest mtime wins, because
+        // intel-mkl-src's build script has already run by the time this script
+        // executes and downloaded the version pinned by Cargo.lock.
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
+        let base = format!(
+            "{}/.local/share/ocipkg/ghcr.io/rust-math/rust-mkl/linux/mkl-static-lp64-iomp",
+            home
+        );
+        let entries = match std::fs::read_dir(&base) {
+            Ok(entries) => entries,
+            Err(err) => panic!(
+                "mkl feature: cannot read ocipkg cache dir {base} ({err})\n\
+                 hint: the static package is fetched by intel-mkl-src (via \
+                 candle-core) on first build; build once with network access \
+                 or pre-seed the ocipkg cache"
+            ),
+        };
 
-        println!("cargo:rustc-link-search=native={}", mkl_lib_dir);
-        println!("cargo:rustc-link-lib=dylib=mkl_intel_lp64");
-        println!("cargo:rustc-link-lib=dylib=mkl_sequential");
-        println!("cargo:rustc-link-lib=dylib=mkl_core");
-        println!("cargo:rustc-link-lib=dylib=pthread");
-        println!("cargo:rustc-link-lib=dylib=m");
+        let mut candidates: Vec<(std::time::SystemTime, std::path::PathBuf)> = entries
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.path())
+            .filter(|path| {
+                path.is_dir()
+                    && [
+                        "libmkl_intel_lp64.a",
+                        "libmkl_intel_thread.a",
+                        "libmkl_core.a",
+                        "libiomp5.a",
+                    ]
+                    .iter()
+                    .all(|lib| path.join(lib).is_file())
+            })
+            .filter_map(|path| {
+                let mtime = path.metadata().and_then(|m| m.modified()).ok()?;
+                Some((mtime, path))
+            })
+            .collect();
+
+        if candidates.is_empty() {
+            panic!(
+                "mkl feature: no ocipkg package directory containing all of \
+                 libmkl_intel_lp64.a, libmkl_intel_thread.a, libmkl_core.a and \
+                 libiomp5.a under {base}"
+            );
+        }
+        // Newest first; ties broken by path for determinism.
+        candidates.sort_by(|a, b| b.cmp(a));
+        let (_, dir) = candidates.remove(0);
+        if !candidates.is_empty() {
+            println!(
+                "cargo:warning=mkl: multiple ocipkg package versions found, using the newest: {}",
+                dir.display()
+            );
+        }
+        println!("cargo:rustc-link-search=native={}", dir.display());
+        println!("cargo:rustc-link-lib=static=mkl_intel_lp64");
+        println!("cargo:rustc-link-lib=static=mkl_intel_thread");
+        println!("cargo:rustc-link-lib=static=mkl_core");
+        println!("cargo:rustc-link-lib=static=iomp5");
     }
 }

--- a/candle-binding/src/ffi/mkl_shim.rs
+++ b/candle-binding/src/ffi/mkl_shim.rs
@@ -1,0 +1,83 @@
+//! MKL `hgemm_` shim (half-precision BLAS GEMM).
+//!
+//! candle-core's `mkl` feature routes every f16 matmul through the MKL
+//! `hgemm_` Fortran entry point (`candle-core/src/mkl.rs`). The static MKL
+//! 2020.1 package that `intel-mkl-src` fetches via ocipkg
+//! (`mkl-static-lp64-iomp`) predates MKL's f16 GEMM support, so the symbol
+//! does not exist there and loading this binding fails at runtime with
+//! `undefined symbol: hgemm_`.
+//!
+//! This module provides `hgemm_` on top of the `gemm` crate — the same
+//! SIMD-optimized kernels candle uses when built *without* MKL — so the
+//! mkl build keeps working (f32/f64 matmuls still go through MKL).
+
+use gemm::{gemm as gemm_kernel, Parallelism};
+use half::f16;
+use libc::{c_char, c_int};
+
+/// Fortran BLAS interface: `C := alpha*op(A)*op(B) + beta*C`, column-major.
+///
+/// `op(X) = X` for `trans == 'N'`, `X^T` for `trans == 'T'`; A is m×k with
+/// leading dimension `lda`, B is k×n with `ldb`, C is m×n with `ldc`.
+#[no_mangle]
+pub unsafe extern "C" fn hgemm_(
+    transa: *const c_char,
+    transb: *const c_char,
+    m: *const c_int,
+    n: *const c_int,
+    k: *const c_int,
+    alpha: *const f16,
+    a: *const f16,
+    lda: *const c_int,
+    b: *const f16,
+    ldb: *const c_int,
+    beta: *const f16,
+    c: *mut f16,
+    ldc: *const c_int,
+) {
+    let transa = *transa as u8;
+    let transb = *transb as u8;
+    let m = *m as usize;
+    let n = *n as usize;
+    let k = *k as usize;
+    let lda = *lda as isize;
+    let ldb = *ldb as isize;
+    let ldc = *ldc as isize;
+    let alpha = *alpha;
+    let beta = *beta;
+
+    // Map BLAS column-major leading dimensions onto the gemm crate's
+    // (col_stride, row_stride) convention. Column-major storage with
+    // leading dimension L keeps element (row r, col c) at buffer[r + c*L],
+    // so both operands follow the same pattern:
+    //   'N': stride pattern (cs=L, rs=1)
+    //   'T': stride pattern (cs=1, rs=L)
+    let (lhs_cs, lhs_rs) = if transa == b'N' { (lda, 1) } else { (1, lda) };
+    let (rhs_cs, rhs_rs) = if transb == b'N' { (ldb, 1) } else { (1, ldb) };
+
+    // NOTE: the gemm crate computes dst = alpha*dst + beta*(lhs*rhs) — the
+    // OPPOSITE of BLAS (C = alpha*op(A)*op(B) + beta*C). Map accordingly:
+    // gemm-alpha scales the existing destination (BLAS beta), gemm-beta
+    // scales the product (BLAS alpha).
+    gemm_kernel(
+        m,
+        n,
+        k,
+        c,
+        ldc,               // dst_cs
+        1,                 // dst_rs
+        beta != f16::ZERO, // read_dst: skip loading C when beta == 0
+        a,
+        lhs_cs,
+        lhs_rs,
+        b,
+        rhs_cs,
+        rhs_rs,
+        beta,  // gemm-crate alpha: scales existing dst
+        alpha, // gemm-crate beta: scales the product
+        false, // conj_dst
+        false, // conj_lhs
+        false, // conj_rhs
+        Parallelism::Rayon(rayon::current_num_threads()),
+    );
+}

--- a/candle-binding/src/ffi/mod.rs
+++ b/candle-binding/src/ffi/mod.rs
@@ -9,6 +9,8 @@ pub mod generative_classifier; // Qwen3 LoRA generative classifier
 pub mod generative_guard; // Qwen3Guard safety classifier
 pub mod init; //  initialization functions
 pub mod memory; //  memory management functions
+#[cfg(feature = "mkl")]
+pub mod mkl_shim; // hgemm_ fallback: static MKL 2020.1 lacks f16 GEMM
 pub mod mlp; // MLP selector for model selection (GPU-accelerated)
 pub mod similarity; //  similarity functions
 pub mod text_windows; //  embedding window ranges


### PR DESCRIPTION
Closes #3696 

## Purpose

The `mkl` feature in `candle-binding` is unusable for CPU-only deployments:

1. `build.rs` assumes a system MKL install and links the dynamic `-lmkl_sequential`,
   but the ocipkg static package fetched by `intel-mkl-src` ships only
   `mkl_intel_thread` — a fresh `--no-default-features --features mkl` build
   fails to link.
2. After fixing the link, the `.so` fails to load with `undefined symbol: hgemm_`:
   candle-core routes f16 matmul to `hgemm_`, but MKL 2020.1 (as fetched) has no f16
   GEMM symbol, and the unresolved dynamic reference aborts `dlopen`.

This PR makes the mkl feature build and load correctly.

## Changes

- `build.rs`: link the ocipkg static four (`mkl_intel_lp64 / mkl_intel_thread /
  mkl_core / iomp5`) instead of the non-existent system `mkl_sequential`; find the
  cache dir by probing (filter dirs containing the four `.a`s, take newest mtime)
  instead of assuming a system MKL install (MKLROOT / CONDA_PREFIX); the existing
  `#[cfg(feature="mkl")]` guard is kept unchanged.
- `Cargo.toml`: add `gemm` (0.18.2, f16) and `half` (2.5.0) to the `mkl` feature.
- `src/ffi/mod.rs`: declare the shim under `#[cfg(feature="mkl")]`.
- `src/ffi/mkl_shim.rs` (new): `hgemm_` implemented on the gemm crate f16 kernel;
  f32/f64 still go through MKL `sgemm_`/`dgemm_`.
- Regression test: ctypes harness covering `hgemm_` under NN/TT/TN + beta!=0.
  (Happy to convert to a `#[cfg(test)]` Rust unit test on review.)

## Test Plan

- `cargo build --release --no-default-features --features mkl` (compute node)
- `#<test harness name> ` — hgemm_ NN/TT/TN + beta!=0, 4/4 pass
- `nm libcandle_semantic_router.so | grep ' T hgemm_'` shows the export
- Start the router with `LD_LIBRARY_PATH` pointing at the new `.so` and issue
  30 `/api/v1/classify/intent` requests (domain + complexity signals) — loads and
  serves normally.

## Test Result

- Build: `Finished release profile ... in 51.62s`; `.so` = 53,320,024 bytes;
  probing build.rs reproduces the same bytes as the hardcoded-path build (byte-equal).
- `nm`: `T hgemm_` present; `mkl_` symbols present.
- Router load + classify: OK. No routing behavior change (temperature=0,
  deterministic); accuracy / large-model share unchanged across runs.