### PR TITLE
[Bug] Regenerate the config schema for the Fusion analysis mode field

### DIFF
--- a/src/semantic-router/pkg/configschema/router-config-v0.3.schema.json
+++ b/src/semantic-router/pkg/configschema/router-config-v0.3.schema.json
@@ -2447,6 +2447,9 @@
           },
           "type": "array"
         },
+        "analysis_mode": {
+          "type": "string"
+        },
         "analysis_overrides": {
           "items": {
             "$ref": "#/$defs/FusionModelOverride"


### PR DESCRIPTION
## Purpose

Related #3722

`FusionAlgorithmConfig` gained an `AnalysisMode` field, but the tracked schema
artifact was not regenerated, so `TestGeneratedArtifactsMatchGoSource` failed on
main and on every pull request whose run reached that test.

Running `go generate ./pkg/configschema` adds the `analysis_mode` property and
nothing else.

## Test Plan

`go test ./pkg/configschema/` in `src/semantic-router`, which is the test that
fails on main.

## Test Result

Passing. On main the same test reports `generated config schema is stale`.
`make check BASE_REF=origin/main` is green.
