### PR TITLE
[Bug] Accept vLLM 0.21.0 prompt_routed_experts response field (#3708)

### DIFF
--- a/src/semantic-router/pkg/protocolcodec/codec_openai_chat_response_wire.go
+++ b/src/semantic-router/pkg/protocolcodec/codec_openai_chat_response_wire.go
@@ -9,29 +9,30 @@ import (
 )
 
 type chatResponseWire struct {
-	ID                string                    `json:"id"`
-	Object            string                    `json:"object,omitempty"`
-	Created           int64                     `json:"created"`
-	Model             string                    `json:"model"`
-	Choices           []chatChoiceWire          `json:"choices"`
-	Usage             *chatUsageWire            `json:"usage,omitempty"`
-	Metadata          map[string]string         `json:"metadata,omitempty"`
-	Moderation        json.RawMessage           `json:"moderation,omitempty"`
-	Error             *chatErrorWire            `json:"error,omitempty"`
-	ServiceTier       *chatServiceTierWire      `json:"service_tier,omitempty"`
-	SystemFingerprint *string                   `json:"system_fingerprint,omitempty"`
-	PromptLogprobs    *chatNullOnlyWire         `json:"prompt_logprobs,omitempty"`
-	PromptTokenIDs    []int64                   `json:"prompt_token_ids,omitempty"`
-	PromptText        *chatNullOnlyWire         `json:"prompt_text,omitempty"`
-	KVTransferParams  *chatKVTransferParamsWire `json:"kv_transfer_params,omitempty"`
-	ECTransferParams  *chatNullOnlyWire         `json:"ec_transfer_params,omitempty"`
-	Metrics           *chatNullOnlyWire         `json:"metrics,omitempty"`
-	DoRemoteDecode    *bool                     `json:"do_remote_decode,omitempty"`
-	DoRemotePrefill   *bool                     `json:"do_remote_prefill,omitempty"`
-	RemoteBlockIDs    []int64                   `json:"remote_block_ids,omitempty"`
-	RemoteEngineID    *string                   `json:"remote_engine_id,omitempty"`
-	RemoteHost        *string                   `json:"remote_host,omitempty"`
-	RemotePort        *int64                    `json:"remote_port,omitempty"`
+	ID                  string                    `json:"id"`
+	Object              string                    `json:"object,omitempty"`
+	Created             int64                     `json:"created"`
+	Model               string                    `json:"model"`
+	Choices             []chatChoiceWire          `json:"choices"`
+	Usage               *chatUsageWire            `json:"usage,omitempty"`
+	Metadata            map[string]string         `json:"metadata,omitempty"`
+	Moderation          json.RawMessage           `json:"moderation,omitempty"`
+	Error               *chatErrorWire            `json:"error,omitempty"`
+	ServiceTier         *chatServiceTierWire      `json:"service_tier,omitempty"`
+	SystemFingerprint   *string                   `json:"system_fingerprint,omitempty"`
+	PromptLogprobs      *chatNullOnlyWire         `json:"prompt_logprobs,omitempty"`
+	PromptTokenIDs      []int64                   `json:"prompt_token_ids,omitempty"`
+	PromptText          *chatNullOnlyWire         `json:"prompt_text,omitempty"`
+	PromptRoutedExperts *chatNullOnlyWire         `json:"prompt_routed_experts,omitempty"`
+	KVTransferParams    *chatKVTransferParamsWire `json:"kv_transfer_params,omitempty"`
+	ECTransferParams    *chatNullOnlyWire         `json:"ec_transfer_params,omitempty"`
+	Metrics             *chatNullOnlyWire         `json:"metrics,omitempty"`
+	DoRemoteDecode      *bool                     `json:"do_remote_decode,omitempty"`
+	DoRemotePrefill     *bool                     `json:"do_remote_prefill,omitempty"`
+	RemoteBlockIDs      []int64                   `json:"remote_block_ids,omitempty"`
+	RemoteEngineID      *string                   `json:"remote_engine_id,omitempty"`
+	RemoteHost          *string                   `json:"remote_host,omitempty"`
+	RemotePort          *int64                    `json:"remote_port,omitempty"`
 }
 
 // hasLegacyKVTransferMetadata recognizes the flat KV-transfer response

--- a/src/semantic-router/pkg/protocolcodec/official_schema_inventory_test.go
+++ b/src/semantic-router/pkg/protocolcodec/official_schema_inventory_test.go
@@ -144,7 +144,7 @@ func TestOfficialResponseFieldInventoriesAreClosed(t *testing.T) {
 			),
 			extensions: fields(
 				"do_remote_decode", "do_remote_prefill", "ec_transfer_params", "error", "kv_transfer_params", "metrics",
-				"prompt_logprobs", "prompt_text", "prompt_token_ids", "remote_block_ids", "remote_engine_id",
+				"prompt_logprobs", "prompt_routed_experts", "prompt_text", "prompt_token_ids", "remote_block_ids", "remote_engine_id",
 				"remote_host", "remote_port",
 			),
 		},

--- a/src/semantic-router/pkg/protocolcodec/testdata/golden/capability/016-chat-official-response-fields-anthropic-out.json
+++ b/src/semantic-router/pkg/protocolcodec/testdata/golden/capability/016-chat-official-response-fields-anthropic-out.json
@@ -568,6 +568,47 @@
       }
     },
     {
+      "name": "prompt_routed_experts",
+      "outcome": {
+        "status": "ok",
+        "body": {
+          "container": null,
+          "content": [
+            {
+              "text": "done",
+              "type": "text"
+            }
+          ],
+          "id": "chatcmpl_1",
+          "model": "routed-model",
+          "role": "assistant",
+          "stop_details": null,
+          "stop_reason": "end_turn",
+          "stop_sequence": null,
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 0
+            },
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+            "inference_geo": "global",
+            "input_tokens": 2,
+            "output_tokens": 1,
+            "output_tokens_details": {
+              "thinking_tokens": 0
+            },
+            "server_tool_use": {
+              "web_fetch_requests": 0,
+              "web_search_requests": 0
+            },
+            "service_tier": "standard"
+          }
+        }
+      }
+    },
+    {
       "name": "prompt_text",
       "outcome": {
         "status": "ok",

--- a/src/semantic-router/pkg/protocolcodec/testdata/golden/capability/016-chat-official-response-fields-chat-out.json
+++ b/src/semantic-router/pkg/protocolcodec/testdata/golden/capability/016-chat-official-response-fields-chat-out.json
@@ -386,6 +386,33 @@
       }
     },
     {
+      "name": "prompt_routed_experts",
+      "outcome": {
+        "status": "ok",
+        "body": {
+          "choices": [
+            {
+              "finish_reason": "stop",
+              "index": 0,
+              "message": {
+                "content": "done",
+                "role": "assistant"
+              }
+            }
+          ],
+          "created": 100,
+          "id": "chatcmpl_1",
+          "model": "routed-model",
+          "object": "chat.completion",
+          "usage": {
+            "completion_tokens": 1,
+            "prompt_tokens": 2,
+            "total_tokens": 3
+          }
+        }
+      }
+    },
+    {
       "name": "prompt_text",
       "outcome": {
         "status": "ok",

--- a/src/semantic-router/pkg/protocolcodec/testdata/golden/capability/016-chat-official-response-fields-in.json
+++ b/src/semantic-router/pkg/protocolcodec/testdata/golden/capability/016-chat-official-response-fields-in.json
@@ -23,6 +23,7 @@
     {"name": "moderation", "patch": {"moderation": {"status": "passed"}}},
     {"name": "object", "patch": {"object": "chat.completion"}},
     {"name": "prompt_logprobs", "patch": {"prompt_logprobs": null}},
+    {"name": "prompt_routed_experts", "patch": {"prompt_routed_experts": null}},
     {"name": "prompt_text", "patch": {"prompt_text": null}},
     {"name": "prompt_token_ids", "patch": {"prompt_token_ids": [1, 2, 3]}},
     {"name": "remote_block_ids", "patch": {"remote_block_ids": [11, 12]}},

--- a/src/semantic-router/pkg/protocolcodec/testdata/golden/capability/016-chat-official-response-fields-responses-out.json
+++ b/src/semantic-router/pkg/protocolcodec/testdata/golden/capability/016-chat-official-response-fields-responses-out.json
@@ -685,6 +685,56 @@
       }
     },
     {
+      "name": "prompt_routed_experts",
+      "outcome": {
+        "status": "ok",
+        "body": {
+          "created_at": 100,
+          "error": null,
+          "id": "chatcmpl_1",
+          "incomplete_details": null,
+          "instructions": null,
+          "metadata": {},
+          "model": "routed-model",
+          "object": "response",
+          "output": [
+            {
+              "content": [
+                {
+                  "annotations": [],
+                  "text": "done",
+                  "type": "output_text"
+                }
+              ],
+              "id": "item_778767bae4047c000ddcae9a",
+              "role": "assistant",
+              "status": "completed",
+              "type": "message"
+            }
+          ],
+          "output_text": "done",
+          "parallel_tool_calls": true,
+          "status": "completed",
+          "temperature": null,
+          "tool_choice": "auto",
+          "tools": [],
+          "top_p": null,
+          "usage": {
+            "input_tokens": 2,
+            "input_tokens_details": {
+              "cache_write_tokens": 0,
+              "cached_tokens": 0
+            },
+            "output_tokens": 1,
+            "output_tokens_details": {
+              "reasoning_tokens": 0
+            },
+            "total_tokens": 3
+          }
+        }
+      }
+    },
+    {
       "name": "prompt_text",
       "outcome": {
         "status": "ok",

--- a/tools/mock-vllm/schema_contract.json
+++ b/tools/mock-vllm/schema_contract.json
@@ -110,6 +110,7 @@
         "kv_transfer_params",
         "metrics",
         "prompt_logprobs",
+        "prompt_routed_experts",
         "prompt_text",
         "prompt_token_ids",
         "remote_block_ids",


### PR DESCRIPTION
Closes #3708

## Summary

vLLM 0.21.0 adds top-level `prompt_routed_experts` (and per-choice
`routed_experts`) fields to non-streaming `/chat/completions` responses. The
canonical `chatResponseWire` has no matching top-level field, and
`llmprotocol.DefaultPolicy()` hardcodes `UnknownReject`, so a non-streaming chat
response from any vLLM 0.21.0 backend fails with `invalid_upstream_json:
upstream response JSON contains a non-canonical field` and the router returns
502.

This adds `prompt_routed_experts` as a null-only wire field (`*chatNullOnlyWire`,
same pattern as `prompt_text`/`routed_experts`), matching v0.21.0 semantics where
the field is unconditionally serialized but null for dense models. Streaming
chunks are unaffected.

Note: the top-level field was removed in v0.21.1rc0 and remains absent in
v0.22.0+; per-choice `routed_experts` is already covered by the existing
null-only field. So this is scoped to v0.21.0 backends.

## Changes

- `codec_openai_chat_response_wire.go`: add `PromptRoutedExperts *chatNullOnlyWire`
- Sync the four contract surfaces (repo rule for wire-field changes):
  - `official_schema_inventory_test.go` (extension field list)
  - golden matrix fixture `016-chat-official-response-fields-*.json` (in + 3 out)
  - `tools/mock-vllm/schema_contract.json` (extension_response_fields)

## Verification

- `go test ./pkg/protocolcodec/` green (incl. ability-matrix 016 cases and the
  three field-inventory "closed" tests that lock wire ↔ contract parity)
- `gofmt` clean, `go vet` clean
- End-to-end: real vLLM 0.21.0 engine (qwen3-4b) non-streaming chat via router
  returned HTTP 200 after the fix; 502 before.
