### PR TITLE
[Feature] Admit Writer / Palmyra (Palmyra X6, Palmyra X5) to the Model Card catalog

### DIFF
--- a/config/catalog/README.md
+++ b/config/catalog/README.md
@@ -115,7 +115,7 @@ without duplicating its intrinsic identity. Virtual recipes are materialized
 from packaged assets and keep their own evaluation directory.
 
 The built-in physical inventory is curated at the creator-company level. The
-current baseline contains 84 physical cards from 22 mainstream creators and
+current baseline contains 86 physical cards from 23 mainstream creators and
 five separately stored virtual cards. For each creator, prefer roughly the
 latest three generations or representative product lines over accumulating a
 shallow long tail of lesser-known creators. This policy is about Model Cards,
@@ -134,6 +134,13 @@ representatives, or a creator that falls below that depth. The policy
 is not emitted into runtime snapshots or exposed in user configuration; whether
 a candidate is mainstream and which recent lines are representative remains a
 review decision rather than a mechanical release-date ranking.
+A creator may carry a reviewed `min_representatives` below the default when it
+has fewer current, separately selectable product lines and the alternative
+would be reviving a retired or deprecated product. Thinking Machines Lab and
+Writer currently hold that two-representative exception: Writer's first-party
+catalog lists Palmyra X6 and Palmyra X5 as its only current lines, while
+Palmyra X4 is scheduled for deprecation on 2026-11-18 with a migration path to
+X5 and X6.
 
 ## User configuration boundary
 

--- a/config/catalog/manifest.yaml
+++ b/config/catalog/manifest.yaml
@@ -124,6 +124,11 @@ inventory:
         representative_models:
           - thinking-machines/inkling
           - thinking-machines/inkling-small
+      - publisher: Writer
+        min_representatives: 2
+        representative_models:
+          - writer/palmyra-x6
+          - writer/palmyra-x5
       - publisher: Xiaomi
         representative_models:
           - xiaomi/mimo-v2.5-pro

--- a/config/catalog/resources/benchmarks.yaml
+++ b/config/catalog/resources/benchmarks.yaml
@@ -632,6 +632,9 @@
     - id: prompt-loose
       display_name: Prompt-level loose accuracy
       description: Prompt-level loose accuracy on IFBench, with model-side reasoning and generation settings retained on the record.
+    - id: published-unspecified
+      display_name: Published setup unspecified
+      description: Vendor-published IFBench result whose accuracy level (prompt or instruction, loose or strict) is not stated by the source; kept separate from prompt-level loose records.
   metrics:
     - id: accuracy
       unit: proportion
@@ -744,6 +747,9 @@
     - id: published-standard
       display_name: Published standard
       description: Accuracy on MATH using the source-published evaluation setup.
+    - id: published-hard-subset
+      display_name: Published hard subset
+      description: Vendor-published result labeled MATH-Hard by the source; the hard-subset definition and harness are not stated by the source and it is never compared with full-set MATH records.
     - id: rmcb-eacl-2026-valid-output-test
       display_name: RMCB EACL 2026 valid-output test
       description: Accuracy over valid generated outputs in the EACL 2026 RMCB test protocol; filtering counts and generation settings remain on the evaluation record.
@@ -873,6 +879,9 @@
   source: https://github.com/suzgunmirac/BIG-Bench-Hard
   default_profile: rmcb-eacl-2026-valid-output-test
   profiles:
+    - id: published-standard
+      display_name: Published standard
+      description: Vendor-published BIG-Bench Hard accuracy; prompt format, shot count, and harness are retained on the evaluation record when the source states them.
     - id: rmcb-eacl-2026-valid-output-test
       display_name: RMCB EACL 2026 valid-output test
       description: Accuracy over valid generated outputs in the EACL 2026 RMCB test protocol; filtering counts and dataset revision remain on the evaluation record.
@@ -976,6 +985,117 @@
       description: Vendor-published AdvanceIF accuracy with the evaluated model variant retained on the record.
   metrics:
     - id: accuracy
+      unit: proportion
+      direction: higher_is_better
+      range: [0, 1]
+- id: idavidrein/gpqa@1.0.0
+  display_name: GPQA
+  domain: scientific_reasoning
+  source: https://arxiv.org/abs/2311.12022
+  default_profile: published-unspecified
+  profiles:
+    - id: published-unspecified
+      display_name: Published subset unspecified
+      description: Vendor-published GPQA accuracy whose subset (main, extended, or diamond) is not stated by the source; kept separate from GPQA Diamond records and excluded from the default index.
+  metrics:
+    - id: accuracy
+      unit: proportion
+      direction: higher_is_better
+      range: [0, 1]
+- id: openai/mrcr@1.0.0
+  display_name: OpenAI MRCR
+  domain: long_context
+  source: https://huggingface.co/datasets/openai/mrcr
+  default_profile: published-8-needle
+  profiles:
+    - id: published-8-needle
+      display_name: Published 8-needle
+      description: Vendor-published score on the 8-needle OpenAI MRCR task; the context-length bins covered are not stated by the source.
+  metrics:
+    - id: score
+      unit: proportion
+      direction: higher_is_better
+      range: [0, 1]
+- id: bigcode/bigcodebench@1.0.0
+  display_name: BigCodeBench
+  domain: software_engineering
+  source: https://bigcode-bench.github.io/
+  default_profile: published-full-instruct
+  profiles:
+    - id: published-full-instruct
+      display_name: Published Full Instruct
+      description: Vendor-published Pass@1 on the BigCodeBench Full split, Instruct variant; calibration and decoding settings are not stated by the source.
+  metrics:
+    - id: pass_at_1
+      unit: proportion
+      direction: higher_is_better
+      range: [0, 1]
+- id: unattributed/finance-agent@1.0.0
+  display_name: Finance Agent (owner and version unstated)
+  domain: financial_reasoning
+  default_profile: published-unspecified
+  profiles:
+    - id: published-unspecified
+      display_name: Published setup unspecified
+      description: Vendor-published result labeled only "Finance Agent" by the source; benchmark owner, version, and run setup are not stated, so it is never merged with Vals Finance Agent records.
+  metrics:
+    - id: score
+      unit: proportion
+      direction: higher_is_better
+      range: [0, 1]
+- id: afterquery/financeqa@1.0.0
+  display_name: FinanceQA
+  domain: financial_reasoning
+  source: https://huggingface.co/datasets/AfterQuery/FinanceQA
+  default_profile: published-unspecified
+  profiles:
+    - id: published-unspecified
+      display_name: Published setup unspecified
+      description: Vendor-published FinanceQA score; grader, prompt protocol, and dataset revision are not stated by the source.
+  metrics:
+    - id: score
+      unit: proportion
+      direction: higher_is_better
+      range: [0, 1]
+- id: patronusai/financebench@1.0.0
+  display_name: FinanceBench
+  domain: financial_reasoning
+  source: https://huggingface.co/datasets/PatronusAI/financebench
+  default_profile: published-unspecified
+  profiles:
+    - id: published-unspecified
+      display_name: Published setup unspecified
+      description: Vendor-published FinanceBench score; retrieval configuration, grader, and dataset revision are not stated by the source.
+  metrics:
+    - id: score
+      unit: proportion
+      direction: higher_is_better
+      range: [0, 1]
+- id: gorilla/bfcl-core@1.0.0
+  display_name: BFCL Core
+  domain: agentic_systems
+  source: https://gorilla.cs.berkeley.edu/leaderboard.html
+  default_profile: published-unspecified
+  profiles:
+    - id: published-unspecified
+      display_name: Published setup unspecified
+      description: Vendor-published score labeled "BFCL Core" by the source; the BFCL version and the category composition behind "Core" are not stated by the source and are not defined by the public leaderboard.
+  metrics:
+    - id: score
+      unit: proportion
+      direction: higher_is_better
+      range: [0, 1]
+- id: scale/mcp-atlas@1.0.0
+  display_name: MCP Atlas
+  domain: agentic_systems
+  source: https://labs.scale.com/leaderboard/mcp_atlas
+  default_profile: published-unspecified
+  profiles:
+    - id: published-unspecified
+      display_name: Published setup unspecified
+      description: Vendor-published MCP Atlas score; leaderboard revision, tool-call budget, and judge configuration are not stated by the source.
+  metrics:
+    - id: score
       unit: proportion
       direction: higher_is_better
       range: [0, 1]

--- a/config/catalog/resources/evaluations/single/writer.yaml
+++ b/config/catalog/resources/evaluations/single/writer.yaml
@@ -1,0 +1,298 @@
+- id: writer/palmyra-x6-model-catalog-finance-agent@1.0.0
+  model: writer/palmyra-x6
+  benchmark: unattributed/finance-agent@1.0.0
+  benchmark_profile: published-unspecified
+  reasoning_effort: unspecified
+  subject:
+    variant: Palmyra X6
+    source_model_slug: palmyra-x6
+    source_kind: official_model_card
+    source_label: Finance Agent
+    benchmark_revision: unspecified_by_source
+    harness: raw model, not WRITER Agent, per source
+    tool_policy: unspecified_by_source
+    context_length: unspecified_by_source
+    endpoint: unspecified_by_source
+  metrics:
+    score: 0.753
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://dev.writer.com/home/models
+    redistributable: true
+- id: writer/palmyra-x6-model-catalog-financeqa@1.0.0
+  model: writer/palmyra-x6
+  benchmark: afterquery/financeqa@1.0.0
+  benchmark_profile: published-unspecified
+  reasoning_effort: unspecified
+  subject:
+    variant: Palmyra X6
+    source_model_slug: palmyra-x6
+    source_kind: official_model_card
+    source_label: FinanceQA
+    benchmark_revision: unspecified_by_source
+    harness: raw model, not WRITER Agent, per source
+    tool_policy: unspecified_by_source
+    context_length: unspecified_by_source
+    endpoint: unspecified_by_source
+  metrics:
+    score: 0.673
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://dev.writer.com/home/models
+    redistributable: true
+- id: writer/palmyra-x6-model-catalog-financebench@1.0.0
+  model: writer/palmyra-x6
+  benchmark: patronusai/financebench@1.0.0
+  benchmark_profile: published-unspecified
+  reasoning_effort: unspecified
+  subject:
+    variant: Palmyra X6
+    source_model_slug: palmyra-x6
+    source_kind: official_model_card
+    source_label: FinanceBench
+    benchmark_revision: unspecified_by_source
+    harness: raw model, not WRITER Agent, per source
+    tool_policy: unspecified_by_source
+    context_length: unspecified_by_source
+    endpoint: unspecified_by_source
+  metrics:
+    score: 0.855
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://dev.writer.com/home/models
+    redistributable: true
+- id: writer/palmyra-x6-technical-report-bfcl-core@1.0.0
+  model: writer/palmyra-x6
+  benchmark: gorilla/bfcl-core@1.0.0
+  benchmark_profile: published-unspecified
+  reasoning_effort: unspecified
+  subject:
+    variant: Palmyra x6
+    source_model_slug: palmyra-x6
+    source_kind: official_technical_report
+    source_label: BFCL Core
+    source_document: arXiv:2608.16620v1
+    benchmark_revision: unspecified_by_source
+    harness: unspecified_by_source
+    tool_policy: unspecified_by_source
+    context_length: unspecified_by_source
+    endpoint: unspecified_by_source
+  metrics:
+    score: 0.785
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://arxiv.org/abs/2608.16620
+    redistributable: true
+- id: writer/palmyra-x6-technical-report-ifbench@1.0.0
+  model: writer/palmyra-x6
+  benchmark: allenai/ifbench@1.0.0
+  benchmark_profile: published-unspecified
+  reasoning_effort: unspecified
+  subject:
+    variant: Palmyra x6
+    source_model_slug: palmyra-x6
+    source_kind: official_technical_report
+    source_label: IFBench
+    source_document: arXiv:2608.16620v1
+    reported_in: Figure 2 bar label
+    benchmark_revision: unspecified_by_source
+    harness: unspecified_by_source
+    tool_policy: unspecified_by_source
+    context_length: unspecified_by_source
+    endpoint: unspecified_by_source
+  metrics:
+    accuracy: 0.737
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://arxiv.org/abs/2608.16620
+    redistributable: true
+- id: writer/palmyra-x6-technical-report-mcp-atlas@1.0.0
+  model: writer/palmyra-x6
+  benchmark: scale/mcp-atlas@1.0.0
+  benchmark_profile: published-unspecified
+  reasoning_effort: unspecified
+  subject:
+    variant: Palmyra x6
+    source_model_slug: palmyra-x6
+    source_kind: official_technical_report
+    source_label: MCP-Atlas
+    source_document: arXiv:2608.16620v1
+    reported_in: Figure 2 bar label
+    benchmark_revision: unspecified_by_source
+    harness: unspecified_by_source
+    tool_policy: unspecified_by_source
+    context_length: unspecified_by_source
+    endpoint: unspecified_by_source
+  metrics:
+    score: 0.771
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://arxiv.org/abs/2608.16620
+    redistributable: true
+- id: writer/palmyra-x5-model-catalog-mmlu-pro@1.0.0
+  model: writer/palmyra-x5
+  benchmark: tiger-ai-lab/mmlu-pro@1.0.0
+  benchmark_profile: published-standard
+  reasoning_effort: unspecified
+  subject:
+    variant: Palmyra X5
+    source_model_slug: palmyra-x5
+    source_kind: official_model_card
+    source_label: MMLU_PRO
+    benchmark_revision: unspecified_by_source
+    harness: unspecified_by_source
+    tool_policy: unspecified_by_source
+    context_length: unspecified_by_source
+    endpoint: unspecified_by_source
+  metrics:
+    accuracy: 0.6502
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://dev.writer.com/home/models
+    redistributable: true
+- id: writer/palmyra-x5-model-catalog-gpqa@1.0.0
+  model: writer/palmyra-x5
+  benchmark: idavidrein/gpqa@1.0.0
+  benchmark_profile: published-unspecified
+  reasoning_effort: unspecified
+  subject:
+    variant: Palmyra X5
+    source_model_slug: palmyra-x5
+    source_kind: official_model_card
+    source_label: GPQA
+    dataset_subset: unspecified_by_source
+    benchmark_revision: unspecified_by_source
+    harness: unspecified_by_source
+    tool_policy: unspecified_by_source
+    context_length: unspecified_by_source
+    endpoint: unspecified_by_source
+  metrics:
+    accuracy: 0.472
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://dev.writer.com/home/models
+    redistributable: true
+- id: writer/palmyra-x5-model-catalog-bbh@1.0.0
+  model: writer/palmyra-x5
+  benchmark: maveriq/bigbenchhard@1.0.0
+  benchmark_profile: published-standard
+  reasoning_effort: unspecified
+  subject:
+    variant: Palmyra X5
+    source_model_slug: palmyra-x5
+    source_kind: official_model_card
+    source_label: BBH (Big-Bench Hard)
+    benchmark_revision: unspecified_by_source
+    harness: unspecified_by_source
+    tool_policy: unspecified_by_source
+    context_length: unspecified_by_source
+    endpoint: unspecified_by_source
+  metrics:
+    accuracy: 0.7099
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://dev.writer.com/home/models
+    redistributable: true
+- id: writer/palmyra-x5-model-catalog-math-hard@1.0.0
+  model: writer/palmyra-x5
+  benchmark: hendrycks/math@1.0.0
+  benchmark_profile: published-hard-subset
+  reasoning_effort: unspecified
+  subject:
+    variant: Palmyra X5
+    source_model_slug: palmyra-x5
+    source_kind: official_model_card
+    source_label: MATH_HARD
+    dataset_subset: hard subset as labeled by source, definition unspecified_by_source
+    benchmark_revision: unspecified_by_source
+    harness: unspecified_by_source
+    tool_policy: unspecified_by_source
+    context_length: unspecified_by_source
+    endpoint: unspecified_by_source
+  metrics:
+    accuracy: 0.7157
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://dev.writer.com/home/models
+    redistributable: true
+- id: writer/palmyra-x5-launch-openai-mrcr-8-needle@1.0.0
+  model: writer/palmyra-x5
+  benchmark: openai/mrcr@1.0.0
+  benchmark_profile: published-8-needle
+  reasoning_effort: unspecified
+  subject:
+    variant: Palmyra X5
+    source_model_slug: palmyra-x5
+    source_kind: official_launch_evaluation
+    source_label: OpenAI MRCR 8-needle
+    needles: 8
+    benchmark_revision: unspecified_by_source
+    harness: unspecified_by_source
+    tool_policy: unspecified_by_source
+    context_length: unspecified_by_source
+    endpoint: unspecified_by_source
+  metrics:
+    score: 0.191
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://writer.com/blog/long-context-palmyra-x5/
+    redistributable: true
+- id: writer/palmyra-x5-launch-bigcodebench-full-instruct@1.0.0
+  model: writer/palmyra-x5
+  benchmark: bigcode/bigcodebench@1.0.0
+  benchmark_profile: published-full-instruct
+  reasoning_effort: unspecified
+  subject:
+    variant: Palmyra X5
+    source_model_slug: palmyra-x5
+    source_kind: official_launch_evaluation
+    source_label: BigCodeBench (Full, Instruct)
+    dataset_split: full
+    dataset_variant: instruct
+    benchmark_revision: unspecified_by_source
+    harness: unspecified_by_source
+    tool_policy: unspecified_by_source
+    context_length: unspecified_by_source
+    endpoint: unspecified_by_source
+  metrics:
+    pass_at_1: 0.487
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://writer.com/blog/long-context-palmyra-x5/
+    redistributable: true

--- a/config/catalog/resources/models/single/writer.yaml
+++ b/config/catalog/resources/models/single/writer.yaml
@@ -1,0 +1,76 @@
+- id: writer/palmyra-x6
+  display_name: Palmyra X6
+  description: Writer's flagship agentic Palmyra model for long-horizon enterprise workflows, sub-agents, and MCP tool use.
+  kind: physical
+  publisher: Writer
+  presentation:
+    logo: monogram
+    monogram: W
+    monochrome: true
+  distribution:
+    type: proprietary_api
+    source: https://dev.writer.com/home/models
+  family: palmyra-x6
+  lifecycle: active
+  limits:
+    context_window_size: 1000000
+    max_output_tokens: 8192
+  capabilities:
+  - chat
+  - tools
+  - structured_output
+  - long_context
+  modalities:
+    input:
+    - text
+    output:
+    - text
+  verification:
+    authority: Writer
+    status: claimed
+    verified_at: 2026-09-11
+    source: https://dev.writer.com/home/models
+  tags:
+  - proprietary
+  - agentic
+  - enterprise
+  released_at: '2026-08-13'
+- id: writer/palmyra-x5
+  display_name: Palmyra X5
+  description: Writer's general-purpose Palmyra model with a 1M token context window, adaptive reasoning, and vision input.
+  kind: physical
+  publisher: Writer
+  presentation:
+    logo: monogram
+    monogram: W
+    monochrome: true
+  distribution:
+    type: proprietary_api
+    source: https://dev.writer.com/home/models
+  family: palmyra-x5
+  lifecycle: active
+  limits:
+    context_window_size: 1000000
+    max_output_tokens: 8192
+  capabilities:
+  - chat
+  - tools
+  - structured_output
+  - vision
+  - long_context
+  modalities:
+    input:
+    - text
+    - image
+    output:
+    - text
+  verification:
+    authority: Writer
+    status: claimed
+    verified_at: 2026-09-11
+    source: https://dev.writer.com/home/models
+  tags:
+  - proprietary
+  - multimodal
+  - enterprise
+  released_at: '2025-04-28'

--- a/config/catalog/resources/providers/writer.yaml
+++ b/config/catalog/resources/providers/writer.yaml
@@ -21,4 +21,32 @@ presentation:
   monochrome: true
 conformance:
   status: unverified
-models: []
+models:
+- catalog: writer/palmyra-x6
+  relationship: first_party
+  id: palmyra-x6
+  protocols:
+  - openai/chat-completions@1
+  pricing:
+    currency: USD
+    prompt_per_1m: 2.0
+    completion_per_1m: 8.0
+  lifecycle: active
+  verification:
+    status: claimed
+    verified_at: 2026-09-11
+    source: https://dev.writer.com/home/models
+- catalog: writer/palmyra-x5
+  relationship: first_party
+  id: palmyra-x5
+  protocols:
+  - openai/chat-completions@1
+  pricing:
+    currency: USD
+    prompt_per_1m: 0.6
+    completion_per_1m: 6.0
+  lifecycle: active
+  verification:
+    status: claimed
+    verified_at: 2026-09-11
+    source: https://dev.writer.com/home/models

--- a/config/recipes/built-in/latest/catalog.yaml
+++ b/config/recipes/built-in/latest/catalog.yaml
@@ -3510,7 +3510,35 @@ providers:
     monochrome: true
   conformance:
     status: unverified
-  models: []
+  models:
+  - catalog: writer/palmyra-x6
+    relationship: first_party
+    id: palmyra-x6
+    protocols:
+    - openai/chat-completions@1
+    pricing:
+      currency: USD
+      prompt_per_1m: 2.0
+      completion_per_1m: 8.0
+    lifecycle: active
+    verification:
+      status: claimed
+      verified_at: '2026-09-11'
+      source: https://dev.writer.com/home/models
+  - catalog: writer/palmyra-x5
+    relationship: first_party
+    id: palmyra-x5
+    protocols:
+    - openai/chat-completions@1
+    pricing:
+      currency: USD
+      prompt_per_1m: 0.6
+      completion_per_1m: 6.0
+    lifecycle: active
+    verification:
+      status: claimed
+      verified_at: '2026-09-11'
+      source: https://dev.writer.com/home/models
 - id: xai
   display_name: xAI
   description: Grok models through an OpenAI-style API.
@@ -7762,6 +7790,82 @@ models:
   - moe
   - agentic
   - efficient
+- id: writer/palmyra-x6
+  display_name: Palmyra X6
+  description: Writer's flagship agentic Palmyra model for long-horizon enterprise workflows, sub-agents, and MCP tool use.
+  kind: physical
+  publisher: Writer
+  presentation:
+    logo: monogram
+    monogram: W
+    monochrome: true
+  distribution:
+    type: proprietary_api
+    source: https://dev.writer.com/home/models
+  family: palmyra-x6
+  lifecycle: active
+  limits:
+    context_window_size: 1000000
+    max_output_tokens: 8192
+  capabilities:
+  - chat
+  - tools
+  - structured_output
+  - long_context
+  modalities:
+    input:
+    - text
+    output:
+    - text
+  verification:
+    authority: Writer
+    status: claimed
+    verified_at: '2026-09-11'
+    source: https://dev.writer.com/home/models
+  tags:
+  - proprietary
+  - agentic
+  - enterprise
+  released_at: '2026-08-13'
+- id: writer/palmyra-x5
+  display_name: Palmyra X5
+  description: Writer's general-purpose Palmyra model with a 1M token context window, adaptive reasoning, and vision input.
+  kind: physical
+  publisher: Writer
+  presentation:
+    logo: monogram
+    monogram: W
+    monochrome: true
+  distribution:
+    type: proprietary_api
+    source: https://dev.writer.com/home/models
+  family: palmyra-x5
+  lifecycle: active
+  limits:
+    context_window_size: 1000000
+    max_output_tokens: 8192
+  capabilities:
+  - chat
+  - tools
+  - structured_output
+  - vision
+  - long_context
+  modalities:
+    input:
+    - text
+    - image
+    output:
+    - text
+  verification:
+    authority: Writer
+    status: claimed
+    verified_at: '2026-09-11'
+    source: https://dev.writer.com/home/models
+  tags:
+  - proprietary
+  - multimodal
+  - enterprise
+  released_at: '2025-04-28'
 - id: xai/grok-4.6
   display_name: Grok 4.6
   description: xAI frontier reasoning model with image input and tool support.
@@ -9341,6 +9445,10 @@ benchmarks:
     display_name: Prompt-level loose accuracy
     description: Prompt-level loose accuracy on IFBench, with model-side reasoning and generation settings retained on the
       record.
+  - id: published-unspecified
+    display_name: Published setup unspecified
+    description: Vendor-published IFBench result whose accuracy level (prompt or instruction, loose or strict) is not stated
+      by the source; kept separate from prompt-level loose records.
   metrics:
   - id: accuracy
     unit: proportion
@@ -9469,6 +9577,10 @@ benchmarks:
   - id: published-standard
     display_name: Published standard
     description: Accuracy on MATH using the source-published evaluation setup.
+  - id: published-hard-subset
+    display_name: Published hard subset
+    description: Vendor-published result labeled MATH-Hard by the source; the hard-subset definition and harness are not stated
+      by the source and it is never compared with full-set MATH records.
   - id: rmcb-eacl-2026-valid-output-test
     display_name: RMCB EACL 2026 valid-output test
     description: Accuracy over valid generated outputs in the EACL 2026 RMCB test protocol; filtering counts and generation
@@ -9622,6 +9734,10 @@ benchmarks:
   source: https://github.com/suzgunmirac/BIG-Bench-Hard
   default_profile: rmcb-eacl-2026-valid-output-test
   profiles:
+  - id: published-standard
+    display_name: Published standard
+    description: Vendor-published BIG-Bench Hard accuracy; prompt format, shot count, and harness are retained on the evaluation
+      record when the source states them.
   - id: rmcb-eacl-2026-valid-output-test
     display_name: RMCB EACL 2026 valid-output test
     description: Accuracy over valid generated outputs in the EACL 2026 RMCB test protocol; filtering counts and dataset revision
@@ -9740,6 +9856,140 @@ benchmarks:
     description: Vendor-published AdvanceIF accuracy with the evaluated model variant retained on the record.
   metrics:
   - id: accuracy
+    unit: proportion
+    direction: higher_is_better
+    range:
+    - 0
+    - 1
+- id: idavidrein/gpqa@1.0.0
+  display_name: GPQA
+  domain: scientific_reasoning
+  source: https://arxiv.org/abs/2311.12022
+  default_profile: published-unspecified
+  profiles:
+  - id: published-unspecified
+    display_name: Published subset unspecified
+    description: Vendor-published GPQA accuracy whose subset (main, extended, or diamond) is not stated by the source; kept
+      separate from GPQA Diamond records and excluded from the default index.
+  metrics:
+  - id: accuracy
+    unit: proportion
+    direction: higher_is_better
+    range:
+    - 0
+    - 1
+- id: openai/mrcr@1.0.0
+  display_name: OpenAI MRCR
+  domain: long_context
+  source: https://huggingface.co/datasets/openai/mrcr
+  default_profile: published-8-needle
+  profiles:
+  - id: published-8-needle
+    display_name: Published 8-needle
+    description: Vendor-published score on the 8-needle OpenAI MRCR task; the context-length bins covered are not stated by
+      the source.
+  metrics:
+  - id: score
+    unit: proportion
+    direction: higher_is_better
+    range:
+    - 0
+    - 1
+- id: bigcode/bigcodebench@1.0.0
+  display_name: BigCodeBench
+  domain: software_engineering
+  source: https://bigcode-bench.github.io/
+  default_profile: published-full-instruct
+  profiles:
+  - id: published-full-instruct
+    display_name: Published Full Instruct
+    description: Vendor-published Pass@1 on the BigCodeBench Full split, Instruct variant; calibration and decoding settings
+      are not stated by the source.
+  metrics:
+  - id: pass_at_1
+    unit: proportion
+    direction: higher_is_better
+    range:
+    - 0
+    - 1
+- id: unattributed/finance-agent@1.0.0
+  display_name: Finance Agent (owner and version unstated)
+  domain: financial_reasoning
+  default_profile: published-unspecified
+  profiles:
+  - id: published-unspecified
+    display_name: Published setup unspecified
+    description: Vendor-published result labeled only "Finance Agent" by the source; benchmark owner, version, and run setup
+      are not stated, so it is never merged with Vals Finance Agent records.
+  metrics:
+  - id: score
+    unit: proportion
+    direction: higher_is_better
+    range:
+    - 0
+    - 1
+- id: afterquery/financeqa@1.0.0
+  display_name: FinanceQA
+  domain: financial_reasoning
+  source: https://huggingface.co/datasets/AfterQuery/FinanceQA
+  default_profile: published-unspecified
+  profiles:
+  - id: published-unspecified
+    display_name: Published setup unspecified
+    description: Vendor-published FinanceQA score; grader, prompt protocol, and dataset revision are not stated by the source.
+  metrics:
+  - id: score
+    unit: proportion
+    direction: higher_is_better
+    range:
+    - 0
+    - 1
+- id: patronusai/financebench@1.0.0
+  display_name: FinanceBench
+  domain: financial_reasoning
+  source: https://huggingface.co/datasets/PatronusAI/financebench
+  default_profile: published-unspecified
+  profiles:
+  - id: published-unspecified
+    display_name: Published setup unspecified
+    description: Vendor-published FinanceBench score; retrieval configuration, grader, and dataset revision are not stated
+      by the source.
+  metrics:
+  - id: score
+    unit: proportion
+    direction: higher_is_better
+    range:
+    - 0
+    - 1
+- id: gorilla/bfcl-core@1.0.0
+  display_name: BFCL Core
+  domain: agentic_systems
+  source: https://gorilla.cs.berkeley.edu/leaderboard.html
+  default_profile: published-unspecified
+  profiles:
+  - id: published-unspecified
+    display_name: Published setup unspecified
+    description: Vendor-published score labeled "BFCL Core" by the source; the BFCL version and the category composition behind
+      "Core" are not stated by the source and are not defined by the public leaderboard.
+  metrics:
+  - id: score
+    unit: proportion
+    direction: higher_is_better
+    range:
+    - 0
+    - 1
+- id: scale/mcp-atlas@1.0.0
+  display_name: MCP Atlas
+  domain: agentic_systems
+  source: https://labs.scale.com/leaderboard/mcp_atlas
+  default_profile: published-unspecified
+  profiles:
+  - id: published-unspecified
+    display_name: Published setup unspecified
+    description: Vendor-published MCP Atlas score; leaderboard revision, tool-call budget, and judge configuration are not
+      stated by the source.
+  metrics:
+  - id: score
     unit: proportion
     direction: higher_is_better
     range:
@@ -34083,6 +34333,304 @@ evaluations:
     verification: imported
     source: https://benchmarks.duellab.org/model-thinkingmachines-inkling-small
     redistributable: true
+- id: writer/palmyra-x6-model-catalog-finance-agent@1.0.0
+  model: writer/palmyra-x6
+  benchmark: unattributed/finance-agent@1.0.0
+  benchmark_profile: published-unspecified
+  reasoning_effort: unspecified
+  subject:
+    variant: Palmyra X6
+    source_model_slug: palmyra-x6
+    source_kind: official_model_card
+    source_label: Finance Agent
+    benchmark_revision: unspecified_by_source
+    harness: raw model, not WRITER Agent, per source
+    tool_policy: unspecified_by_source
+    context_length: unspecified_by_source
+    endpoint: unspecified_by_source
+  metrics:
+    score: 0.753
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://dev.writer.com/home/models
+    redistributable: true
+- id: writer/palmyra-x6-model-catalog-financeqa@1.0.0
+  model: writer/palmyra-x6
+  benchmark: afterquery/financeqa@1.0.0
+  benchmark_profile: published-unspecified
+  reasoning_effort: unspecified
+  subject:
+    variant: Palmyra X6
+    source_model_slug: palmyra-x6
+    source_kind: official_model_card
+    source_label: FinanceQA
+    benchmark_revision: unspecified_by_source
+    harness: raw model, not WRITER Agent, per source
+    tool_policy: unspecified_by_source
+    context_length: unspecified_by_source
+    endpoint: unspecified_by_source
+  metrics:
+    score: 0.673
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://dev.writer.com/home/models
+    redistributable: true
+- id: writer/palmyra-x6-model-catalog-financebench@1.0.0
+  model: writer/palmyra-x6
+  benchmark: patronusai/financebench@1.0.0
+  benchmark_profile: published-unspecified
+  reasoning_effort: unspecified
+  subject:
+    variant: Palmyra X6
+    source_model_slug: palmyra-x6
+    source_kind: official_model_card
+    source_label: FinanceBench
+    benchmark_revision: unspecified_by_source
+    harness: raw model, not WRITER Agent, per source
+    tool_policy: unspecified_by_source
+    context_length: unspecified_by_source
+    endpoint: unspecified_by_source
+  metrics:
+    score: 0.855
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://dev.writer.com/home/models
+    redistributable: true
+- id: writer/palmyra-x6-technical-report-bfcl-core@1.0.0
+  model: writer/palmyra-x6
+  benchmark: gorilla/bfcl-core@1.0.0
+  benchmark_profile: published-unspecified
+  reasoning_effort: unspecified
+  subject:
+    variant: Palmyra x6
+    source_model_slug: palmyra-x6
+    source_kind: official_technical_report
+    source_label: BFCL Core
+    source_document: arXiv:2608.16620v1
+    benchmark_revision: unspecified_by_source
+    harness: unspecified_by_source
+    tool_policy: unspecified_by_source
+    context_length: unspecified_by_source
+    endpoint: unspecified_by_source
+  metrics:
+    score: 0.785
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://arxiv.org/abs/2608.16620
+    redistributable: true
+- id: writer/palmyra-x6-technical-report-ifbench@1.0.0
+  model: writer/palmyra-x6
+  benchmark: allenai/ifbench@1.0.0
+  benchmark_profile: published-unspecified
+  reasoning_effort: unspecified
+  subject:
+    variant: Palmyra x6
+    source_model_slug: palmyra-x6
+    source_kind: official_technical_report
+    source_label: IFBench
+    source_document: arXiv:2608.16620v1
+    reported_in: Figure 2 bar label
+    benchmark_revision: unspecified_by_source
+    harness: unspecified_by_source
+    tool_policy: unspecified_by_source
+    context_length: unspecified_by_source
+    endpoint: unspecified_by_source
+  metrics:
+    accuracy: 0.737
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://arxiv.org/abs/2608.16620
+    redistributable: true
+- id: writer/palmyra-x6-technical-report-mcp-atlas@1.0.0
+  model: writer/palmyra-x6
+  benchmark: scale/mcp-atlas@1.0.0
+  benchmark_profile: published-unspecified
+  reasoning_effort: unspecified
+  subject:
+    variant: Palmyra x6
+    source_model_slug: palmyra-x6
+    source_kind: official_technical_report
+    source_label: MCP-Atlas
+    source_document: arXiv:2608.16620v1
+    reported_in: Figure 2 bar label
+    benchmark_revision: unspecified_by_source
+    harness: unspecified_by_source
+    tool_policy: unspecified_by_source
+    context_length: unspecified_by_source
+    endpoint: unspecified_by_source
+  metrics:
+    score: 0.771
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://arxiv.org/abs/2608.16620
+    redistributable: true
+- id: writer/palmyra-x5-model-catalog-mmlu-pro@1.0.0
+  model: writer/palmyra-x5
+  benchmark: tiger-ai-lab/mmlu-pro@1.0.0
+  benchmark_profile: published-standard
+  reasoning_effort: unspecified
+  subject:
+    variant: Palmyra X5
+    source_model_slug: palmyra-x5
+    source_kind: official_model_card
+    source_label: MMLU_PRO
+    benchmark_revision: unspecified_by_source
+    harness: unspecified_by_source
+    tool_policy: unspecified_by_source
+    context_length: unspecified_by_source
+    endpoint: unspecified_by_source
+  metrics:
+    accuracy: 0.6502
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://dev.writer.com/home/models
+    redistributable: true
+- id: writer/palmyra-x5-model-catalog-gpqa@1.0.0
+  model: writer/palmyra-x5
+  benchmark: idavidrein/gpqa@1.0.0
+  benchmark_profile: published-unspecified
+  reasoning_effort: unspecified
+  subject:
+    variant: Palmyra X5
+    source_model_slug: palmyra-x5
+    source_kind: official_model_card
+    source_label: GPQA
+    dataset_subset: unspecified_by_source
+    benchmark_revision: unspecified_by_source
+    harness: unspecified_by_source
+    tool_policy: unspecified_by_source
+    context_length: unspecified_by_source
+    endpoint: unspecified_by_source
+  metrics:
+    accuracy: 0.472
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://dev.writer.com/home/models
+    redistributable: true
+- id: writer/palmyra-x5-model-catalog-bbh@1.0.0
+  model: writer/palmyra-x5
+  benchmark: maveriq/bigbenchhard@1.0.0
+  benchmark_profile: published-standard
+  reasoning_effort: unspecified
+  subject:
+    variant: Palmyra X5
+    source_model_slug: palmyra-x5
+    source_kind: official_model_card
+    source_label: BBH (Big-Bench Hard)
+    benchmark_revision: unspecified_by_source
+    harness: unspecified_by_source
+    tool_policy: unspecified_by_source
+    context_length: unspecified_by_source
+    endpoint: unspecified_by_source
+  metrics:
+    accuracy: 0.7099
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://dev.writer.com/home/models
+    redistributable: true
+- id: writer/palmyra-x5-model-catalog-math-hard@1.0.0
+  model: writer/palmyra-x5
+  benchmark: hendrycks/math@1.0.0
+  benchmark_profile: published-hard-subset
+  reasoning_effort: unspecified
+  subject:
+    variant: Palmyra X5
+    source_model_slug: palmyra-x5
+    source_kind: official_model_card
+    source_label: MATH_HARD
+    dataset_subset: hard subset as labeled by source, definition unspecified_by_source
+    benchmark_revision: unspecified_by_source
+    harness: unspecified_by_source
+    tool_policy: unspecified_by_source
+    context_length: unspecified_by_source
+    endpoint: unspecified_by_source
+  metrics:
+    accuracy: 0.7157
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://dev.writer.com/home/models
+    redistributable: true
+- id: writer/palmyra-x5-launch-openai-mrcr-8-needle@1.0.0
+  model: writer/palmyra-x5
+  benchmark: openai/mrcr@1.0.0
+  benchmark_profile: published-8-needle
+  reasoning_effort: unspecified
+  subject:
+    variant: Palmyra X5
+    source_model_slug: palmyra-x5
+    source_kind: official_launch_evaluation
+    source_label: OpenAI MRCR 8-needle
+    needles: 8
+    benchmark_revision: unspecified_by_source
+    harness: unspecified_by_source
+    tool_policy: unspecified_by_source
+    context_length: unspecified_by_source
+    endpoint: unspecified_by_source
+  metrics:
+    score: 0.191
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://writer.com/blog/long-context-palmyra-x5/
+    redistributable: true
+- id: writer/palmyra-x5-launch-bigcodebench-full-instruct@1.0.0
+  model: writer/palmyra-x5
+  benchmark: bigcode/bigcodebench@1.0.0
+  benchmark_profile: published-full-instruct
+  reasoning_effort: unspecified
+  subject:
+    variant: Palmyra X5
+    source_model_slug: palmyra-x5
+    source_kind: official_launch_evaluation
+    source_label: BigCodeBench (Full, Instruct)
+    dataset_split: full
+    dataset_variant: instruct
+    benchmark_revision: unspecified_by_source
+    harness: unspecified_by_source
+    tool_policy: unspecified_by_source
+    context_length: unspecified_by_source
+    endpoint: unspecified_by_source
+  metrics:
+    pass_at_1: 0.487
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://writer.com/blog/long-context-palmyra-x5/
+    redistributable: true
 - id: independent/grok-4-3-non-reasoning-critpt@1.0.0
   model: xai/grok-4.3
   benchmark: artificial-analysis/critpt@1.0.0
@@ -47207,6 +47755,28 @@ index_results:
   - thinking-machines/inkling-small-model-card-terminal-bench@1.0.0
   domains:
     agentic_systems: 64.7
+- model: writer/palmyra-x5
+  reasoning_effort: unspecified
+  index: vllm-sr/general@1.0.0
+  status: available
+  score: 65.02
+  coverage: 1.0
+  components:
+  - weight: 1.0
+    status: available
+    value: 0.6502
+    normalized: 0.6502
+    benchmark: tiger-ai-lab/mmlu-pro@1.0.0
+    metric: accuracy
+    benchmark_profiles:
+    - independent-standard
+    - published-standard
+    evaluation: writer/palmyra-x5-model-catalog-mmlu-pro@1.0.0
+    benchmark_profile: published-standard
+  provenance:
+  - writer/palmyra-x5-model-catalog-mmlu-pro@1.0.0
+  domains:
+    general_reasoning: 65.02
 - model: xai/grok-4.6
   reasoning_effort: low
   index: vllm-sr/reasoning@1.0.0

--- a/dashboard/backend/handlers/model_catalog_test.go
+++ b/dashboard/backend/handlers/model_catalog_test.go
@@ -451,7 +451,7 @@ func TestGeneratedPublicModelCatalogSatisfiesDashboardContract(t *testing.T) {
 	if unmarshalErr := json.Unmarshal(normalized, &document); unmarshalErr != nil {
 		t.Fatalf("decode normalized public catalog: %v", unmarshalErr)
 	}
-	if len(document.Models) != 101 || len(document.Providers) != 61 || len(document.Evaluations) != 1509 {
+	if len(document.Models) != 103 || len(document.Providers) != 61 || len(document.Evaluations) != 1521 {
 		t.Fatalf(
 			"unexpected generated inventory: models=%d providers=%d evaluations=%d; "+
 				"regenerate the catalog, or update these counts if the change is intended",

--- a/src/semantic-router/pkg/catalog/zz_generated_catalog.go
+++ b/src/semantic-router/pkg/catalog/zz_generated_catalog.go
@@ -2,7 +2,7 @@
 
 package catalog
 
-const builtInCatalogDigest = "sha256:2a3a1ae9f6a1897dffa998105d74ad37d8b006268077d231277dd1e7728ef22f"
+const builtInCatalogDigest = "sha256:57c06e0eb0aa7730c46cbf9e2bf48fe7883d8aeefe117772cb2f80ac1f48577d"
 
 const builtInCatalogJSON = `{
   "benchmarks": [
@@ -1183,6 +1183,11 @@ const builtInCatalogJSON = `{
           "description": "Prompt-level loose accuracy on IFBench, with model-side reasoning and generation settings retained on the record.",
           "display_name": "Prompt-level loose accuracy",
           "id": "prompt-loose"
+        },
+        {
+          "description": "Vendor-published IFBench result whose accuracy level (prompt or instruction, loose or strict) is not stated by the source; kept separate from prompt-level loose records.",
+          "display_name": "Published setup unspecified",
+          "id": "published-unspecified"
         }
       ],
       "source": "https://github.com/allenai/IFBench"
@@ -1383,6 +1388,11 @@ const builtInCatalogJSON = `{
           "description": "Accuracy on MATH using the source-published evaluation setup.",
           "display_name": "Published standard",
           "id": "published-standard"
+        },
+        {
+          "description": "Vendor-published result labeled MATH-Hard by the source; the hard-subset definition and harness are not stated by the source and it is never compared with full-set MATH records.",
+          "display_name": "Published hard subset",
+          "id": "published-hard-subset"
         },
         {
           "description": "Accuracy over valid generated outputs in the EACL 2026 RMCB test protocol; filtering counts and generation settings remain on the evaluation record.",
@@ -1615,6 +1625,11 @@ const builtInCatalogJSON = `{
       ],
       "profiles": [
         {
+          "description": "Vendor-published BIG-Bench Hard accuracy; prompt format, shot count, and harness are retained on the evaluation record when the source states them.",
+          "display_name": "Published standard",
+          "id": "published-standard"
+        },
+        {
           "description": "Accuracy over valid generated outputs in the EACL 2026 RMCB test protocol; filtering counts and dataset revision remain on the evaluation record.",
           "display_name": "RMCB EACL 2026 valid-output test",
           "id": "rmcb-eacl-2026-valid-output-test"
@@ -1796,6 +1811,205 @@ const builtInCatalogJSON = `{
         }
       ],
       "source": "https://ernie.baidu.com/blog/posts/ernie-5.1-0508-release/"
+    },
+    {
+      "default_profile": "published-unspecified",
+      "display_name": "GPQA",
+      "domain": "scientific_reasoning",
+      "id": "idavidrein/gpqa@1.0.0",
+      "metrics": [
+        {
+          "direction": "higher_is_better",
+          "id": "accuracy",
+          "range": [
+            0,
+            1
+          ],
+          "unit": "proportion"
+        }
+      ],
+      "profiles": [
+        {
+          "description": "Vendor-published GPQA accuracy whose subset (main, extended, or diamond) is not stated by the source; kept separate from GPQA Diamond records and excluded from the default index.",
+          "display_name": "Published subset unspecified",
+          "id": "published-unspecified"
+        }
+      ],
+      "source": "https://arxiv.org/abs/2311.12022"
+    },
+    {
+      "default_profile": "published-8-needle",
+      "display_name": "OpenAI MRCR",
+      "domain": "long_context",
+      "id": "openai/mrcr@1.0.0",
+      "metrics": [
+        {
+          "direction": "higher_is_better",
+          "id": "score",
+          "range": [
+            0,
+            1
+          ],
+          "unit": "proportion"
+        }
+      ],
+      "profiles": [
+        {
+          "description": "Vendor-published score on the 8-needle OpenAI MRCR task; the context-length bins covered are not stated by the source.",
+          "display_name": "Published 8-needle",
+          "id": "published-8-needle"
+        }
+      ],
+      "source": "https://huggingface.co/datasets/openai/mrcr"
+    },
+    {
+      "default_profile": "published-full-instruct",
+      "display_name": "BigCodeBench",
+      "domain": "software_engineering",
+      "id": "bigcode/bigcodebench@1.0.0",
+      "metrics": [
+        {
+          "direction": "higher_is_better",
+          "id": "pass_at_1",
+          "range": [
+            0,
+            1
+          ],
+          "unit": "proportion"
+        }
+      ],
+      "profiles": [
+        {
+          "description": "Vendor-published Pass@1 on the BigCodeBench Full split, Instruct variant; calibration and decoding settings are not stated by the source.",
+          "display_name": "Published Full Instruct",
+          "id": "published-full-instruct"
+        }
+      ],
+      "source": "https://bigcode-bench.github.io/"
+    },
+    {
+      "default_profile": "published-unspecified",
+      "display_name": "Finance Agent (owner and version unstated)",
+      "domain": "financial_reasoning",
+      "id": "unattributed/finance-agent@1.0.0",
+      "metrics": [
+        {
+          "direction": "higher_is_better",
+          "id": "score",
+          "range": [
+            0,
+            1
+          ],
+          "unit": "proportion"
+        }
+      ],
+      "profiles": [
+        {
+          "description": "Vendor-published result labeled only \"Finance Agent\" by the source; benchmark owner, version, and run setup are not stated, so it is never merged with Vals Finance Agent records.",
+          "display_name": "Published setup unspecified",
+          "id": "published-unspecified"
+        }
+      ]
+    },
+    {
+      "default_profile": "published-unspecified",
+      "display_name": "FinanceQA",
+      "domain": "financial_reasoning",
+      "id": "afterquery/financeqa@1.0.0",
+      "metrics": [
+        {
+          "direction": "higher_is_better",
+          "id": "score",
+          "range": [
+            0,
+            1
+          ],
+          "unit": "proportion"
+        }
+      ],
+      "profiles": [
+        {
+          "description": "Vendor-published FinanceQA score; grader, prompt protocol, and dataset revision are not stated by the source.",
+          "display_name": "Published setup unspecified",
+          "id": "published-unspecified"
+        }
+      ],
+      "source": "https://huggingface.co/datasets/AfterQuery/FinanceQA"
+    },
+    {
+      "default_profile": "published-unspecified",
+      "display_name": "FinanceBench",
+      "domain": "financial_reasoning",
+      "id": "patronusai/financebench@1.0.0",
+      "metrics": [
+        {
+          "direction": "higher_is_better",
+          "id": "score",
+          "range": [
+            0,
+            1
+          ],
+          "unit": "proportion"
+        }
+      ],
+      "profiles": [
+        {
+          "description": "Vendor-published FinanceBench score; retrieval configuration, grader, and dataset revision are not stated by the source.",
+          "display_name": "Published setup unspecified",
+          "id": "published-unspecified"
+        }
+      ],
+      "source": "https://huggingface.co/datasets/PatronusAI/financebench"
+    },
+    {
+      "default_profile": "published-unspecified",
+      "display_name": "BFCL Core",
+      "domain": "agentic_systems",
+      "id": "gorilla/bfcl-core@1.0.0",
+      "metrics": [
+        {
+          "direction": "higher_is_better",
+          "id": "score",
+          "range": [
+            0,
+            1
+          ],
+          "unit": "proportion"
+        }
+      ],
+      "profiles": [
+        {
+          "description": "Vendor-published score labeled \"BFCL Core\" by the source; the BFCL version and the category composition behind \"Core\" are not stated by the source and are not defined by the public leaderboard.",
+          "display_name": "Published setup unspecified",
+          "id": "published-unspecified"
+        }
+      ],
+      "source": "https://gorilla.cs.berkeley.edu/leaderboard.html"
+    },
+    {
+      "default_profile": "published-unspecified",
+      "display_name": "MCP Atlas",
+      "domain": "agentic_systems",
+      "id": "scale/mcp-atlas@1.0.0",
+      "metrics": [
+        {
+          "direction": "higher_is_better",
+          "id": "score",
+          "range": [
+            0,
+            1
+          ],
+          "unit": "proportion"
+        }
+      ],
+      "profiles": [
+        {
+          "description": "Vendor-published MCP Atlas score; leaderboard revision, tool-call budget, and judge configuration are not stated by the source.",
+          "display_name": "Published setup unspecified",
+          "id": "published-unspecified"
+        }
+      ],
+      "source": "https://labs.scale.com/leaderboard/mcp_atlas"
     },
     {
       "default_profile": "operator",
@@ -32765,6 +32979,364 @@ const builtInCatalogJSON = `{
         "run_kind": "independent",
         "source_model": "Inkling Small",
         "source_model_slug": "thinkingmachines-inkling-small-medium"
+      }
+    },
+    {
+      "benchmark": "unattributed/finance-agent@1.0.0",
+      "benchmark_profile": "published-unspecified",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://dev.writer.com/home/models",
+        "verification": "claimed"
+      },
+      "id": "writer/palmyra-x6-model-catalog-finance-agent@1.0.0",
+      "metrics": {
+        "score": 0.753
+      },
+      "model": "writer/palmyra-x6",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "benchmark_revision": "unspecified_by_source",
+        "context_length": "unspecified_by_source",
+        "endpoint": "unspecified_by_source",
+        "harness": "raw model, not WRITER Agent, per source",
+        "source_kind": "official_model_card",
+        "source_label": "Finance Agent",
+        "source_model_slug": "palmyra-x6",
+        "tool_policy": "unspecified_by_source",
+        "variant": "Palmyra X6"
+      }
+    },
+    {
+      "benchmark": "afterquery/financeqa@1.0.0",
+      "benchmark_profile": "published-unspecified",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://dev.writer.com/home/models",
+        "verification": "claimed"
+      },
+      "id": "writer/palmyra-x6-model-catalog-financeqa@1.0.0",
+      "metrics": {
+        "score": 0.673
+      },
+      "model": "writer/palmyra-x6",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "benchmark_revision": "unspecified_by_source",
+        "context_length": "unspecified_by_source",
+        "endpoint": "unspecified_by_source",
+        "harness": "raw model, not WRITER Agent, per source",
+        "source_kind": "official_model_card",
+        "source_label": "FinanceQA",
+        "source_model_slug": "palmyra-x6",
+        "tool_policy": "unspecified_by_source",
+        "variant": "Palmyra X6"
+      }
+    },
+    {
+      "benchmark": "patronusai/financebench@1.0.0",
+      "benchmark_profile": "published-unspecified",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://dev.writer.com/home/models",
+        "verification": "claimed"
+      },
+      "id": "writer/palmyra-x6-model-catalog-financebench@1.0.0",
+      "metrics": {
+        "score": 0.855
+      },
+      "model": "writer/palmyra-x6",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "benchmark_revision": "unspecified_by_source",
+        "context_length": "unspecified_by_source",
+        "endpoint": "unspecified_by_source",
+        "harness": "raw model, not WRITER Agent, per source",
+        "source_kind": "official_model_card",
+        "source_label": "FinanceBench",
+        "source_model_slug": "palmyra-x6",
+        "tool_policy": "unspecified_by_source",
+        "variant": "Palmyra X6"
+      }
+    },
+    {
+      "benchmark": "gorilla/bfcl-core@1.0.0",
+      "benchmark_profile": "published-unspecified",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://arxiv.org/abs/2608.16620",
+        "verification": "claimed"
+      },
+      "id": "writer/palmyra-x6-technical-report-bfcl-core@1.0.0",
+      "metrics": {
+        "score": 0.785
+      },
+      "model": "writer/palmyra-x6",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "benchmark_revision": "unspecified_by_source",
+        "context_length": "unspecified_by_source",
+        "endpoint": "unspecified_by_source",
+        "harness": "unspecified_by_source",
+        "source_document": "arXiv:2608.16620v1",
+        "source_kind": "official_technical_report",
+        "source_label": "BFCL Core",
+        "source_model_slug": "palmyra-x6",
+        "tool_policy": "unspecified_by_source",
+        "variant": "Palmyra x6"
+      }
+    },
+    {
+      "benchmark": "allenai/ifbench@1.0.0",
+      "benchmark_profile": "published-unspecified",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://arxiv.org/abs/2608.16620",
+        "verification": "claimed"
+      },
+      "id": "writer/palmyra-x6-technical-report-ifbench@1.0.0",
+      "metrics": {
+        "accuracy": 0.737
+      },
+      "model": "writer/palmyra-x6",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "benchmark_revision": "unspecified_by_source",
+        "context_length": "unspecified_by_source",
+        "endpoint": "unspecified_by_source",
+        "harness": "unspecified_by_source",
+        "reported_in": "Figure 2 bar label",
+        "source_document": "arXiv:2608.16620v1",
+        "source_kind": "official_technical_report",
+        "source_label": "IFBench",
+        "source_model_slug": "palmyra-x6",
+        "tool_policy": "unspecified_by_source",
+        "variant": "Palmyra x6"
+      }
+    },
+    {
+      "benchmark": "scale/mcp-atlas@1.0.0",
+      "benchmark_profile": "published-unspecified",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://arxiv.org/abs/2608.16620",
+        "verification": "claimed"
+      },
+      "id": "writer/palmyra-x6-technical-report-mcp-atlas@1.0.0",
+      "metrics": {
+        "score": 0.771
+      },
+      "model": "writer/palmyra-x6",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "benchmark_revision": "unspecified_by_source",
+        "context_length": "unspecified_by_source",
+        "endpoint": "unspecified_by_source",
+        "harness": "unspecified_by_source",
+        "reported_in": "Figure 2 bar label",
+        "source_document": "arXiv:2608.16620v1",
+        "source_kind": "official_technical_report",
+        "source_label": "MCP-Atlas",
+        "source_model_slug": "palmyra-x6",
+        "tool_policy": "unspecified_by_source",
+        "variant": "Palmyra x6"
+      }
+    },
+    {
+      "benchmark": "tiger-ai-lab/mmlu-pro@1.0.0",
+      "benchmark_profile": "published-standard",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://dev.writer.com/home/models",
+        "verification": "claimed"
+      },
+      "id": "writer/palmyra-x5-model-catalog-mmlu-pro@1.0.0",
+      "metrics": {
+        "accuracy": 0.6502
+      },
+      "model": "writer/palmyra-x5",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "benchmark_revision": "unspecified_by_source",
+        "context_length": "unspecified_by_source",
+        "endpoint": "unspecified_by_source",
+        "harness": "unspecified_by_source",
+        "source_kind": "official_model_card",
+        "source_label": "MMLU_PRO",
+        "source_model_slug": "palmyra-x5",
+        "tool_policy": "unspecified_by_source",
+        "variant": "Palmyra X5"
+      }
+    },
+    {
+      "benchmark": "idavidrein/gpqa@1.0.0",
+      "benchmark_profile": "published-unspecified",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://dev.writer.com/home/models",
+        "verification": "claimed"
+      },
+      "id": "writer/palmyra-x5-model-catalog-gpqa@1.0.0",
+      "metrics": {
+        "accuracy": 0.472
+      },
+      "model": "writer/palmyra-x5",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "benchmark_revision": "unspecified_by_source",
+        "context_length": "unspecified_by_source",
+        "dataset_subset": "unspecified_by_source",
+        "endpoint": "unspecified_by_source",
+        "harness": "unspecified_by_source",
+        "source_kind": "official_model_card",
+        "source_label": "GPQA",
+        "source_model_slug": "palmyra-x5",
+        "tool_policy": "unspecified_by_source",
+        "variant": "Palmyra X5"
+      }
+    },
+    {
+      "benchmark": "maveriq/bigbenchhard@1.0.0",
+      "benchmark_profile": "published-standard",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://dev.writer.com/home/models",
+        "verification": "claimed"
+      },
+      "id": "writer/palmyra-x5-model-catalog-bbh@1.0.0",
+      "metrics": {
+        "accuracy": 0.7099
+      },
+      "model": "writer/palmyra-x5",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "benchmark_revision": "unspecified_by_source",
+        "context_length": "unspecified_by_source",
+        "endpoint": "unspecified_by_source",
+        "harness": "unspecified_by_source",
+        "source_kind": "official_model_card",
+        "source_label": "BBH (Big-Bench Hard)",
+        "source_model_slug": "palmyra-x5",
+        "tool_policy": "unspecified_by_source",
+        "variant": "Palmyra X5"
+      }
+    },
+    {
+      "benchmark": "hendrycks/math@1.0.0",
+      "benchmark_profile": "published-hard-subset",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://dev.writer.com/home/models",
+        "verification": "claimed"
+      },
+      "id": "writer/palmyra-x5-model-catalog-math-hard@1.0.0",
+      "metrics": {
+        "accuracy": 0.7157
+      },
+      "model": "writer/palmyra-x5",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "benchmark_revision": "unspecified_by_source",
+        "context_length": "unspecified_by_source",
+        "dataset_subset": "hard subset as labeled by source, definition unspecified_by_source",
+        "endpoint": "unspecified_by_source",
+        "harness": "unspecified_by_source",
+        "source_kind": "official_model_card",
+        "source_label": "MATH_HARD",
+        "source_model_slug": "palmyra-x5",
+        "tool_policy": "unspecified_by_source",
+        "variant": "Palmyra X5"
+      }
+    },
+    {
+      "benchmark": "openai/mrcr@1.0.0",
+      "benchmark_profile": "published-8-needle",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://writer.com/blog/long-context-palmyra-x5/",
+        "verification": "claimed"
+      },
+      "id": "writer/palmyra-x5-launch-openai-mrcr-8-needle@1.0.0",
+      "metrics": {
+        "score": 0.191
+      },
+      "model": "writer/palmyra-x5",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "benchmark_revision": "unspecified_by_source",
+        "context_length": "unspecified_by_source",
+        "endpoint": "unspecified_by_source",
+        "harness": "unspecified_by_source",
+        "needles": 8,
+        "source_kind": "official_launch_evaluation",
+        "source_label": "OpenAI MRCR 8-needle",
+        "source_model_slug": "palmyra-x5",
+        "tool_policy": "unspecified_by_source",
+        "variant": "Palmyra X5"
+      }
+    },
+    {
+      "benchmark": "bigcode/bigcodebench@1.0.0",
+      "benchmark_profile": "published-full-instruct",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://writer.com/blog/long-context-palmyra-x5/",
+        "verification": "claimed"
+      },
+      "id": "writer/palmyra-x5-launch-bigcodebench-full-instruct@1.0.0",
+      "metrics": {
+        "pass_at_1": 0.487
+      },
+      "model": "writer/palmyra-x5",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "benchmark_revision": "unspecified_by_source",
+        "context_length": "unspecified_by_source",
+        "dataset_split": "full",
+        "dataset_variant": "instruct",
+        "endpoint": "unspecified_by_source",
+        "harness": "unspecified_by_source",
+        "source_kind": "official_launch_evaluation",
+        "source_label": "BigCodeBench (Full, Instruct)",
+        "source_model_slug": "palmyra-x5",
+        "tool_policy": "unspecified_by_source",
+        "variant": "Palmyra X5"
       }
     },
     {
@@ -80151,6 +80723,635 @@ const builtInCatalogJSON = `{
       ],
       "coverage": 0.0,
       "index": "vllm-sr/general@1.0.0",
+      "model": "writer/palmyra-x6",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "cais/humanitys-last-exam@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "no-tools"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/reasoning@1.0.0",
+      "model": "writer/palmyra-x6",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "livecodebench/livecodebench@6.0.0",
+          "benchmark_profiles": [
+            "independent-code-generation",
+            "published-code-generation"
+          ],
+          "metric": "pass_at_1",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "scicode-bench/scicode@1.0.0",
+          "benchmark_profiles": [
+            "independent-test-288",
+            "published-standard"
+          ],
+          "metric": "score",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/coding@1.0.0",
+      "model": "writer/palmyra-x6",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "harbor/terminal-bench@2.1.0",
+          "benchmark_profiles": [
+            "independent-agent",
+            "published-agent"
+          ],
+          "metric": "resolved",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/agentic@1.0.0",
+      "model": "writer/palmyra-x6",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "index": "vllm-sr/general@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/reasoning@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.4
+        },
+        {
+          "index": "vllm-sr/coding@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/agentic@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/intelligence@1.0.0",
+      "model": "writer/palmyra-x6",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "tiger-ai-lab/mmlu-pro@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/general@1.0.0",
+      "model": "writer/palmyra-x6",
+      "provenance": [],
+      "reasoning_effort": "unspecified",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "cais/humanitys-last-exam@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "no-tools"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/reasoning@1.0.0",
+      "model": "writer/palmyra-x6",
+      "provenance": [],
+      "reasoning_effort": "unspecified",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "livecodebench/livecodebench@6.0.0",
+          "benchmark_profiles": [
+            "independent-code-generation",
+            "published-code-generation"
+          ],
+          "metric": "pass_at_1",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "scicode-bench/scicode@1.0.0",
+          "benchmark_profiles": [
+            "independent-test-288",
+            "published-standard"
+          ],
+          "metric": "score",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/coding@1.0.0",
+      "model": "writer/palmyra-x6",
+      "provenance": [],
+      "reasoning_effort": "unspecified",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "harbor/terminal-bench@2.1.0",
+          "benchmark_profiles": [
+            "independent-agent",
+            "published-agent"
+          ],
+          "metric": "resolved",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/agentic@1.0.0",
+      "model": "writer/palmyra-x6",
+      "provenance": [],
+      "reasoning_effort": "unspecified",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "index": "vllm-sr/general@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/reasoning@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.4
+        },
+        {
+          "index": "vllm-sr/coding@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/agentic@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/intelligence@1.0.0",
+      "model": "writer/palmyra-x6",
+      "provenance": [],
+      "reasoning_effort": "unspecified",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "tiger-ai-lab/mmlu-pro@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/general@1.0.0",
+      "model": "writer/palmyra-x5",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "cais/humanitys-last-exam@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "no-tools"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/reasoning@1.0.0",
+      "model": "writer/palmyra-x5",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "livecodebench/livecodebench@6.0.0",
+          "benchmark_profiles": [
+            "independent-code-generation",
+            "published-code-generation"
+          ],
+          "metric": "pass_at_1",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "scicode-bench/scicode@1.0.0",
+          "benchmark_profiles": [
+            "independent-test-288",
+            "published-standard"
+          ],
+          "metric": "score",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/coding@1.0.0",
+      "model": "writer/palmyra-x5",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "harbor/terminal-bench@2.1.0",
+          "benchmark_profiles": [
+            "independent-agent",
+            "published-agent"
+          ],
+          "metric": "resolved",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/agentic@1.0.0",
+      "model": "writer/palmyra-x5",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "index": "vllm-sr/general@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/reasoning@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.4
+        },
+        {
+          "index": "vllm-sr/coding@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/agentic@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/intelligence@1.0.0",
+      "model": "writer/palmyra-x5",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "tiger-ai-lab/mmlu-pro@1.0.0",
+          "benchmark_profile": "published-standard",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "evaluation": "writer/palmyra-x5-model-catalog-mmlu-pro@1.0.0",
+          "metric": "accuracy",
+          "normalized": 0.6502,
+          "status": "available",
+          "value": 0.6502,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 1.0,
+      "domains": {
+        "general_reasoning": 65.02
+      },
+      "index": "vllm-sr/general@1.0.0",
+      "model": "writer/palmyra-x5",
+      "provenance": [
+        "writer/palmyra-x5-model-catalog-mmlu-pro@1.0.0"
+      ],
+      "reasoning_effort": "unspecified",
+      "score": 65.02,
+      "status": "available"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "cais/humanitys-last-exam@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "no-tools"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/reasoning@1.0.0",
+      "model": "writer/palmyra-x5",
+      "provenance": [],
+      "reasoning_effort": "unspecified",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "livecodebench/livecodebench@6.0.0",
+          "benchmark_profiles": [
+            "independent-code-generation",
+            "published-code-generation"
+          ],
+          "metric": "pass_at_1",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "scicode-bench/scicode@1.0.0",
+          "benchmark_profiles": [
+            "independent-test-288",
+            "published-standard"
+          ],
+          "metric": "score",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/coding@1.0.0",
+      "model": "writer/palmyra-x5",
+      "provenance": [],
+      "reasoning_effort": "unspecified",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "harbor/terminal-bench@2.1.0",
+          "benchmark_profiles": [
+            "independent-agent",
+            "published-agent"
+          ],
+          "metric": "resolved",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/agentic@1.0.0",
+      "model": "writer/palmyra-x5",
+      "provenance": [],
+      "reasoning_effort": "unspecified",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "index": "vllm-sr/general@1.0.0",
+          "normalized": 0.6502,
+          "status": "available",
+          "value": 0.6502,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/reasoning@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.4
+        },
+        {
+          "index": "vllm-sr/coding@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/agentic@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        }
+      ],
+      "coverage": 0.2,
+      "index": "vllm-sr/intelligence@1.0.0",
+      "model": "writer/palmyra-x5",
+      "provenance": [
+        "writer/palmyra-x5-model-catalog-mmlu-pro@1.0.0"
+      ],
+      "reasoning_effort": "unspecified",
+      "score": null,
+      "status": "partial"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "tiger-ai-lab/mmlu-pro@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/general@1.0.0",
       "model": "xai/grok-4.6",
       "provenance": [],
       "reasoning_effort": "low",
@@ -90805,6 +92006,104 @@ const builtInCatalogJSON = `{
     {
       "capabilities": [
         "chat",
+        "tools",
+        "structured_output",
+        "long_context"
+      ],
+      "description": "Writer's flagship agentic Palmyra model for long-horizon enterprise workflows, sub-agents, and MCP tool use.",
+      "display_name": "Palmyra X6",
+      "distribution": {
+        "source": "https://dev.writer.com/home/models",
+        "type": "proprietary_api"
+      },
+      "family": "palmyra-x6",
+      "id": "writer/palmyra-x6",
+      "kind": "physical",
+      "lifecycle": "active",
+      "limits": {
+        "context_window_size": 1000000,
+        "max_output_tokens": 8192
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "presentation": {
+        "logo": "monogram",
+        "monochrome": true,
+        "monogram": "W"
+      },
+      "publisher": "Writer",
+      "released_at": "2026-08-13",
+      "tags": [
+        "proprietary",
+        "agentic",
+        "enterprise"
+      ],
+      "verification": {
+        "authority": "Writer",
+        "source": "https://dev.writer.com/home/models",
+        "status": "claimed",
+        "verified_at": "2026-09-11"
+      }
+    },
+    {
+      "capabilities": [
+        "chat",
+        "tools",
+        "structured_output",
+        "vision",
+        "long_context"
+      ],
+      "description": "Writer's general-purpose Palmyra model with a 1M token context window, adaptive reasoning, and vision input.",
+      "display_name": "Palmyra X5",
+      "distribution": {
+        "source": "https://dev.writer.com/home/models",
+        "type": "proprietary_api"
+      },
+      "family": "palmyra-x5",
+      "id": "writer/palmyra-x5",
+      "kind": "physical",
+      "lifecycle": "active",
+      "limits": {
+        "context_window_size": 1000000,
+        "max_output_tokens": 8192
+      },
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "presentation": {
+        "logo": "monogram",
+        "monochrome": true,
+        "monogram": "W"
+      },
+      "publisher": "Writer",
+      "released_at": "2025-04-28",
+      "tags": [
+        "proprietary",
+        "multimodal",
+        "enterprise"
+      ],
+      "verification": {
+        "authority": "Writer",
+        "source": "https://dev.writer.com/home/models",
+        "status": "claimed",
+        "verified_at": "2026-09-11"
+      }
+    },
+    {
+      "capabilities": [
+        "chat",
         "reasoning",
         "tools",
         "structured_output",
@@ -96525,7 +97824,46 @@ const builtInCatalogJSON = `{
       "description": "Palmyra enterprise models through the Writer chat API.",
       "display_name": "Writer",
       "id": "writer",
-      "models": [],
+      "models": [
+        {
+          "catalog": "writer/palmyra-x6",
+          "id": "palmyra-x6",
+          "lifecycle": "active",
+          "pricing": {
+            "completion_per_1m": 8.0,
+            "currency": "USD",
+            "prompt_per_1m": 2.0
+          },
+          "protocols": [
+            "openai/chat-completions@1"
+          ],
+          "relationship": "first_party",
+          "verification": {
+            "source": "https://dev.writer.com/home/models",
+            "status": "claimed",
+            "verified_at": "2026-09-11"
+          }
+        },
+        {
+          "catalog": "writer/palmyra-x5",
+          "id": "palmyra-x5",
+          "lifecycle": "active",
+          "pricing": {
+            "completion_per_1m": 6.0,
+            "currency": "USD",
+            "prompt_per_1m": 0.6
+          },
+          "protocols": [
+            "openai/chat-completions@1"
+          ],
+          "relationship": "first_party",
+          "verification": {
+            "source": "https://dev.writer.com/home/models",
+            "status": "claimed",
+            "verified_at": "2026-09-11"
+          }
+        }
+      ],
       "path_overrides": {
         "openai/chat-completions@1#create": "/v1/chat"
       },

--- a/website/static/model-catalog/catalog.json
+++ b/website/static/model-catalog/catalog.json
@@ -1177,6 +1177,11 @@
           "description": "Prompt-level loose accuracy on IFBench, with model-side reasoning and generation settings retained on the record.",
           "display_name": "Prompt-level loose accuracy",
           "id": "prompt-loose"
+        },
+        {
+          "description": "Vendor-published IFBench result whose accuracy level (prompt or instruction, loose or strict) is not stated by the source; kept separate from prompt-level loose records.",
+          "display_name": "Published setup unspecified",
+          "id": "published-unspecified"
         }
       ],
       "source": "https://github.com/allenai/IFBench"
@@ -1377,6 +1382,11 @@
           "description": "Accuracy on MATH using the source-published evaluation setup.",
           "display_name": "Published standard",
           "id": "published-standard"
+        },
+        {
+          "description": "Vendor-published result labeled MATH-Hard by the source; the hard-subset definition and harness are not stated by the source and it is never compared with full-set MATH records.",
+          "display_name": "Published hard subset",
+          "id": "published-hard-subset"
         },
         {
           "description": "Accuracy over valid generated outputs in the EACL 2026 RMCB test protocol; filtering counts and generation settings remain on the evaluation record.",
@@ -1609,6 +1619,11 @@
       ],
       "profiles": [
         {
+          "description": "Vendor-published BIG-Bench Hard accuracy; prompt format, shot count, and harness are retained on the evaluation record when the source states them.",
+          "display_name": "Published standard",
+          "id": "published-standard"
+        },
+        {
           "description": "Accuracy over valid generated outputs in the EACL 2026 RMCB test protocol; filtering counts and dataset revision remain on the evaluation record.",
           "display_name": "RMCB EACL 2026 valid-output test",
           "id": "rmcb-eacl-2026-valid-output-test"
@@ -1790,6 +1805,205 @@
         }
       ],
       "source": "https://ernie.baidu.com/blog/posts/ernie-5.1-0508-release/"
+    },
+    {
+      "default_profile": "published-unspecified",
+      "display_name": "GPQA",
+      "domain": "scientific_reasoning",
+      "id": "idavidrein/gpqa@1.0.0",
+      "metrics": [
+        {
+          "direction": "higher_is_better",
+          "id": "accuracy",
+          "range": [
+            0,
+            1
+          ],
+          "unit": "proportion"
+        }
+      ],
+      "profiles": [
+        {
+          "description": "Vendor-published GPQA accuracy whose subset (main, extended, or diamond) is not stated by the source; kept separate from GPQA Diamond records and excluded from the default index.",
+          "display_name": "Published subset unspecified",
+          "id": "published-unspecified"
+        }
+      ],
+      "source": "https://arxiv.org/abs/2311.12022"
+    },
+    {
+      "default_profile": "published-8-needle",
+      "display_name": "OpenAI MRCR",
+      "domain": "long_context",
+      "id": "openai/mrcr@1.0.0",
+      "metrics": [
+        {
+          "direction": "higher_is_better",
+          "id": "score",
+          "range": [
+            0,
+            1
+          ],
+          "unit": "proportion"
+        }
+      ],
+      "profiles": [
+        {
+          "description": "Vendor-published score on the 8-needle OpenAI MRCR task; the context-length bins covered are not stated by the source.",
+          "display_name": "Published 8-needle",
+          "id": "published-8-needle"
+        }
+      ],
+      "source": "https://huggingface.co/datasets/openai/mrcr"
+    },
+    {
+      "default_profile": "published-full-instruct",
+      "display_name": "BigCodeBench",
+      "domain": "software_engineering",
+      "id": "bigcode/bigcodebench@1.0.0",
+      "metrics": [
+        {
+          "direction": "higher_is_better",
+          "id": "pass_at_1",
+          "range": [
+            0,
+            1
+          ],
+          "unit": "proportion"
+        }
+      ],
+      "profiles": [
+        {
+          "description": "Vendor-published Pass@1 on the BigCodeBench Full split, Instruct variant; calibration and decoding settings are not stated by the source.",
+          "display_name": "Published Full Instruct",
+          "id": "published-full-instruct"
+        }
+      ],
+      "source": "https://bigcode-bench.github.io/"
+    },
+    {
+      "default_profile": "published-unspecified",
+      "display_name": "Finance Agent (owner and version unstated)",
+      "domain": "financial_reasoning",
+      "id": "unattributed/finance-agent@1.0.0",
+      "metrics": [
+        {
+          "direction": "higher_is_better",
+          "id": "score",
+          "range": [
+            0,
+            1
+          ],
+          "unit": "proportion"
+        }
+      ],
+      "profiles": [
+        {
+          "description": "Vendor-published result labeled only \"Finance Agent\" by the source; benchmark owner, version, and run setup are not stated, so it is never merged with Vals Finance Agent records.",
+          "display_name": "Published setup unspecified",
+          "id": "published-unspecified"
+        }
+      ]
+    },
+    {
+      "default_profile": "published-unspecified",
+      "display_name": "FinanceQA",
+      "domain": "financial_reasoning",
+      "id": "afterquery/financeqa@1.0.0",
+      "metrics": [
+        {
+          "direction": "higher_is_better",
+          "id": "score",
+          "range": [
+            0,
+            1
+          ],
+          "unit": "proportion"
+        }
+      ],
+      "profiles": [
+        {
+          "description": "Vendor-published FinanceQA score; grader, prompt protocol, and dataset revision are not stated by the source.",
+          "display_name": "Published setup unspecified",
+          "id": "published-unspecified"
+        }
+      ],
+      "source": "https://huggingface.co/datasets/AfterQuery/FinanceQA"
+    },
+    {
+      "default_profile": "published-unspecified",
+      "display_name": "FinanceBench",
+      "domain": "financial_reasoning",
+      "id": "patronusai/financebench@1.0.0",
+      "metrics": [
+        {
+          "direction": "higher_is_better",
+          "id": "score",
+          "range": [
+            0,
+            1
+          ],
+          "unit": "proportion"
+        }
+      ],
+      "profiles": [
+        {
+          "description": "Vendor-published FinanceBench score; retrieval configuration, grader, and dataset revision are not stated by the source.",
+          "display_name": "Published setup unspecified",
+          "id": "published-unspecified"
+        }
+      ],
+      "source": "https://huggingface.co/datasets/PatronusAI/financebench"
+    },
+    {
+      "default_profile": "published-unspecified",
+      "display_name": "BFCL Core",
+      "domain": "agentic_systems",
+      "id": "gorilla/bfcl-core@1.0.0",
+      "metrics": [
+        {
+          "direction": "higher_is_better",
+          "id": "score",
+          "range": [
+            0,
+            1
+          ],
+          "unit": "proportion"
+        }
+      ],
+      "profiles": [
+        {
+          "description": "Vendor-published score labeled \"BFCL Core\" by the source; the BFCL version and the category composition behind \"Core\" are not stated by the source and are not defined by the public leaderboard.",
+          "display_name": "Published setup unspecified",
+          "id": "published-unspecified"
+        }
+      ],
+      "source": "https://gorilla.cs.berkeley.edu/leaderboard.html"
+    },
+    {
+      "default_profile": "published-unspecified",
+      "display_name": "MCP Atlas",
+      "domain": "agentic_systems",
+      "id": "scale/mcp-atlas@1.0.0",
+      "metrics": [
+        {
+          "direction": "higher_is_better",
+          "id": "score",
+          "range": [
+            0,
+            1
+          ],
+          "unit": "proportion"
+        }
+      ],
+      "profiles": [
+        {
+          "description": "Vendor-published MCP Atlas score; leaderboard revision, tool-call budget, and judge configuration are not stated by the source.",
+          "display_name": "Published setup unspecified",
+          "id": "published-unspecified"
+        }
+      ],
+      "source": "https://labs.scale.com/leaderboard/mcp_atlas"
     },
     {
       "default_profile": "operator",
@@ -32759,6 +32973,364 @@
         "run_kind": "independent",
         "source_model": "Inkling Small",
         "source_model_slug": "thinkingmachines-inkling-small-medium"
+      }
+    },
+    {
+      "benchmark": "unattributed/finance-agent@1.0.0",
+      "benchmark_profile": "published-unspecified",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://dev.writer.com/home/models",
+        "verification": "claimed"
+      },
+      "id": "writer/palmyra-x6-model-catalog-finance-agent@1.0.0",
+      "metrics": {
+        "score": 0.753
+      },
+      "model": "writer/palmyra-x6",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "benchmark_revision": "unspecified_by_source",
+        "context_length": "unspecified_by_source",
+        "endpoint": "unspecified_by_source",
+        "harness": "raw model, not WRITER Agent, per source",
+        "source_kind": "official_model_card",
+        "source_label": "Finance Agent",
+        "source_model_slug": "palmyra-x6",
+        "tool_policy": "unspecified_by_source",
+        "variant": "Palmyra X6"
+      }
+    },
+    {
+      "benchmark": "afterquery/financeqa@1.0.0",
+      "benchmark_profile": "published-unspecified",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://dev.writer.com/home/models",
+        "verification": "claimed"
+      },
+      "id": "writer/palmyra-x6-model-catalog-financeqa@1.0.0",
+      "metrics": {
+        "score": 0.673
+      },
+      "model": "writer/palmyra-x6",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "benchmark_revision": "unspecified_by_source",
+        "context_length": "unspecified_by_source",
+        "endpoint": "unspecified_by_source",
+        "harness": "raw model, not WRITER Agent, per source",
+        "source_kind": "official_model_card",
+        "source_label": "FinanceQA",
+        "source_model_slug": "palmyra-x6",
+        "tool_policy": "unspecified_by_source",
+        "variant": "Palmyra X6"
+      }
+    },
+    {
+      "benchmark": "patronusai/financebench@1.0.0",
+      "benchmark_profile": "published-unspecified",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://dev.writer.com/home/models",
+        "verification": "claimed"
+      },
+      "id": "writer/palmyra-x6-model-catalog-financebench@1.0.0",
+      "metrics": {
+        "score": 0.855
+      },
+      "model": "writer/palmyra-x6",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "benchmark_revision": "unspecified_by_source",
+        "context_length": "unspecified_by_source",
+        "endpoint": "unspecified_by_source",
+        "harness": "raw model, not WRITER Agent, per source",
+        "source_kind": "official_model_card",
+        "source_label": "FinanceBench",
+        "source_model_slug": "palmyra-x6",
+        "tool_policy": "unspecified_by_source",
+        "variant": "Palmyra X6"
+      }
+    },
+    {
+      "benchmark": "gorilla/bfcl-core@1.0.0",
+      "benchmark_profile": "published-unspecified",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://arxiv.org/abs/2608.16620",
+        "verification": "claimed"
+      },
+      "id": "writer/palmyra-x6-technical-report-bfcl-core@1.0.0",
+      "metrics": {
+        "score": 0.785
+      },
+      "model": "writer/palmyra-x6",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "benchmark_revision": "unspecified_by_source",
+        "context_length": "unspecified_by_source",
+        "endpoint": "unspecified_by_source",
+        "harness": "unspecified_by_source",
+        "source_document": "arXiv:2608.16620v1",
+        "source_kind": "official_technical_report",
+        "source_label": "BFCL Core",
+        "source_model_slug": "palmyra-x6",
+        "tool_policy": "unspecified_by_source",
+        "variant": "Palmyra x6"
+      }
+    },
+    {
+      "benchmark": "allenai/ifbench@1.0.0",
+      "benchmark_profile": "published-unspecified",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://arxiv.org/abs/2608.16620",
+        "verification": "claimed"
+      },
+      "id": "writer/palmyra-x6-technical-report-ifbench@1.0.0",
+      "metrics": {
+        "accuracy": 0.737
+      },
+      "model": "writer/palmyra-x6",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "benchmark_revision": "unspecified_by_source",
+        "context_length": "unspecified_by_source",
+        "endpoint": "unspecified_by_source",
+        "harness": "unspecified_by_source",
+        "reported_in": "Figure 2 bar label",
+        "source_document": "arXiv:2608.16620v1",
+        "source_kind": "official_technical_report",
+        "source_label": "IFBench",
+        "source_model_slug": "palmyra-x6",
+        "tool_policy": "unspecified_by_source",
+        "variant": "Palmyra x6"
+      }
+    },
+    {
+      "benchmark": "scale/mcp-atlas@1.0.0",
+      "benchmark_profile": "published-unspecified",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://arxiv.org/abs/2608.16620",
+        "verification": "claimed"
+      },
+      "id": "writer/palmyra-x6-technical-report-mcp-atlas@1.0.0",
+      "metrics": {
+        "score": 0.771
+      },
+      "model": "writer/palmyra-x6",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "benchmark_revision": "unspecified_by_source",
+        "context_length": "unspecified_by_source",
+        "endpoint": "unspecified_by_source",
+        "harness": "unspecified_by_source",
+        "reported_in": "Figure 2 bar label",
+        "source_document": "arXiv:2608.16620v1",
+        "source_kind": "official_technical_report",
+        "source_label": "MCP-Atlas",
+        "source_model_slug": "palmyra-x6",
+        "tool_policy": "unspecified_by_source",
+        "variant": "Palmyra x6"
+      }
+    },
+    {
+      "benchmark": "tiger-ai-lab/mmlu-pro@1.0.0",
+      "benchmark_profile": "published-standard",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://dev.writer.com/home/models",
+        "verification": "claimed"
+      },
+      "id": "writer/palmyra-x5-model-catalog-mmlu-pro@1.0.0",
+      "metrics": {
+        "accuracy": 0.6502
+      },
+      "model": "writer/palmyra-x5",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "benchmark_revision": "unspecified_by_source",
+        "context_length": "unspecified_by_source",
+        "endpoint": "unspecified_by_source",
+        "harness": "unspecified_by_source",
+        "source_kind": "official_model_card",
+        "source_label": "MMLU_PRO",
+        "source_model_slug": "palmyra-x5",
+        "tool_policy": "unspecified_by_source",
+        "variant": "Palmyra X5"
+      }
+    },
+    {
+      "benchmark": "idavidrein/gpqa@1.0.0",
+      "benchmark_profile": "published-unspecified",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://dev.writer.com/home/models",
+        "verification": "claimed"
+      },
+      "id": "writer/palmyra-x5-model-catalog-gpqa@1.0.0",
+      "metrics": {
+        "accuracy": 0.472
+      },
+      "model": "writer/palmyra-x5",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "benchmark_revision": "unspecified_by_source",
+        "context_length": "unspecified_by_source",
+        "dataset_subset": "unspecified_by_source",
+        "endpoint": "unspecified_by_source",
+        "harness": "unspecified_by_source",
+        "source_kind": "official_model_card",
+        "source_label": "GPQA",
+        "source_model_slug": "palmyra-x5",
+        "tool_policy": "unspecified_by_source",
+        "variant": "Palmyra X5"
+      }
+    },
+    {
+      "benchmark": "maveriq/bigbenchhard@1.0.0",
+      "benchmark_profile": "published-standard",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://dev.writer.com/home/models",
+        "verification": "claimed"
+      },
+      "id": "writer/palmyra-x5-model-catalog-bbh@1.0.0",
+      "metrics": {
+        "accuracy": 0.7099
+      },
+      "model": "writer/palmyra-x5",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "benchmark_revision": "unspecified_by_source",
+        "context_length": "unspecified_by_source",
+        "endpoint": "unspecified_by_source",
+        "harness": "unspecified_by_source",
+        "source_kind": "official_model_card",
+        "source_label": "BBH (Big-Bench Hard)",
+        "source_model_slug": "palmyra-x5",
+        "tool_policy": "unspecified_by_source",
+        "variant": "Palmyra X5"
+      }
+    },
+    {
+      "benchmark": "hendrycks/math@1.0.0",
+      "benchmark_profile": "published-hard-subset",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://dev.writer.com/home/models",
+        "verification": "claimed"
+      },
+      "id": "writer/palmyra-x5-model-catalog-math-hard@1.0.0",
+      "metrics": {
+        "accuracy": 0.7157
+      },
+      "model": "writer/palmyra-x5",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "benchmark_revision": "unspecified_by_source",
+        "context_length": "unspecified_by_source",
+        "dataset_subset": "hard subset as labeled by source, definition unspecified_by_source",
+        "endpoint": "unspecified_by_source",
+        "harness": "unspecified_by_source",
+        "source_kind": "official_model_card",
+        "source_label": "MATH_HARD",
+        "source_model_slug": "palmyra-x5",
+        "tool_policy": "unspecified_by_source",
+        "variant": "Palmyra X5"
+      }
+    },
+    {
+      "benchmark": "openai/mrcr@1.0.0",
+      "benchmark_profile": "published-8-needle",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://writer.com/blog/long-context-palmyra-x5/",
+        "verification": "claimed"
+      },
+      "id": "writer/palmyra-x5-launch-openai-mrcr-8-needle@1.0.0",
+      "metrics": {
+        "score": 0.191
+      },
+      "model": "writer/palmyra-x5",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "benchmark_revision": "unspecified_by_source",
+        "context_length": "unspecified_by_source",
+        "endpoint": "unspecified_by_source",
+        "harness": "unspecified_by_source",
+        "needles": 8,
+        "source_kind": "official_launch_evaluation",
+        "source_label": "OpenAI MRCR 8-needle",
+        "source_model_slug": "palmyra-x5",
+        "tool_policy": "unspecified_by_source",
+        "variant": "Palmyra X5"
+      }
+    },
+    {
+      "benchmark": "bigcode/bigcodebench@1.0.0",
+      "benchmark_profile": "published-full-instruct",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://writer.com/blog/long-context-palmyra-x5/",
+        "verification": "claimed"
+      },
+      "id": "writer/palmyra-x5-launch-bigcodebench-full-instruct@1.0.0",
+      "metrics": {
+        "pass_at_1": 0.487
+      },
+      "model": "writer/palmyra-x5",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "benchmark_revision": "unspecified_by_source",
+        "context_length": "unspecified_by_source",
+        "dataset_split": "full",
+        "dataset_variant": "instruct",
+        "endpoint": "unspecified_by_source",
+        "harness": "unspecified_by_source",
+        "source_kind": "official_launch_evaluation",
+        "source_label": "BigCodeBench (Full, Instruct)",
+        "source_model_slug": "palmyra-x5",
+        "tool_policy": "unspecified_by_source",
+        "variant": "Palmyra X5"
       }
     },
     {
@@ -80145,6 +80717,635 @@
       ],
       "coverage": 0.0,
       "index": "vllm-sr/general@1.0.0",
+      "model": "writer/palmyra-x6",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "cais/humanitys-last-exam@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "no-tools"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/reasoning@1.0.0",
+      "model": "writer/palmyra-x6",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "livecodebench/livecodebench@6.0.0",
+          "benchmark_profiles": [
+            "independent-code-generation",
+            "published-code-generation"
+          ],
+          "metric": "pass_at_1",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "scicode-bench/scicode@1.0.0",
+          "benchmark_profiles": [
+            "independent-test-288",
+            "published-standard"
+          ],
+          "metric": "score",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/coding@1.0.0",
+      "model": "writer/palmyra-x6",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "harbor/terminal-bench@2.1.0",
+          "benchmark_profiles": [
+            "independent-agent",
+            "published-agent"
+          ],
+          "metric": "resolved",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/agentic@1.0.0",
+      "model": "writer/palmyra-x6",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "index": "vllm-sr/general@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/reasoning@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.4
+        },
+        {
+          "index": "vllm-sr/coding@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/agentic@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/intelligence@1.0.0",
+      "model": "writer/palmyra-x6",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "tiger-ai-lab/mmlu-pro@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/general@1.0.0",
+      "model": "writer/palmyra-x6",
+      "provenance": [],
+      "reasoning_effort": "unspecified",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "cais/humanitys-last-exam@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "no-tools"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/reasoning@1.0.0",
+      "model": "writer/palmyra-x6",
+      "provenance": [],
+      "reasoning_effort": "unspecified",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "livecodebench/livecodebench@6.0.0",
+          "benchmark_profiles": [
+            "independent-code-generation",
+            "published-code-generation"
+          ],
+          "metric": "pass_at_1",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "scicode-bench/scicode@1.0.0",
+          "benchmark_profiles": [
+            "independent-test-288",
+            "published-standard"
+          ],
+          "metric": "score",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/coding@1.0.0",
+      "model": "writer/palmyra-x6",
+      "provenance": [],
+      "reasoning_effort": "unspecified",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "harbor/terminal-bench@2.1.0",
+          "benchmark_profiles": [
+            "independent-agent",
+            "published-agent"
+          ],
+          "metric": "resolved",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/agentic@1.0.0",
+      "model": "writer/palmyra-x6",
+      "provenance": [],
+      "reasoning_effort": "unspecified",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "index": "vllm-sr/general@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/reasoning@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.4
+        },
+        {
+          "index": "vllm-sr/coding@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/agentic@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/intelligence@1.0.0",
+      "model": "writer/palmyra-x6",
+      "provenance": [],
+      "reasoning_effort": "unspecified",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "tiger-ai-lab/mmlu-pro@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/general@1.0.0",
+      "model": "writer/palmyra-x5",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "cais/humanitys-last-exam@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "no-tools"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/reasoning@1.0.0",
+      "model": "writer/palmyra-x5",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "livecodebench/livecodebench@6.0.0",
+          "benchmark_profiles": [
+            "independent-code-generation",
+            "published-code-generation"
+          ],
+          "metric": "pass_at_1",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "scicode-bench/scicode@1.0.0",
+          "benchmark_profiles": [
+            "independent-test-288",
+            "published-standard"
+          ],
+          "metric": "score",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/coding@1.0.0",
+      "model": "writer/palmyra-x5",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "harbor/terminal-bench@2.1.0",
+          "benchmark_profiles": [
+            "independent-agent",
+            "published-agent"
+          ],
+          "metric": "resolved",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/agentic@1.0.0",
+      "model": "writer/palmyra-x5",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "index": "vllm-sr/general@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/reasoning@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.4
+        },
+        {
+          "index": "vllm-sr/coding@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/agentic@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/intelligence@1.0.0",
+      "model": "writer/palmyra-x5",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "tiger-ai-lab/mmlu-pro@1.0.0",
+          "benchmark_profile": "published-standard",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "evaluation": "writer/palmyra-x5-model-catalog-mmlu-pro@1.0.0",
+          "metric": "accuracy",
+          "normalized": 0.6502,
+          "status": "available",
+          "value": 0.6502,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 1.0,
+      "domains": {
+        "general_reasoning": 65.02
+      },
+      "index": "vllm-sr/general@1.0.0",
+      "model": "writer/palmyra-x5",
+      "provenance": [
+        "writer/palmyra-x5-model-catalog-mmlu-pro@1.0.0"
+      ],
+      "reasoning_effort": "unspecified",
+      "score": 65.02,
+      "status": "available"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "cais/humanitys-last-exam@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "no-tools"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/reasoning@1.0.0",
+      "model": "writer/palmyra-x5",
+      "provenance": [],
+      "reasoning_effort": "unspecified",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "livecodebench/livecodebench@6.0.0",
+          "benchmark_profiles": [
+            "independent-code-generation",
+            "published-code-generation"
+          ],
+          "metric": "pass_at_1",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "scicode-bench/scicode@1.0.0",
+          "benchmark_profiles": [
+            "independent-test-288",
+            "published-standard"
+          ],
+          "metric": "score",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/coding@1.0.0",
+      "model": "writer/palmyra-x5",
+      "provenance": [],
+      "reasoning_effort": "unspecified",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "harbor/terminal-bench@2.1.0",
+          "benchmark_profiles": [
+            "independent-agent",
+            "published-agent"
+          ],
+          "metric": "resolved",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/agentic@1.0.0",
+      "model": "writer/palmyra-x5",
+      "provenance": [],
+      "reasoning_effort": "unspecified",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "index": "vllm-sr/general@1.0.0",
+          "normalized": 0.6502,
+          "status": "available",
+          "value": 0.6502,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/reasoning@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.4
+        },
+        {
+          "index": "vllm-sr/coding@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/agentic@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        }
+      ],
+      "coverage": 0.2,
+      "index": "vllm-sr/intelligence@1.0.0",
+      "model": "writer/palmyra-x5",
+      "provenance": [
+        "writer/palmyra-x5-model-catalog-mmlu-pro@1.0.0"
+      ],
+      "reasoning_effort": "unspecified",
+      "score": null,
+      "status": "partial"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "tiger-ai-lab/mmlu-pro@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/general@1.0.0",
       "model": "xai/grok-4.6",
       "provenance": [],
       "reasoning_effort": "low",
@@ -90799,6 +92000,104 @@
     {
       "capabilities": [
         "chat",
+        "tools",
+        "structured_output",
+        "long_context"
+      ],
+      "description": "Writer's flagship agentic Palmyra model for long-horizon enterprise workflows, sub-agents, and MCP tool use.",
+      "display_name": "Palmyra X6",
+      "distribution": {
+        "source": "https://dev.writer.com/home/models",
+        "type": "proprietary_api"
+      },
+      "family": "palmyra-x6",
+      "id": "writer/palmyra-x6",
+      "kind": "physical",
+      "lifecycle": "active",
+      "limits": {
+        "context_window_size": 1000000,
+        "max_output_tokens": 8192
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "presentation": {
+        "logo": "monogram",
+        "monochrome": true,
+        "monogram": "W"
+      },
+      "publisher": "Writer",
+      "released_at": "2026-08-13",
+      "tags": [
+        "proprietary",
+        "agentic",
+        "enterprise"
+      ],
+      "verification": {
+        "authority": "Writer",
+        "source": "https://dev.writer.com/home/models",
+        "status": "claimed",
+        "verified_at": "2026-09-11"
+      }
+    },
+    {
+      "capabilities": [
+        "chat",
+        "tools",
+        "structured_output",
+        "vision",
+        "long_context"
+      ],
+      "description": "Writer's general-purpose Palmyra model with a 1M token context window, adaptive reasoning, and vision input.",
+      "display_name": "Palmyra X5",
+      "distribution": {
+        "source": "https://dev.writer.com/home/models",
+        "type": "proprietary_api"
+      },
+      "family": "palmyra-x5",
+      "id": "writer/palmyra-x5",
+      "kind": "physical",
+      "lifecycle": "active",
+      "limits": {
+        "context_window_size": 1000000,
+        "max_output_tokens": 8192
+      },
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "presentation": {
+        "logo": "monogram",
+        "monochrome": true,
+        "monogram": "W"
+      },
+      "publisher": "Writer",
+      "released_at": "2025-04-28",
+      "tags": [
+        "proprietary",
+        "multimodal",
+        "enterprise"
+      ],
+      "verification": {
+        "authority": "Writer",
+        "source": "https://dev.writer.com/home/models",
+        "status": "claimed",
+        "verified_at": "2026-09-11"
+      }
+    },
+    {
+      "capabilities": [
+        "chat",
         "reasoning",
         "tools",
         "structured_output",
@@ -96519,7 +97818,46 @@
       "description": "Palmyra enterprise models through the Writer chat API.",
       "display_name": "Writer",
       "id": "writer",
-      "models": [],
+      "models": [
+        {
+          "catalog": "writer/palmyra-x6",
+          "id": "palmyra-x6",
+          "lifecycle": "active",
+          "pricing": {
+            "completion_per_1m": 8.0,
+            "currency": "USD",
+            "prompt_per_1m": 2.0
+          },
+          "protocols": [
+            "openai/chat-completions@1"
+          ],
+          "relationship": "first_party",
+          "verification": {
+            "source": "https://dev.writer.com/home/models",
+            "status": "claimed",
+            "verified_at": "2026-09-11"
+          }
+        },
+        {
+          "catalog": "writer/palmyra-x5",
+          "id": "palmyra-x5",
+          "lifecycle": "active",
+          "pricing": {
+            "completion_per_1m": 6.0,
+            "currency": "USD",
+            "prompt_per_1m": 0.6
+          },
+          "protocols": [
+            "openai/chat-completions@1"
+          ],
+          "relationship": "first_party",
+          "verification": {
+            "source": "https://dev.writer.com/home/models",
+            "status": "claimed",
+            "verified_at": "2026-09-11"
+          }
+        }
+      ],
       "path_overrides": {
         "openai/chat-completions@1#create": "/v1/chat"
       },


### PR DESCRIPTION
Related #3606

## Purpose

Covers steps 1 to 3 of #3606 only. Steps 4 and 5 (v1 profile reproduction for the anchor model and artifact publication) need Writer API access and are pending the Workgroup funding decision. No benchmark was run against the Writer API for this PR.

### Model selection and inventory exception

Snapshot of https://dev.writer.com/home/models taken 2026-09-11 and re-reviewed 2026-09-20. Writer lists three API models: Palmyra X6, Palmyra X5, and Palmyra X4. As of the 2026-09-20 review, Writer schedules both X5 and X4 for deprecation on 2026-12-14 with migration to X6, and every older Palmyra line is already deprecated. X6 is the only line not on a deprecation path, so Writer enters the inventory policy with `min_representatives: 1` and X6 as its sole representative. The Palmyra X5 card is kept with `lifecycle: deprecated`, so its mapping and evidence stay visible until Writer removes the model, but it is not a representative. Reviving X4 to reach the default depth is outside the issue scope.

| Card | Writer model ID | Lifecycle | Context / max output | Price in / out per 1M |
|---|---|---|---|---|
| `writer/palmyra-x6` | `palmyra-x6` | active | 1M / 8,192 | $2.00 / $8.00 |
| `writer/palmyra-x5` | `palmyra-x5` | deprecated on 2026-12-14 | 1M / 8,192 | $0.60 / $6.00 |

Both mappings are `first_party` on the existing `writer` provider over `openai/chat-completions@1` (`/v1/chat`). Bedrock aliases (`writer.palmyra-x5-v1:0`, `us.writer.palmyra-x5-v1:0`, `writer.palmyra-x4-v1:0`) are not mirrored: the card schema has no alias field and the issue excludes alias mirroring. X5 carries `vision` because the Writer docs state image analysis is done with Palmyra X5; X6 stays text-only because the docs only claim image handling inside WRITER Agent. No reasoning family is attached to either card.

### Admission evidence

All records are `vendor_claimed` with `reasoning_effort: unspecified` and `observed_at: 2026-09-11`. Each card has six distinct benchmarks in one exact model / effort / provenance bucket, above the five the audit requires. Benchmark revision, harness, tool policy, context length, and endpoint are stored as `unspecified_by_source` wherever the source does not state them. Nothing is imputed, zero-filled, or borrowed across models or efforts.

Palmyra X5 (model catalog page, plus the 2025-04-28 launch post for the last two rows):

| Source label | Catalog identity | Value |
|---|---|---|
| MMLU_PRO | `tiger-ai-lab/mmlu-pro@1.0.0` / published-standard | 0.6502 |
| GPQA | `idavidrein/gpqa@1.0.0` / published-unspecified | 0.472 |
| BBH (Big-Bench Hard) | `maveriq/bigbenchhard@1.0.0` / published-standard | 0.7099 |
| MATH_HARD | `hendrycks/math@1.0.0` / published-hard-subset | 0.7157 |
| OpenAI MRCR 8-needle | `openai/mrcr@1.0.0` / published-8-needle | 0.191 |
| BigCodeBench (Full, Instruct) | `bigcode/bigcodebench@1.0.0` / published-full-instruct | 0.487 |

GPQA is recorded as stated, not upgraded to GPQA Diamond, so it does not fill the Diamond index slot.

Palmyra X6 (model catalog page raw-model table for the first three rows, technical report arXiv:2608.16620v1 for the rest):

| Source label | Catalog identity | Value | Where stated |
|---|---|---|---|
| Finance Agent | `unattributed/finance-agent@1.0.0` | 0.753 | catalog page |
| FinanceQA | `afterquery/financeqa@1.0.0` | 0.673 | catalog page |
| FinanceBench | `patronusai/financebench@1.0.0` | 0.855 | catalog page |
| BFCL Core | `gorilla/bfcl-core@1.0.0` | 0.785 | report abstract and Figure 2 |
| IFBench | `allenai/ifbench@1.0.0` / published-unspecified | 0.737 | report Figure 2 bar label |
| MCP-Atlas | `scale/mcp-atlas@1.0.0` | 0.771 | report Figure 2 bar label |

The X6 capability-score table (sub-agents 0.86, grounding 0.91, MCP tool use 0.88, and so on) is excluded. Writer states those scores measure X6 running inside WRITER Agent, not the API model.

Explicit gaps and caveats:

- No third-party evidence exists for either card. Artificial Analysis, Vals AI Finance Agent, Scale MCP Atlas, BFCL V4, and BigCodeBench leaderboards were checked on 2026-09-11 and list no Palmyra model. The v1 default-index slots stay missing for both cards, apart from X5 MMLU-Pro.
- The technical report also prints Finance Agent 0.773, FinanceQA 0.649, and FinanceBench 0.878 for X6, which differ from the catalog page values. Only the catalog page values are recorded, to avoid two conflicting records for one identity. Reviewer call if the report values should be used instead.
- "Finance Agent" names no owner or version on either Writer source, so it is stored under a separate `unattributed/finance-agent` identity rather than merged into Vals Finance Agent v2. "BFCL Core" is not a category defined by the public BFCL leaderboard and is stored as its own identity with that stated in the profile.
- Writer's X5 benchmark labels (BBH, GPQA, MMLU_PRO, MATH_HARD) match lm-eval-harness leaderboard task names, but the source does not state a harness, so none is recorded.

Anchor for the pending v1 reproduction is `palmyra-x5`. The card schema has no anchor or reproduction-status field, so that status is tracked in the issue only.

### Files

| File | Change |
|---|---|
| `config/catalog/manifest.yaml` | Writer creator with `min_representatives: 1` (X6 only; X5 kept as a deprecated card) |
| `config/catalog/resources/models/single/writer.yaml` | Two physical Model Cards |
| `config/catalog/resources/providers/writer.yaml` | Two first-party mappings with pricing |
| `config/catalog/resources/evaluations/single/writer.yaml` | Twelve vendor-claimed records |
| `config/catalog/resources/benchmarks.yaml` | Seven new benchmark identities, three new profiles on existing ones |
| `config/catalog/README.md` | Baseline counts and the two-representative exception note |
| `dashboard/backend/handlers/model_catalog_test.go` | Contract counts 101 to 103 models, 1509 to 1521 evaluations |
| generated: `config/recipes/built-in/latest/catalog.yaml`, `src/semantic-router/pkg/catalog/zz_generated_catalog.go`, `website/static/model-catalog/catalog.json` | Regenerated projections |

## Test Plan

- `make model-catalog-generate`
- `make model-catalog-check`
- `python3 tools/catalog/audit_model_catalog.py`
- `go test ./pkg/catalog/...` (src/semantic-router)
- `go test ./handlers/ -run ModelCatalog` (dashboard/backend)
- `python3 -m unittest tools/ci/tests/test_model_catalog_snapshot.py`
- `make check CHANGED_FILES="<changed files>"`

## Test Result

- `make model-catalog-generate` and `make model-catalog-check`: pass, 64 catalog tests, generated projections in parity.
- Catalog audit: `writer/palmyra-x5` and `writer/palmyra-x6` each report `best=unspecified/vendor_claimed benchmarks=6`; the five-benchmark admission gate passes for all 86 physical cards.
- `go test ./pkg/catalog/...` (src/semantic-router): pass.
- `go test ./handlers/ -run ModelCatalog` (dashboard/backend): pass with the updated contract counts (103 models, 61 providers, 1521 evaluations).
- `python3 -m unittest tools/ci/tests/test_model_catalog_snapshot.py`: 5 tests pass.
- `make recipe-conformance-static` and `make docs-check-translation-coverage`: pass.
- `pre-commit run --files <changed files>`: all applicable hooks pass (go fmt, model catalog generated projections, md fmt, yamllint, structure check, architecture check, supply chain scan).
- `make check CHANGED_FILES=...` was started but the host killed it for memory during the full `test-semantic-router` and `dashboard-check` suites, so those two were covered by the targeted Go test runs above rather than the full suites.

Remaining blocker: steps 4 and 5 of #3606 need Writer API funding from the Workgroup. No Writer API call was made for this PR.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category, such as `[Feature]`, `[Bug]`, `[Docs]`, `[Test]`, `[Research]`, `[Community]`, or `[CI/Build]`
- [x] The title does not stack prefixes such as `[Router][Docs]`; affected modules belong in labels and the PR body
- [x] The PR links an `accepted` issue with exactly one owner: one `wg/*` label for project work or `owner/maintainers` for repository governance
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>