### PR TITLE
[Docs] Add Ethan Jiang and PharosEast to Workgroup rosters

### DIFF
--- a/website/src/data/workGroups.ts
+++ b/website/src/data/workGroups.ts
@@ -171,6 +171,11 @@ export const workGroups: WorkGroup[] = [
         avatar: 'https://github.com/Bevisy.png',
         profile: 'https://github.com/Bevisy',
       },
+      {
+        name: 'Haoyu Jing',
+        avatar: 'https://github.com/PharosEast.png',
+        profile: 'https://github.com/PharosEast',
+      },
     ],
   },
   {
@@ -319,6 +324,11 @@ export const workGroups: WorkGroup[] = [
         name: 'Shrek Luzz',
         avatar: 'https://github.com/Zheng-Lu.png',
         profile: 'https://github.com/Zheng-Lu',
+      },
+      {
+        name: 'Ethan Jiang',
+        avatar: 'https://github.com/ethanjyx.png',
+        profile: 'https://github.com/ethanjyx',
       },
     ],
   },


### PR DESCRIPTION
<!-- workgroup-operations:roster -->

## Summary

Add @ethanjyx as an Agentic & Context Member and @PharosEast as a Router Models & Inference Runtime Member.

Related #2987
Related #2966

| Candidate | Workgroup | Role | Application / nomination | Qualifying contribution |
| --- | --- | --- | --- | --- |
| [@ethanjyx](https://github.com/ethanjyx) | Agentic & Context | Member | [charter application](https://github.com/vllm-project/semantic-router/issues/2987#issuecomment-5545309911) | [#3521](https://github.com/vllm-project/semantic-router/pull/3521) |
| [@PharosEast](https://github.com/PharosEast) | Router Models & Inference Runtime | Member |  | [#3697](https://github.com/vllm-project/semantic-router/pull/3697) |

Membership becomes canonical only after this PR merges.