### PR TITLE
[Test] Register llm/sequence classifier tests in the PR-lane CI test list

### DIFF
--- a/.github/workflows/integration-test-k8s.yml
+++ b/.github/workflows/integration-test-k8s.yml
@@ -87,7 +87,7 @@ jobs:
           set +e
           if [ "${{ matrix.profile }}" = "envoy-ai-gateway" ]; then
             # Temporarily skip the stress / pressure coverage until the suite is stable again.
-            ENVOY_AI_GATEWAY_CI_TESTS="chat-completions-request,apiserver-runtime-config-endpoints,domain-classify,semantic-cache,semantic-cache-polarity,pii-detection,pii-entity-offsets,pii-long-text,jailbreak-detection,security-long-text,decision-priority-selection,plugin-chain-execution,tool-selection,rule-condition-logic,decision-fallback-behavior,plugin-config-variations,event-routing,plugin-short-circuit-no-dispatch,language-routing,reask-routing"
+            ENVOY_AI_GATEWAY_CI_TESTS="chat-completions-request,apiserver-runtime-config-endpoints,domain-classify,semantic-cache,semantic-cache-polarity,pii-detection,pii-entity-offsets,pii-long-text,jailbreak-detection,security-long-text,decision-priority-selection,plugin-chain-execution,tool-selection,rule-condition-logic,decision-fallback-behavior,plugin-config-variations,event-routing,plugin-short-circuit-no-dispatch,language-routing,reask-routing,llm-classifier-distribution-routing,sequence-classifier-routing"
             make e2e-test E2E_PROFILE=${{ matrix.profile }} E2E_TESTS="${ENVOY_AI_GATEWAY_CI_TESTS}" E2E_VERBOSE=true E2E_KEEP_CLUSTER=false
             TEST_EXIT_CODE=$?
             set -e

--- a/e2e/testcases/signal_routing_contract_test.go
+++ b/e2e/testcases/signal_routing_contract_test.go
@@ -20,6 +20,8 @@ var signalRoutingContracts = []struct {
 	{profile: "envoy-ai-gateway", testCase: "event-routing"},
 	{profile: "envoy-ai-gateway", testCase: "language-routing"},
 	{profile: "envoy-ai-gateway", testCase: "reask-routing"},
+	{profile: "envoy-ai-gateway", testCase: "llm-classifier-distribution-routing"},
+	{profile: "envoy-ai-gateway", testCase: "sequence-classifier-routing"},
 }
 
 func TestProfilesSelectSignalRoutingContracts(t *testing.T) {


### PR DESCRIPTION
Related #3178

## Purpose

While scoping the `classifier` routing signal's e2e coverage for #3178,
found that `llm-classifier-distribution-routing` and
`sequence-classifier-routing` already have complete test coverage —
not new tests written in this PR:
- `e2e/profiles/ai-gateway/values.yaml`: `signals.classifiers`
  (`llm_toxicity`, `remote_toxicity`) and their decisions
  (`llm_classifier_toxic`, `sequence_classifier_toxic`)
- `e2e/profiles/ai-gateway/manifests/mock-sequence-classifier.yaml`:
  the deterministic mock server backing both backends
- `e2e/testcases/llm_classifier_distribution_routing.go` and
  `e2e/testcases/sequence_classifier_routing.go`: the test cases
  themselves
- `e2e/pkg/testmatrix/testcases.go`: both already listed in
  `BaselineRouterContract`

They were missing from the two remaining registration layers, so the
PR-lane CI job never actually executed them (`BaselineRouterContract`
membership alone doesn't run a test — the same three-layer-registration
lesson from #3399/#3507/#3653). This PR adds:
- A row each in `signal_routing_contract_test.go` (profile-selection
  regression guard)
- Both names in the hardcoded `ENVOY_AI_GATEWAY_CI_TESTS` override in
  `.github/workflows/integration-test-k8s.yml`

Local classifier backend coverage (the third `classifier` backend
type, currently untested) will land as a separate follow-up slice
under #3178.

Owning Workgroup: Evaluation & Quality (`wg/evaluation-quality`).

## Test Plan

- `gofmt -l e2e/testcases/signal_routing_contract_test.go`
- `go vet ./...` (run from `e2e/`)
- `go build ./...` (run from `e2e/`)
- `golangci-lint run ./pkg/testmatrix ./testcases` (run from `e2e/`, using `tools/linter/go/.golangci.yml`)
- `go test ./testcases/... -run TestProfilesSelectSignalRoutingContracts`

## Test Result

- gofmt / go vet / go build: pass.
- golangci-lint: 0 issues in the files this PR touches.
- `TestProfilesSelectSignalRoutingContracts`: pass, confirms the
  `envoy-ai-gateway` profile selects both `llm-classifier-distribution-routing`
  and `sequence-classifier-routing`.
- Deferring live confirmation that both tests now actually execute and
  pass to CI on this PR (this change only touches registration, not
  the pre-existing test logic itself).

---
AI assistance (Claude Code) was used to draft this change, under my review;
I read and understand the diff and take responsibility for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
