### PR TITLE
[Bug] Partition semantic cache by compatibility fingerprint

### DIFF
--- a/src/semantic-router/pkg/cache/contracts.go
+++ b/src/semantic-router/pkg/cache/contracts.go
@@ -64,6 +64,10 @@ type CacheIdentity struct {
 	SemanticQuery            string         `json:"-"`
 }
 
+func (i CacheIdentity) SemanticPartitionKey() string {
+	return joinPartitionParts(i.Partition.Key(), i.CompatibilityFingerprint)
+}
+
 type TTLPolicy struct {
 	UseDefault bool
 	NoStore    bool

--- a/src/semantic-router/pkg/cache/contracts.go
+++ b/src/semantic-router/pkg/cache/contracts.go
@@ -65,7 +65,7 @@ type CacheIdentity struct {
 }
 
 func (i CacheIdentity) SemanticPartitionKey() string {
-	return joinPartitionParts(i.Partition.Key(), i.CompatibilityFingerprint)
+	return CombineFingerprints("semantic", i.Partition.Key(), i.CompatibilityFingerprint)
 }
 
 type TTLPolicy struct {

--- a/src/semantic-router/pkg/cache/legacy_adapter.go
+++ b/src/semantic-router/pkg/cache/legacy_adapter.go
@@ -95,7 +95,7 @@ func (a *LegacyBackendAdapter) LookupSemantic(
 	}
 	result, err := a.backend.LookupSimilarWithThreshold(
 		ctx,
-		lookup.Identity.Partition.Key(),
+		lookup.Identity.SemanticPartitionKey(),
 		lookup.Identity.SemanticQuery,
 		lookup.Threshold,
 	)
@@ -129,7 +129,7 @@ func (a *LegacyBackendAdapter) StoreSemantic(ctx context.Context, write CacheWri
 	return a.backend.AddEntry(
 		ctx,
 		write.RequestID,
-		write.Identity.Partition.Key(),
+		write.Identity.SemanticPartitionKey(),
 		write.Identity.SemanticQuery,
 		write.RequestBody,
 		write.ResponseBody,

--- a/src/semantic-router/pkg/cache/legacy_adapter_fingerprint_test.go
+++ b/src/semantic-router/pkg/cache/legacy_adapter_fingerprint_test.go
@@ -1,0 +1,66 @@
+package cache
+
+import (
+	"context"
+	"testing"
+)
+
+type partitionRecordingBackend struct {
+	entries map[string][]byte
+}
+
+func (b *partitionRecordingBackend) IsEnabled() bool                       { return true }
+func (b *partitionRecordingBackend) CheckConnection(context.Context) error { return nil }
+func (b *partitionRecordingBackend) Close() error                          { return nil }
+func (b *partitionRecordingBackend) GetStats() CacheStats                  { return CacheStats{} }
+
+func (b *partitionRecordingBackend) AddEntry(
+	_ context.Context, _ string, model string, _ string, _, responseBody []byte, _ int,
+) error {
+	b.entries[model] = responseBody
+	return nil
+}
+
+func (b *partitionRecordingBackend) LookupSimilarWithThreshold(
+	_ context.Context, model string, _ string, _ float32,
+) (LookupResult, error) {
+	body, ok := b.entries[model]
+	return LookupResult{Found: ok, ResponseBody: body}, nil
+}
+
+func TestLegacyAdapterPartitionsSemanticEntriesByCompatibilityFingerprint(t *testing.T) {
+	backend := &partitionRecordingBackend{entries: make(map[string][]byte)}
+	adapter := NewLegacyBackendAdapter(backend, InMemoryCacheType)
+	identity := func(fingerprint string) CacheIdentity {
+		return CacheIdentity{
+			Partition:                CachePartition{RequestModel: "model"},
+			CompatibilityFingerprint: fingerprint,
+			SemanticQuery:            "what is the capital of france",
+		}
+	}
+	if err := adapter.StoreSemantic(context.Background(), CacheWrite{
+		Identity:     identity("system-a"),
+		ResponseBody: []byte("paris"),
+		TTL:          DefaultTTL(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	lookup := func(fingerprint string) bool {
+		result, err := adapter.LookupSemantic(context.Background(), SemanticLookup{
+			Identity: identity(fingerprint),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return result.Found
+	}
+	if !lookup("system-a") {
+		t.Fatal("same compatibility fingerprint must hit")
+	}
+	if lookup("system-b") {
+		t.Fatal("different compatibility fingerprint must miss")
+	}
+	if lookup("") {
+		t.Fatal("missing compatibility fingerprint must miss")
+	}
+}

--- a/src/semantic-router/pkg/cache/legacy_adapter_fingerprint_test.go
+++ b/src/semantic-router/pkg/cache/legacy_adapter_fingerprint_test.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"context"
+	"strings"
 	"testing"
 )
 
@@ -62,5 +63,19 @@ func TestLegacyAdapterPartitionsSemanticEntriesByCompatibilityFingerprint(t *tes
 	}
 	if lookup("") {
 		t.Fatal("missing compatibility fingerprint must miss")
+	}
+}
+
+func TestSemanticPartitionKeyStaysWithinMilvusFieldWidth(t *testing.T) {
+	identity := CacheIdentity{
+		Partition: CachePartition{
+			Recipe:    strings.Repeat("r", 200),
+			Decision:  strings.Repeat("d", 200),
+			Namespace: strings.Repeat("n", 200),
+		},
+		CompatibilityFingerprint: strings.Repeat("f", 64),
+	}
+	if got := len(identity.SemanticPartitionKey()); got != 64 {
+		t.Fatalf("semantic partition key length = %d, want 64", got)
 	}
 }

--- a/src/semantic-router/pkg/extproc/processor_res_cache_test.go
+++ b/src/semantic-router/pkg/extproc/processor_res_cache_test.go
@@ -175,7 +175,13 @@ func TestUpdateResponseCache_WritesExactEntryWithRequestIdentity(t *testing.T) {
 	assert.True(t, mockCache.addEntryCalled)
 	assert.False(t, mockCache.updateCalled)
 	assert.True(t, mockCache.exactAdded)
-	assert.Contains(t, mockCache.addEntryModel, "exact-cache-decision")
+	assert.Equal(
+		t,
+		router.responseCacheService().
+			ResolveIdentity(responseCacheIdentity(ctx, ctx.CacheRequestModel)).
+			SemanticPartitionKey(),
+		mockCache.addEntryModel,
+	)
 	assert.Equal(t, "hello", mockCache.addEntryQuery)
 }
 

--- a/src/semantic-router/pkg/extproc/req_filter_cache_scope_test.go
+++ b/src/semantic-router/pkg/extproc/req_filter_cache_scope_test.go
@@ -68,8 +68,11 @@ func TestHandleCaching_PartitionsNamedRecipeWithoutChangingSemanticQuery(t *test
 	resp, hit := router.handleCaching(ctx, "")
 	assert.Nil(t, resp)
 	assert.False(t, hit)
-	assert.Contains(t, mockCache.findSimilarModel, "privacy")
-	assert.Contains(t, mockCache.findSimilarModel, "MoM")
+	assert.Equal(
+		t,
+		router.responseCacheService().ResolveIdentity(ctx.CacheIdentity).SemanticPartitionKey(),
+		mockCache.findSimilarModel,
+	)
 	assert.Equal(t, "hello", ctx.CacheQuery, "recipe identity must not pollute the embedding input")
 }
 
@@ -252,8 +255,11 @@ func TestHandleCaching_HardPartitionsTenantSelectedModelAndCompatibility(t *test
 	assert.Nil(t, resp)
 	assert.False(t, hit)
 	assert.NotContains(t, mockCache.findSimilarModel, "alice")
-	assert.Contains(t, mockCache.findSimilarModel, "privacy")
-	assert.Contains(t, mockCache.findSimilarModel, "frontier")
+	assert.Equal(
+		t,
+		router.responseCacheService().ResolveIdentity(ctx.CacheIdentity).SemanticPartitionKey(),
+		mockCache.findSimilarModel,
+	)
 
 	alicePartition := mockCache.findSimilarModel
 	bobCtx := &RequestContext{


### PR DESCRIPTION
Closes #3423

## Purpose

- Semantic cache lookups and writes ignored `CompatibilityFingerprint`, so one system prompt's response served another.
- Partition semantic entries by the compatibility fingerprint in `pkg/cache`.

## Test Plan

- `go test ./pkg/cache/ -run 'TestLegacyAdapter|TestResponseCacheService'`

## Test Result

- Passed. The new test fails on `main` and passes with the fix.

