### PR TITLE
[Bug] Harden agent installation and routing validation

### DIFF
--- a/dashboard/frontend/src/pages/ConfigSchemaReferencePage.tsx
+++ b/dashboard/frontend/src/pages/ConfigSchemaReferencePage.tsx
@@ -72,6 +72,7 @@ const ConfigSchemaReferencePage: React.FC = () => {
         const params = new URLSearchParams({ view: selectionKind })
         if (selectionKind === 'section') {
           params.set('path', selectionValue)
+          params.set('expanded', 'true')
         } else {
           const [kind, ...nameParts] = selectionValue.split(':')
           params.set('kind', kind)

--- a/src/semantic-router/pkg/apiserver/route_config_deploy.go
+++ b/src/semantic-router/pkg/apiserver/route_config_deploy.go
@@ -199,10 +199,7 @@ func (s *ClassificationAPIServer) loadCompatibleRollbackSource(
 		)
 		return nil, false
 	}
-	if err := config.ValidateLocalClassifierReload(
-		currentCfg,
-		backupCfg,
-	); err != nil {
+	if err := validateParsedHotReloadCompatibility(currentCfg, backupCfg); err != nil {
 		s.writeErrorResponse(
 			w,
 			http.StatusConflict,

--- a/src/semantic-router/pkg/apiserver/route_config_schema.go
+++ b/src/semantic-router/pkg/apiserver/route_config_schema.go
@@ -15,6 +15,7 @@ func (s *ClassificationAPIServer) handleConfigSchema(w http.ResponseWriter, r *h
 		Path:        r.URL.Query().Get("path"),
 		SurfaceKind: r.URL.Query().Get("kind"),
 		SurfaceName: r.URL.Query().Get("name"),
+		Expanded:    r.URL.Query().Get("expanded") == "true",
 	})
 	if err != nil {
 		var viewError *configschema.ViewError

--- a/src/semantic-router/pkg/apiserver/route_config_schema_test.go
+++ b/src/semantic-router/pkg/apiserver/route_config_schema_test.go
@@ -87,6 +87,27 @@ func TestConfigSchemaRouteSupportsProgressiveViews(t *testing.T) {
 	if section.Body.Len() >= len(configschema.Document()) {
 		t.Fatalf("section view should be smaller than full schema: section=%d full=%d", section.Body.Len(), len(configschema.Document()))
 	}
+	var sectionDirectory map[string]any
+	if err := json.Unmarshal(section.Body.Bytes(), &sectionDirectory); err != nil {
+		t.Fatalf("decode section directory: %v", err)
+	}
+	sectionMetadata, _ := sectionDirectory["x-vllm-sr-view"].(map[string]any)
+	if sectionMetadata["detail"] != "summary" || sectionDirectory["$defs"] != nil {
+		t.Fatalf("section did not return a compact field directory: %#v", sectionDirectory)
+	}
+
+	expanded := httptest.NewRecorder()
+	server.handleConfigSchema(expanded, httptest.NewRequest(http.MethodGet, "/api/v1/config/schema?view=section&path=global.router.learning&expanded=true", nil))
+	if expanded.Code != http.StatusOK || expanded.Header().Get("Content-Type") != "application/schema+json" {
+		t.Fatalf("expanded status=%d content-type=%q", expanded.Code, expanded.Header().Get("Content-Type"))
+	}
+	var expandedDocument map[string]any
+	if err := json.Unmarshal(expanded.Body.Bytes(), &expandedDocument); err != nil {
+		t.Fatalf("decode expanded section: %v", err)
+	}
+	if expandedDocument["$defs"] == nil {
+		t.Fatal("expanded section omitted referenced definitions")
+	}
 
 	surface := httptest.NewRecorder()
 	server.handleConfigSchema(surface, httptest.NewRequest(http.MethodGet, "/api/v1/config/schema?view=surface&kind=algorithm&name=static", nil))

--- a/src/semantic-router/pkg/apiserver/route_router_config_plan.go
+++ b/src/semantic-router/pkg/apiserver/route_router_config_plan.go
@@ -5,6 +5,7 @@ package apiserver
 import (
 	"bytes"
 	"net/http"
+	"reflect"
 	"strings"
 )
 
@@ -60,8 +61,23 @@ func (s *ClassificationAPIServer) handleConfigPlan(
 	s.writeJSONResponse(w, http.StatusOK, routerConfigPlanResponse{
 		Valid:         true,
 		Mode:          req.Mode,
-		Changed:       !bytes.Equal(current, candidate),
+		Changed:       !equivalentConfigDocuments(current, candidate),
 		CurrentETag:   configDocumentETag(current),
 		CandidateETag: configDocumentETag(candidate),
 	})
+}
+
+func equivalentConfigDocuments(current, candidate []byte) bool {
+	if bytes.Equal(current, candidate) {
+		return true
+	}
+	currentDocument, currentErr := decodeYAMLDocument(current)
+	if currentErr != nil {
+		return false
+	}
+	candidateDocument, candidateErr := decodeYAMLDocument(candidate)
+	if candidateErr != nil {
+		return false
+	}
+	return reflect.DeepEqual(currentDocument, candidateDocument)
 }

--- a/src/semantic-router/pkg/apiserver/route_router_config_plan_test.go
+++ b/src/semantic-router/pkg/apiserver/route_router_config_plan_test.go
@@ -53,6 +53,46 @@ func TestHandleConfigPlanValidatesWithoutMutation(t *testing.T) {
 	}
 }
 
+func TestHandleConfigPlanTreatsFormattingOnlyChangeAsUnchanged(t *testing.T) {
+	configPath := writeDeployTestBaseConfig(t)
+	before, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	body, err := json.Marshal(routerConfigPlanRequest{
+		YAML: string(before),
+		Mode: routerConfigMutationReplace,
+	})
+	if err != nil {
+		t.Fatalf("marshal plan: %v", err)
+	}
+
+	request := httptest.NewRequest(http.MethodPost, apiConfigPlanPath, bytes.NewReader(body))
+	response := httptest.NewRecorder()
+	(&ClassificationAPIServer{configPath: configPath}).handleConfigPlan(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+	}
+	var plan routerConfigPlanResponse
+	if decodeErr := json.Unmarshal(response.Body.Bytes(), &plan); decodeErr != nil {
+		t.Fatalf("decode plan: %v", decodeErr)
+	}
+	if !plan.Valid || plan.Changed {
+		t.Fatalf("formatting-only plan = %+v, want valid and unchanged", plan)
+	}
+	if plan.CurrentETag == plan.CandidateETag {
+		t.Fatalf("test fixture did not produce distinct byte identities: %+v", plan)
+	}
+	after, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config after plan: %v", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("formatting-only plan mutated the source document")
+	}
+}
+
 func TestHandleConfigPlanRejectsUnknownMode(t *testing.T) {
 	configPath := writeDeployTestBaseConfig(t)
 	body, err := json.Marshal(routerConfigPlanRequest{YAML: "version: v0.3\n", Mode: "patch"})

--- a/src/semantic-router/pkg/apiserver/route_router_config_plan_test.go
+++ b/src/semantic-router/pkg/apiserver/route_router_config_plan_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -65,5 +66,39 @@ func TestHandleConfigPlanRejectsUnknownMode(t *testing.T) {
 
 	if response.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+	}
+}
+
+func TestHandleConfigPlanRejectsEnvoyTopologyMutation(t *testing.T) {
+	configPath := writeDeployTestBaseConfig(t)
+	before, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	candidateConfig := minimalDeployTestConfig("old_route")
+	candidateConfig.VLLMEndpoints[0].Port++
+	candidate := mustMarshalCanonicalConfigYAML(t, candidateConfig)
+	body, err := json.Marshal(routerConfigPlanRequest{
+		YAML: string(candidate),
+		Mode: routerConfigMutationReplace,
+	})
+	if err != nil {
+		t.Fatalf("marshal plan: %v", err)
+	}
+
+	request := httptest.NewRequest(http.MethodPost, apiConfigPlanPath, bytes.NewReader(body))
+	response := httptest.NewRecorder()
+	(&ClassificationAPIServer{configPath: configPath}).handleConfigPlan(response, request)
+
+	if response.Code != http.StatusConflict ||
+		!strings.Contains(response.Body.String(), "RESTART_REQUIRED") {
+		t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+	}
+	after, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config after plan: %v", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("restart-required plan mutated the source document")
 	}
 }

--- a/src/semantic-router/pkg/apiserver/route_router_config_update.go
+++ b/src/semantic-router/pkg/apiserver/route_router_config_update.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"time"
 
@@ -167,7 +168,80 @@ func validateHotReloadCompatibility(currentYAML []byte, nextYAML []byte) error {
 	if err != nil {
 		return fmt.Errorf("failed to parse next config for reload validation: %w", err)
 	}
-	return config.ValidateLocalClassifierReload(currentCfg, nextCfg)
+	return validateParsedHotReloadCompatibility(currentCfg, nextCfg)
+}
+
+func validateParsedHotReloadCompatibility(
+	currentCfg *config.RouterConfig,
+	nextCfg *config.RouterConfig,
+) error {
+	if err := config.ValidateLocalClassifierReload(currentCfg, nextCfg); err != nil {
+		return err
+	}
+	if !reflect.DeepEqual(
+		envoyDeploymentProjectionFromConfig(currentCfg),
+		envoyDeploymentProjectionFromConfig(nextCfg),
+	) {
+		return fmt.Errorf(
+			"listener or provider backend topology changed; these fields are rendered into Envoy and cannot be activated by the Router hot-reload API; activate the candidate through the deployment workflow",
+		)
+	}
+	return nil
+}
+
+// envoyDeploymentProjection contains only canonical state rendered into the
+// Envoy listener, route, cluster, and backend-pool configuration. Router-owned
+// model metadata, evaluation evidence, and routing policy remain hot-reloadable.
+type envoyDeploymentProjection struct {
+	Listeners   []config.Listener
+	Endpoints   []envoyEndpointProjection
+	Reliability map[string]config.ProviderReliability
+}
+
+type envoyEndpointProjection struct {
+	Address      string
+	Port         int
+	Weight       int
+	Model        string
+	Protocol     string
+	BaseURL      string
+	ExtraHeaders map[string]string
+}
+
+func envoyDeploymentProjectionFromConfig(
+	cfg *config.RouterConfig,
+) envoyDeploymentProjection {
+	projection := envoyDeploymentProjection{}
+	if cfg == nil {
+		return projection
+	}
+	projection.Listeners = cfg.Listeners
+	if len(cfg.VLLMEndpoints) == 0 {
+		return projection
+	}
+	projection.Endpoints = make([]envoyEndpointProjection, 0, len(cfg.VLLMEndpoints))
+	projection.Reliability = make(map[string]config.ProviderReliability)
+	for _, endpoint := range cfg.VLLMEndpoints {
+		profile := cfg.ProviderProfiles[endpoint.ProviderProfileName]
+		var extraHeaders map[string]string
+		if len(profile.ExtraHeaders) > 0 {
+			extraHeaders = profile.ExtraHeaders
+		}
+		projection.Endpoints = append(projection.Endpoints, envoyEndpointProjection{
+			Address:      endpoint.Address,
+			Port:         endpoint.Port,
+			Weight:       endpoint.Weight,
+			Model:        endpoint.Model,
+			Protocol:     endpoint.Protocol,
+			BaseURL:      profile.BaseURL,
+			ExtraHeaders: extraHeaders,
+		})
+		if endpoint.Model == "" {
+			continue
+		}
+		projection.Reliability[endpoint.Model] = cfg.ModelConfig[endpoint.Model].Reliability
+	}
+	return projection
 }
 
 func normalizeRouterConfigDocument(doc map[string]any) ([]byte, error) {

--- a/src/semantic-router/pkg/apiserver/route_router_config_validate_test.go
+++ b/src/semantic-router/pkg/apiserver/route_router_config_validate_test.go
@@ -161,6 +161,34 @@ func TestValidateHotReloadCompatibilityRejectsLocalClassifierChange(t *testing.T
 	}
 }
 
+func TestValidateHotReloadCompatibilityRejectsEnvoyTopologyChange(t *testing.T) {
+	current := minimalDeployTestConfig("route")
+	next := minimalDeployTestConfig("route")
+	next.VLLMEndpoints[0].Port++
+
+	currentYAML := mustMarshalCanonicalConfigYAML(t, current)
+	nextYAML := mustMarshalCanonicalConfigYAML(t, next)
+	err := validateHotReloadCompatibility(currentYAML, nextYAML)
+	if err == nil {
+		t.Fatal("expected restart-required Envoy topology error")
+	}
+	if !strings.Contains(err.Error(), "deployment workflow") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateHotReloadCompatibilityAllowsRouterPolicyChange(t *testing.T) {
+	current := minimalDeployTestConfig("before")
+	next := minimalDeployTestConfig("after")
+
+	if err := validateHotReloadCompatibility(
+		mustMarshalCanonicalConfigYAML(t, current),
+		mustMarshalCanonicalConfigYAML(t, next),
+	); err != nil {
+		t.Fatalf("routing-only change should be hot-reloadable: %v", err)
+	}
+}
+
 func localClassifierReloadConfig(modelPath string) string {
 	return `
 version: v0.3

--- a/src/semantic-router/pkg/apiserver/routes_catalog.go
+++ b/src/semantic-router/pkg/apiserver/routes_catalog.go
@@ -342,6 +342,7 @@ func apiNonRecipeConfigRoutes() []apiRoute {
 				Parameters: []OpenAPIParameter{
 					{Name: "view", In: "query", Description: "Representation to return. Omit for the compact index; use full for the complete schema.", Schema: OpenAPISchema{Type: "string", Enum: []string{"full", "index", "section", "surface"}}},
 					{Name: "path", In: "query", Description: "Dot- or slash-delimited config path required by view=section.", Schema: OpenAPISchema{Type: "string"}},
+					{Name: "expanded", In: "query", Description: "Return a self-contained JSON Schema for view=section instead of its compact field directory.", Schema: OpenAPISchema{Type: "boolean"}},
 					{Name: "kind", In: "query", Description: "Surface kind required by view=surface.", Schema: OpenAPISchema{Type: "string", Enum: []string{"signal", "algorithm", "plugin", "projection"}}},
 					{Name: "name", In: "query", Description: "Registered surface name required by view=surface.", Schema: OpenAPISchema{Type: "string"}},
 				},

--- a/src/semantic-router/pkg/configschema/view.go
+++ b/src/semantic-router/pkg/configschema/view.go
@@ -24,6 +24,7 @@ type ViewOptions struct {
 	Path        string
 	SurfaceKind string
 	SurfaceName string
+	Expanded    bool
 }
 
 // Representation is one cacheable schema response.
@@ -71,6 +72,34 @@ type schemaIndex struct {
 	Surfaces        map[string]surfaceIndex `json:"surfaces"`
 }
 
+type sectionField struct {
+	Name        string `json:"name"`
+	Path        string `json:"path"`
+	Type        string `json:"type"`
+	Required    bool   `json:"required"`
+	Description string `json:"description,omitempty"`
+	Href        string `json:"href"`
+	Const       any    `json:"const,omitempty"`
+	Default     any    `json:"default,omitempty"`
+	Enum        any    `json:"enum,omitempty"`
+	Minimum     any    `json:"minimum,omitempty"`
+	Maximum     any    `json:"maximum,omitempty"`
+}
+
+type sectionSummary struct {
+	View         map[string]any `json:"x-vllm-sr-view"`
+	Shape        string         `json:"shape"`
+	Title        string         `json:"title"`
+	Description  string         `json:"description,omitempty"`
+	Fields       []sectionField `json:"fields"`
+	ExpandedHref string         `json:"expanded_href"`
+	Const        any            `json:"const,omitempty"`
+	Default      any            `json:"default,omitempty"`
+	Enum         any            `json:"enum,omitempty"`
+	Minimum      any            `json:"minimum,omitempty"`
+	Maximum      any            `json:"maximum,omitempty"`
+}
+
 // Render returns the requested full, index, section, or routing-surface view.
 func Render(options ViewOptions) (Representation, error) {
 	view := strings.ToLower(strings.TrimSpace(options.View))
@@ -92,8 +121,10 @@ func Render(options ViewOptions) (Representation, error) {
 	case ViewIndex:
 		payload, err = buildIndex(document)
 	case ViewSection:
-		contentType = "application/schema+json"
-		payload, err = buildSection(document, options.Path)
+		if options.Expanded {
+			contentType = "application/schema+json"
+		}
+		payload, err = buildSection(document, options.Path, options.Expanded)
 	case ViewSurface:
 		contentType = "application/schema+json"
 		payload, err = buildSurface(document, options.SurfaceKind, options.SurfaceName)
@@ -190,7 +221,7 @@ func buildIndex(document map[string]any) (schemaIndex, error) {
 		DefaultView:     ViewIndex,
 		Views: []viewDescriptor{
 			{Name: ViewIndex, Description: "Compact section and routing-surface directory.", Href: SchemaEndpoint + "?view=index"},
-			{Name: ViewSection, Description: "One config path with only its transitive schema definitions.", Href: SchemaEndpoint + "?view=section&path={path}"},
+			{Name: ViewSection, Description: "Compact field directory for one config path; request expanded=true for its self-contained JSON Schema.", Href: SchemaEndpoint + "?view=section&path={path}"},
 			{Name: ViewSurface, Description: "One signal, algorithm, plugin, or projection contract.", Href: SchemaEndpoint + "?view=surface&kind={kind}&name={name}"},
 			{Name: ViewFull, Description: "Complete canonical JSON Schema.", Href: SchemaEndpoint + "?view=full"},
 		},
@@ -199,7 +230,7 @@ func buildIndex(document map[string]any) (schemaIndex, error) {
 	}, nil
 }
 
-func buildSection(document map[string]any, path string) (map[string]any, error) {
+func buildSection(document map[string]any, path string, expanded bool) (any, error) {
 	path = strings.TrimSpace(path)
 	if path == "" {
 		return nil, &ViewError{Message: "section view requires a non-empty path"}
@@ -209,10 +240,15 @@ func buildSection(document map[string]any, path string) (map[string]any, error) 
 	if err != nil {
 		return nil, &ViewError{Message: err.Error()}
 	}
-	return focusedSchema(document, node, map[string]any{
-		"view": ViewSection,
-		"path": strings.Join(segments, "."),
-	})
+	normalizedPath := strings.Join(segments, ".")
+	if expanded {
+		return focusedSchema(document, node, map[string]any{
+			"view":   ViewSection,
+			"path":   normalizedPath,
+			"detail": "expanded",
+		})
+	}
+	return summarizeSection(document, node, normalizedPath)
 }
 
 func buildSurface(document map[string]any, kind, name string) (map[string]any, error) {
@@ -299,6 +335,124 @@ func schemaAtPath(document map[string]any, segments []string) (map[string]any, e
 		current = next
 	}
 	return current, nil
+}
+
+func summarizeSection(document, node map[string]any, path string) (sectionSummary, error) {
+	root, err := resolveSchemaNode(document, node)
+	if err != nil {
+		return sectionSummary{}, err
+	}
+	fieldRoot := root
+	if root["type"] == "array" {
+		items, _ := root["items"].(map[string]any)
+		fieldRoot, err = resolveSchemaNode(document, items)
+		if err != nil {
+			return sectionSummary{}, err
+		}
+	}
+
+	properties, _ := fieldRoot["properties"].(map[string]any)
+	names := make([]string, 0, len(properties))
+	for name := range properties {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	required := stringSet(fieldRoot["required"])
+	fields := make([]sectionField, 0, len(names))
+	for _, name := range names {
+		child, _ := properties[name].(map[string]any)
+		resolved, resolveErr := resolveSchemaNode(document, child)
+		if resolveErr != nil {
+			return sectionSummary{}, resolveErr
+		}
+		childPath := path + "." + name
+		field := sectionField{
+			Name:        name,
+			Path:        childPath,
+			Type:        schemaNodeType(document, child),
+			Required:    required[name],
+			Description: firstString(resolved, "description", firstString(child, "description", "")),
+			Href:        SchemaEndpoint + "?view=section&path=" + url.QueryEscape(childPath),
+		}
+		field.Const, field.Default, field.Enum, field.Minimum, field.Maximum = sectionConstraints(resolved)
+		fields = append(fields, field)
+	}
+
+	summary := sectionSummary{
+		View: map[string]any{
+			"view":   ViewSection,
+			"path":   path,
+			"detail": "summary",
+		},
+		Shape:        schemaNodeType(document, node),
+		Title:        firstString(fieldRoot, "title", firstString(root, "title", displayName(path))),
+		Description:  firstString(fieldRoot, "description", firstString(root, "description", "")),
+		Fields:       fields,
+		ExpandedHref: SchemaEndpoint + "?view=section&path=" + url.QueryEscape(path) + "&expanded=true",
+	}
+	summary.Const, summary.Default, summary.Enum, summary.Minimum, summary.Maximum = sectionConstraints(root)
+	return summary, nil
+}
+
+func schemaNodeType(document, node map[string]any) string {
+	resolved, err := resolveSchemaNode(document, node)
+	if err != nil {
+		return "value"
+	}
+	switch nodeType := resolved["type"].(type) {
+	case string:
+		if nodeType != "array" {
+			return nodeType
+		}
+		items, _ := resolved["items"].(map[string]any)
+		return "array<" + schemaNodeType(document, items) + ">"
+	case []any:
+		parts := make([]string, 0, len(nodeType))
+		for _, value := range nodeType {
+			if typed, ok := value.(string); ok {
+				parts = append(parts, typed)
+			}
+		}
+		if len(parts) > 0 {
+			return strings.Join(parts, " | ")
+		}
+	}
+	for _, alternativesKey := range []string{"oneOf", "anyOf"} {
+		alternatives, _ := resolved[alternativesKey].([]any)
+		parts := make([]string, 0, len(alternatives))
+		seen := make(map[string]bool)
+		for _, rawAlternative := range alternatives {
+			alternative, _ := rawAlternative.(map[string]any)
+			part := schemaNodeType(document, alternative)
+			if !seen[part] {
+				seen[part] = true
+				parts = append(parts, part)
+			}
+		}
+		if len(parts) > 0 {
+			return strings.Join(parts, " | ")
+		}
+	}
+	if value, ok := resolved["const"]; ok {
+		switch value.(type) {
+		case string:
+			return "string"
+		case bool:
+			return "boolean"
+		case float64, int:
+			return "number"
+		case nil:
+			return "null"
+		}
+	}
+	if _, ok := resolved["properties"].(map[string]any); ok {
+		return "object"
+	}
+	return "value"
+}
+
+func sectionConstraints(source map[string]any) (any, any, any, any, any) {
+	return source["const"], source["default"], source["enum"], source["minimum"], source["maximum"]
 }
 
 func resolveSchemaNode(document, node map[string]any) (map[string]any, error) {

--- a/src/semantic-router/pkg/configschema/view_test.go
+++ b/src/semantic-router/pkg/configschema/view_test.go
@@ -2,6 +2,7 @@ package configschema
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -44,6 +45,26 @@ func TestRenderFocusedViewsIncludeOnlyReferencedDefinitions(t *testing.T) {
 	if metadata["path"] != "global.router.learning" {
 		t.Fatalf("section metadata=%v", metadata)
 	}
+	if metadata["detail"] != "summary" || sectionDocument["$defs"] != nil {
+		t.Fatalf("section is not compact: %#v", sectionDocument)
+	}
+	fields, _ := sectionDocument["fields"].([]any)
+	if len(fields) == 0 {
+		t.Fatalf("section field directory is empty: %#v", sectionDocument)
+	}
+
+	expanded, err := Render(ViewOptions{View: ViewSection, Path: "global.router.learning", Expanded: true})
+	if err != nil {
+		t.Fatalf("render expanded section: %v", err)
+	}
+	var expandedDocument map[string]any
+	if decodeErr := json.Unmarshal(expanded.Body, &expandedDocument); decodeErr != nil {
+		t.Fatalf("decode expanded section: %v", decodeErr)
+	}
+	expandedMetadata, _ := expandedDocument["x-vllm-sr-view"].(map[string]any)
+	if expandedMetadata["detail"] != "expanded" || expandedDocument["$defs"] == nil {
+		t.Fatalf("expanded section is incomplete: %#v", expandedDocument)
+	}
 
 	surface, err := Render(ViewOptions{View: ViewSurface, SurfaceKind: "signal", SurfaceName: "keyword"})
 	if err != nil {
@@ -69,12 +90,12 @@ func TestRenderTopLevelCollectionAndScalarSections(t *testing.T) {
 		if err := json.Unmarshal(section.Body, &document); err != nil {
 			t.Fatalf("decode %s section: %v", path, err)
 		}
-		if document["type"] != "array" || document["items"] == nil {
-			t.Fatalf("%s section does not describe array items: %#v", path, document)
+		if shape, _ := document["shape"].(string); !strings.HasPrefix(shape, "array<") {
+			t.Fatalf("%s section does not describe its array shape: %#v", path, document)
 		}
-		definitions, ok := document["$defs"].(map[string]any)
-		if !ok || len(definitions) == 0 {
-			t.Fatalf("%s section is missing its item definitions", path)
+		fields, ok := document["fields"].([]any)
+		if !ok || len(fields) == 0 {
+			t.Fatalf("%s section is missing its item field directory", path)
 		}
 	}
 
@@ -86,7 +107,7 @@ func TestRenderTopLevelCollectionAndScalarSections(t *testing.T) {
 	if err := json.Unmarshal(version.Body, &document); err != nil {
 		t.Fatalf("decode version section: %v", err)
 	}
-	if document["type"] != "string" || document["const"] != ConfigVersion {
+	if document["shape"] != "string" || document["const"] != ConfigVersion {
 		t.Fatalf("version section does not publish its fixed scalar value: %#v", document)
 	}
 }

--- a/src/vllm-sr/cli/chat_client.py
+++ b/src/vllm-sr/cli/chat_client.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import Any
-from urllib.parse import urljoin
 
 import requests
 
@@ -87,7 +86,14 @@ def build_chat_payload(
 
 
 def chat_completions_url(base: str) -> str:
-    return urljoin(base.rstrip("/") + "/", CHAT_COMPLETIONS_PATH.lstrip("/"))
+    """Resolve a chat-completions URL from an origin or OpenAI ``/v1`` root."""
+
+    normalized = normalize_base_url(base)
+    if normalized.endswith(CHAT_COMPLETIONS_PATH):
+        return normalized
+    if normalized.endswith("/v1"):
+        return normalized + "/chat/completions"
+    return normalized + CHAT_COMPLETIONS_PATH
 
 
 def extract_assistant_text(data: dict[str, Any]) -> str:

--- a/src/vllm-sr/cli/commands/chat.py
+++ b/src/vllm-sr/cli/commands/chat.py
@@ -54,7 +54,10 @@ log = get_logger(__name__)
 @click.option(
     "--base-url",
     default=None,
-    help="Explicit routed HTTP base URL for a remote or port-forwarded stack.",
+    help=(
+        "Explicit routed listener origin or OpenAI /v1 base URL for a remote "
+        "or port-forwarded stack."
+    ),
 )
 @click.option(
     "--json",

--- a/src/vllm-sr/cli/commands/config.py
+++ b/src/vllm-sr/cli/commands/config.py
@@ -62,6 +62,7 @@ def config_schema_command(
     full: bool = False,
     section: str | None = None,
     surface: str | None = None,
+    expanded: bool = False,
     timeout: float = 15,
     token_env: str = "VSR_MGMT_TOKEN",
 ) -> None:
@@ -70,6 +71,8 @@ def config_schema_command(
     selected = sum((full, section is not None, surface is not None))
     if selected > 1:
         raise ValueError("use only one of --full, --section, or --surface")
+    if expanded and section is None:
+        raise ValueError("--expanded requires --section")
     view = (
         "full" if full else "section" if section else "surface" if surface else "index"
     )
@@ -90,6 +93,7 @@ def config_schema_command(
                 path=section,
                 surface_kind=surface_kind,
                 surface_name=surface_name,
+                expanded=expanded,
             )
             .payload
         )
@@ -102,6 +106,7 @@ def config_schema_command(
         path=section,
         surface_kind=surface_kind,
         surface_name=surface_name,
+        expanded=expanded,
     )
     echo(json.dumps(document, indent=2, sort_keys=True) + "\n", nl=False)
 

--- a/src/vllm-sr/cli/commands/config.py
+++ b/src/vllm-sr/cli/commands/config.py
@@ -24,6 +24,36 @@ from cli.validator import (
 )
 
 log = get_logger(__name__)
+CONFIG_TEMPLATE_PATH = (
+    Path(__file__).resolve().parents[1] / "templates" / "config.template.yaml"
+)
+
+
+def init_config_command(
+    output_path: str = "config.yaml",
+    *,
+    force: bool = False,
+) -> Path:
+    """Write the packaged minimal canonical configuration template."""
+
+    destination = Path(output_path)
+    if destination.exists():
+        if destination.is_dir():
+            raise ValueError(f"Config output path is a directory: {destination}")
+        if not force:
+            raise ValueError(
+                f"Config file already exists: {destination}. Use --force to overwrite it."
+            )
+    try:
+        template = CONFIG_TEMPLATE_PATH.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise RuntimeError("packaged config template is unavailable") from exc
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(template, encoding="utf-8")
+
+    success("Configuration template created")
+    fields((("Output", destination),))
+    return destination
 
 
 def config_schema_command(

--- a/src/vllm-sr/cli/commands/general.py
+++ b/src/vllm-sr/cli/commands/general.py
@@ -10,9 +10,9 @@ import click
 from cli.commands.common import exit_with_logged_error
 from cli.commands.config import (
     config_command,
-    init_config_command,
     config_schema_command,
     import_config_from_source_command,
+    init_config_command,
     migrate_config_command,
 )
 from cli.commands.config_management import CONFIG_MANAGEMENT_COMMANDS
@@ -116,6 +116,11 @@ def config_router(config_path: str) -> None:
     metavar="KIND:NAME",
     help="Print one signal, algorithm, plugin, or projection contract.",
 )
+@click.option(
+    "--expanded",
+    is_flag=True,
+    help="Include the selected section's self-contained JSON Schema.",
+)
 @exit_with_logged_error(log)
 def config_schema(
     endpoint: str | None,
@@ -124,6 +129,7 @@ def config_schema(
     full: bool,
     section: str | None,
     surface: str | None,
+    expanded: bool,
 ) -> None:
     """Discover the canonical config contract progressively."""
 
@@ -132,6 +138,7 @@ def config_schema(
         full=full,
         section=section,
         surface=surface,
+        expanded=expanded,
         timeout=timeout,
         token_env=token_env,
     )

--- a/src/vllm-sr/cli/commands/general.py
+++ b/src/vllm-sr/cli/commands/general.py
@@ -10,6 +10,7 @@ import click
 from cli.commands.common import exit_with_logged_error
 from cli.commands.config import (
     config_command,
+    init_config_command,
     config_schema_command,
     import_config_from_source_command,
     migrate_config_command,
@@ -33,6 +34,7 @@ def config(ctx: click.Context) -> None:
     Examples:
         vllm-sr config envoy
         vllm-sr config router
+        vllm-sr config init --output config.yaml
         vllm-sr config envoy --config my-config.yaml
         vllm-sr config migrate --config old.yaml
         vllm-sr config import --from openclaw --source openclaw.json
@@ -40,6 +42,25 @@ def config(ctx: click.Context) -> None:
     if ctx.invoked_subcommand is not None:
         return
     click.echo(ctx.get_help())
+
+
+@config.command("init")
+@click.option(
+    "--output",
+    default="config.yaml",
+    show_default=True,
+    help="Path for the new canonical configuration template.",
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    help="Overwrite the output file if it already exists.",
+)
+@exit_with_logged_error(log)
+def config_init(output: str, force: bool) -> None:
+    """Create a minimal canonical configuration template."""
+
+    init_config_command(output, force=force)
 
 
 @config.command("envoy")

--- a/src/vllm-sr/cli/commands/route.py
+++ b/src/vllm-sr/cli/commands/route.py
@@ -309,11 +309,13 @@ def _routing_receipt_headers(response: requests.Response) -> dict[str, str]:
 def _probe_assertions(
     *,
     response: requests.Response,
+    response_body: Any,
     expected_status: int,
     expected_recipe: str | None,
     expected_decision: str | None,
     expected_algorithm: str | None,
-    expected_model: str | None,
+    expected_selected_model: str | None,
+    expected_response_model: str | None,
 ) -> list[dict[str, Any]]:
     assertions: list[dict[str, Any]] = [
         {
@@ -327,7 +329,7 @@ def _probe_assertions(
         "x-vsr-selected-recipe": expected_recipe,
         "x-vsr-selected-decision": expected_decision,
         "x-vsr-selected-algorithm": expected_algorithm,
-        "x-vsr-selected-model": expected_model,
+        "x-vsr-selected-model": expected_selected_model,
     }
     for header, expected in expectations.items():
         if expected is None:
@@ -339,6 +341,18 @@ def _probe_assertions(
                 "expected": expected,
                 "actual": actual,
                 "passed": actual == expected,
+            }
+        )
+    if expected_response_model is not None:
+        actual = (
+            response_body.get("model", "") if isinstance(response_body, dict) else ""
+        )
+        assertions.append(
+            {
+                "field": "response.body.model",
+                "expected": expected_response_model,
+                "actual": actual,
+                "passed": actual == expected_response_model,
             }
         )
     return assertions
@@ -378,7 +392,16 @@ def _probe_assertions(
 @click.option("--expect-recipe", default=None)
 @click.option("--expect-decision", default=None)
 @click.option("--expect-algorithm", default=None)
-@click.option("--expect-model", default=None)
+@click.option(
+    "--expect-selected-model",
+    default=None,
+    help="Assert the Router's x-vsr-selected-model receipt header.",
+)
+@click.option(
+    "--expect-response-model",
+    default=None,
+    help="Assert the upstream OpenAI response body's top-level model field.",
+)
 @exit_with_logged_error(log)
 def probe(
     prompt: str | None,
@@ -395,7 +418,8 @@ def probe(
     expect_recipe: str | None,
     expect_decision: str | None,
     expect_algorithm: str | None,
-    expect_model: str | None,
+    expect_selected_model: str | None,
+    expect_response_model: str | None,
 ) -> None:
     """Send one real routed request and emit a machine-readable evidence receipt."""
 
@@ -430,13 +454,16 @@ def probe(
             f"Failed to probe routed endpoint {redact_url(url)}: {exc}"
         ) from exc
     latency_ms = round((time.monotonic() - started) * 1000, 3)
+    response_body = _response_body(response)
     assertions = _probe_assertions(
         response=response,
+        response_body=response_body,
         expected_status=expect_status,
         expected_recipe=expect_recipe,
         expected_decision=expect_decision,
         expected_algorithm=expect_algorithm,
-        expected_model=expect_model,
+        expected_selected_model=expect_selected_model,
+        expected_response_model=expect_response_model,
     )
     passed = all(assertion["passed"] for assertion in assertions)
     receipt = {
@@ -451,7 +478,7 @@ def probe(
             "status": response.status_code,
             "latency_ms": latency_ms,
             "routing": _routing_receipt_headers(response),
-            "body": _response_body(response),
+            "body": response_body,
         },
         "assertions": assertions,
     }

--- a/src/vllm-sr/cli/commands/route.py
+++ b/src/vllm-sr/cli/commands/route.py
@@ -8,12 +8,11 @@ import time
 from dataclasses import dataclass
 from http import HTTPStatus
 from typing import Any
-from urllib.parse import urljoin
 
 import click
 import requests
 
-from cli.chat_client import CHAT_COMPLETIONS_PATH, resolve_chat_base_url
+from cli.chat_client import chat_completions_url, resolve_chat_base_url
 from cli.commands.common import exit_with_logged_error
 from cli.commands.eval_rendering import render_route_preview_summary
 from cli.router_management_client import RouterManagementClient
@@ -358,7 +357,10 @@ def _probe_assertions(
 @click.option(
     "--base-url",
     default=None,
-    help="Explicit Envoy-routed base URL; otherwise derive it from --config.",
+    help=(
+        "Explicit Envoy listener origin or OpenAI /v1 base URL; otherwise "
+        "derive it from --config."
+    ),
 )
 @click.option(
     "--api-key-env",
@@ -409,7 +411,7 @@ def probe(
         target=target,
         base_url=base_url,
     )
-    url = urljoin(base.rstrip("/") + "/", CHAT_COMPLETIONS_PATH.lstrip("/"))
+    url = chat_completions_url(base)
     payload: dict[str, Any] = {"model": model, "messages": messages}
     if temperature is not None:
         payload["temperature"] = temperature

--- a/src/vllm-sr/cli/commands/runtime.py
+++ b/src/vllm-sr/cli/commands/runtime.py
@@ -167,6 +167,7 @@ def _deploy_serve_backend(
 
 def _execute_serve(
     config: str,
+    replace_active_config: bool,
     image: str | None,
     router_image: str | None,
     envoy_image: str | None,
@@ -205,6 +206,7 @@ def _execute_serve(
                 source_setup_mode=source_setup_mode,
                 platform=platform,
                 recipe_env_bindings=recipe_env_bindings,
+                replace_active_config=replace_active_config,
             )
         )
         validate_setup_mode_flags(setup_mode, minimal, readonly)
@@ -253,6 +255,14 @@ def _execute_serve(
     default="config.yaml",
     show_default=True,
     help="Path to the Router configuration.",
+)
+@click.option(
+    "--replace-active-config",
+    is_flag=True,
+    help=(
+        "Replace this local Docker stack's active runtime config from --config, "
+        "discarding Dashboard edits."
+    ),
 )
 @click.option(
     "--image",
@@ -365,6 +375,7 @@ def _execute_serve(
 @exit_with_logged_error(log, interrupt_message="\nInterrupted by user")
 def serve(
     config: str,
+    replace_active_config: bool,
     image: str | None,
     router_image: str | None,
     envoy_image: str | None,
@@ -385,6 +396,7 @@ def serve(
 ) -> None:
     _execute_serve(
         config,
+        replace_active_config,
         image,
         router_image,
         envoy_image,

--- a/src/vllm-sr/cli/commands/runtime_help.py
+++ b/src/vllm-sr/cli/commands/runtime_help.py
@@ -45,6 +45,8 @@ Examples:
   vllm-sr serve
   # User-owned single or multi-model topology
   vllm-sr serve --config my-models.yaml
+  # Explicitly replace Dashboard-edited runtime state from reviewed source YAML
+  vllm-sr serve --config my-models.yaml --replace-active-config
   # Deploy a user-owned config to Kubernetes
   vllm-sr serve --target k8s --config my-models.yaml --namespace my-ns
   # Runtime policy and image overrides

--- a/src/vllm-sr/cli/commands/runtime_paths.py
+++ b/src/vllm-sr/cli/commands/runtime_paths.py
@@ -429,12 +429,15 @@ def materialize_runtime_config(
     *,
     state_root_dir: str | Path | None = None,
     stack_name: str | None = None,
+    replace_active: bool = False,
 ) -> Path:
     """Reconcile one runtime-owned active config without overwriting edits.
 
     The CLI records the digest it last materialized. A Dashboard or package
     activation changes the active digest without changing that receipt, so a
     later ``serve`` preserves the active file and reports the divergence.
+    ``replace_active`` is the explicit deployment boundary for replacing that
+    drifted active document from the selected source config.
     """
 
     source_config_path = source_config_path.expanduser().absolute()
@@ -455,6 +458,16 @@ def materialize_runtime_config(
         active_data = runtime_config_path.read_bytes()
         if active_data == effective_data:
             _write_provenance(provenance_path, source_data, active_data)
+            return runtime_config_path
+
+        if replace_active:
+            log.info(
+                "Replacing active runtime config %s from source config %s",
+                runtime_config_path,
+                source_config_path,
+            )
+            _atomic_write_private_bytes(runtime_config_path, effective_data)
+            _write_provenance(provenance_path, source_data, effective_data)
             return runtime_config_path
 
         try:

--- a/src/vllm-sr/cli/commands/runtime_serve_config.py
+++ b/src/vllm-sr/cli/commands/runtime_serve_config.py
@@ -43,6 +43,7 @@ def _prepare_docker_runtime_config(
     source_setup_mode: bool,
     platform: str | None,
     recipe_env_bindings: tuple[str, ...],
+    replace_active_config: bool,
 ):
     stack_layout = resolve_runtime_stack()
     state_root_dir = (
@@ -73,6 +74,12 @@ def _prepare_docker_runtime_config(
             state_root_dir=state_root_dir, stack_name=stack_layout.stack_name
         )
         if package_active:
+            if replace_active_config:
+                raise ValueError(
+                    "--replace-active-config cannot replace an active Recipe "
+                    "package; change or deactivate that package through the "
+                    "Recipe workflow first"
+                )
             # Authorize against what the package declares, not against what
             # the CLI materialized. The runtime config also carries the CLI's
             # own references -- this stack's generated storage credentials --
@@ -98,6 +105,7 @@ def _prepare_docker_runtime_config(
                 effective_config_bytes,
                 state_root_dir=state_root_dir,
                 stack_name=stack_layout.stack_name,
+                replace_active=replace_active_config,
             )
         setup_mode = is_setup_mode_config(effective_config_path)
         return effective_config_path, setup_mode, runtime_lock
@@ -114,12 +122,17 @@ def _prepare_effective_serve_config(
     source_setup_mode: bool,
     platform: str | None,
     recipe_env_bindings: tuple[str, ...],
+    replace_active_config: bool,
 ):
     """Prepare the target-specific active config and its optional runtime lock."""
 
     if resolved_target != "docker" and recipe_env_bindings:
         raise ValueError(
             "--recipe-env is supported only for local Docker Recipe packages"
+        )
+    if resolved_target != "docker" and replace_active_config:
+        raise ValueError(
+            "--replace-active-config is supported only for local Docker deployments"
         )
     if resolved_target == "docker":
         effective_path, setup_mode, runtime_lock = _prepare_docker_runtime_config(
@@ -128,6 +141,7 @@ def _prepare_effective_serve_config(
             source_setup_mode,
             platform,
             recipe_env_bindings,
+            replace_active_config,
         )
         return effective_path, setup_mode, runtime_lock, None
 

--- a/src/vllm-sr/cli/config_schema/views.py
+++ b/src/vllm-sr/cli/config_schema/views.py
@@ -19,6 +19,7 @@ def schema_view(
     path: str | None = None,
     surface_kind: str | None = None,
     surface_name: str | None = None,
+    expanded: bool = False,
 ) -> dict[str, Any]:
     """Return one full, index, section, or routing-surface representation."""
 
@@ -28,7 +29,7 @@ def schema_view(
     if normalized_view == "index":
         return _index(document)
     if normalized_view == "section":
-        return _section(document, path or "")
+        return _section(document, path or "", expanded=expanded)
     if normalized_view == "surface":
         return _surface(document, surface_kind or "", surface_name or "")
     raise ValueError(
@@ -103,7 +104,10 @@ def _index(document: dict[str, Any]) -> dict[str, Any]:
             },
             {
                 "name": "section",
-                "description": "One config path with only its transitive schema definitions.",
+                "description": (
+                    "Compact field directory for one config path; request "
+                    "expanded=true for its self-contained JSON Schema."
+                ),
                 "href": f"{SCHEMA_ENDPOINT}?view=section&path={{path}}",
             },
             {
@@ -122,7 +126,7 @@ def _index(document: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _section(document: dict[str, Any], path: str) -> dict[str, Any]:
+def _section(document: dict[str, Any], path: str, *, expanded: bool) -> dict[str, Any]:
     segments = [segment.strip() for segment in path.replace("/", ".").split(".")]
     segments = [segment for segment in segments if segment]
     if not segments:
@@ -141,11 +145,107 @@ def _section(document: dict[str, Any], path: str) -> dict[str, Any]:
                 f"at {'.'.join(traversed)!r}"
             )
         node = child
-    return _focused(
-        document,
-        node,
-        {"view": "section", "path": ".".join(segments)},
-    )
+    normalized_path = ".".join(segments)
+    if expanded:
+        return _focused(
+            document,
+            node,
+            {"view": "section", "path": normalized_path, "detail": "expanded"},
+        )
+    return _section_summary(document, node, normalized_path)
+
+
+def _section_summary(
+    document: dict[str, Any], node: dict[str, Any], path: str
+) -> dict[str, Any]:
+    root = _resolve(document, node)
+    field_root = root
+    if root.get("type") == "array":
+        field_root = _resolve(document, root.get("items", {}))
+
+    required = set(field_root.get("required", []))
+    properties = field_root.get("properties", {})
+    fields = []
+    for name in sorted(properties):
+        child = properties[name]
+        if not isinstance(child, dict):
+            continue
+        resolved = _resolve(document, child)
+        child_path = f"{path}.{name}"
+        field = {
+            "name": name,
+            "path": child_path,
+            "type": _schema_type(document, child),
+            "required": name in required,
+            "href": (f"{SCHEMA_ENDPOINT}?view=section&path={quote_plus(child_path)}"),
+        }
+        if description := resolved.get("description") or child.get("description"):
+            field["description"] = description
+        _copy_constraints(resolved, field)
+        fields.append(field)
+
+    summary = {
+        "x-vllm-sr-view": {
+            "view": "section",
+            "path": path,
+            "detail": "summary",
+        },
+        "shape": _schema_type(document, node),
+        "title": field_root.get("title") or root.get("title") or _display_name(path),
+        "fields": fields,
+        "expanded_href": (
+            f"{SCHEMA_ENDPOINT}?view=section&path={quote_plus(path)}&expanded=true"
+        ),
+    }
+    if description := field_root.get("description") or root.get("description"):
+        summary["description"] = description
+    _copy_constraints(root, summary)
+    return summary
+
+
+def _schema_type(document: dict[str, Any], node: dict[str, Any]) -> str:
+    resolved = _resolve(document, node)
+    node_type = resolved.get("type")
+    if isinstance(node_type, list):
+        return " | ".join(str(value) for value in node_type)
+    if node_type == "array":
+        item = resolved.get("items")
+        item_type = _schema_type(document, item) if isinstance(item, dict) else "value"
+        return f"array<{item_type}>"
+    if isinstance(node_type, str):
+        return node_type
+    for alternatives_key in ("oneOf", "anyOf"):
+        alternatives = resolved.get(alternatives_key)
+        if not isinstance(alternatives, list):
+            continue
+        types = []
+        for alternative in alternatives:
+            if not isinstance(alternative, dict):
+                continue
+            alternative_type = _schema_type(document, alternative)
+            if alternative_type not in types:
+                types.append(alternative_type)
+        if types:
+            return " | ".join(types)
+    if "const" in resolved:
+        constant = resolved["const"]
+        if constant is None:
+            return "null"
+        if isinstance(constant, bool):
+            return "boolean"
+        if isinstance(constant, str):
+            return "string"
+        if isinstance(constant, (int, float)):
+            return "number"
+    if isinstance(resolved.get("properties"), dict):
+        return "object"
+    return "value"
+
+
+def _copy_constraints(source: dict[str, Any], target: dict[str, Any]) -> None:
+    for key in ("const", "default", "enum", "minimum", "maximum"):
+        if key in source:
+            target[key] = deepcopy(source[key])
 
 
 def _surface(document: dict[str, Any], kind: str, name: str) -> dict[str, Any]:

--- a/src/vllm-sr/cli/router_management_client.py
+++ b/src/vllm-sr/cli/router_management_client.py
@@ -107,6 +107,7 @@ class RouterManagementClient:
         path: str | None = None,
         surface_kind: str | None = None,
         surface_name: str | None = None,
+        expanded: bool = False,
     ) -> RouterResponse:
         params = {"view": view}
         if path:
@@ -115,6 +116,8 @@ class RouterManagementClient:
             params["kind"] = surface_kind
         if surface_name:
             params["name"] = surface_name
+        if expanded:
+            params["expanded"] = "true"
         return self.request("GET", CONFIG_SCHEMA_PATH, params=params)
 
     def validate_config(self, yaml_text: str) -> RouterResponse:

--- a/src/vllm-sr/cli/templates/config.template.yaml
+++ b/src/vllm-sr/cli/templates/config.template.yaml
@@ -1,6 +1,5 @@
-# Advanced YAML sample for vLLM Semantic Router.
-# Most users should start with `vllm-sr serve` and finish setup in the dashboard.
-# Use this template when you want to hand-author routing config directly.
+# Minimal canonical YAML starter for vLLM Semantic Router.
+# Replace the model name and backend endpoint, then validate before applying.
 
 version: v0.3
 
@@ -34,5 +33,6 @@ routing:
         operator: "AND"
         conditions: []
       modelRefs:
+        # A provider model is routable only when a decision references it here.
         - model: "replace-with-your-model"
           use_reasoning: false

--- a/src/vllm-sr/tests/test_chat_command.py
+++ b/src/vllm-sr/tests/test_chat_command.py
@@ -99,10 +99,29 @@ def test_extract_assistant_text_api_error():
         )
 
 
-def test_chat_completions_url():
-    u = chat_client.chat_completions_url("http://localhost:8899")
-    assert u.endswith("/v1/chat/completions")
-    assert u.startswith("http://localhost:8899")
+@pytest.mark.parametrize(
+    ("base_url", "expected"),
+    [
+        (
+            "http://localhost:8899",
+            "http://localhost:8899/v1/chat/completions",
+        ),
+        (
+            "http://localhost:8899/v1/",
+            "http://localhost:8899/v1/chat/completions",
+        ),
+        (
+            "https://router.example.test/prefix/v1",
+            "https://router.example.test/prefix/v1/chat/completions",
+        ),
+        (
+            "https://router.example.test/v1/chat/completions",
+            "https://router.example.test/v1/chat/completions",
+        ),
+    ],
+)
+def test_chat_completions_url(base_url: str, expected: str):
+    assert chat_client.chat_completions_url(base_url) == expected
 
 
 def test_cli_chat_help_uses_namespaced_auto_model():

--- a/src/vllm-sr/tests/test_cli_main.py
+++ b/src/vllm-sr/tests/test_cli_main.py
@@ -154,6 +154,56 @@ def test_serve_materializes_active_config_under_custom_host_state_root(
     assert "VLLM_SR_STATE_ROOT_DIR" not in captured["env_vars"]
 
 
+def test_serve_replace_active_config_reaches_runtime_materializer(
+    monkeypatch, tmp_path: Path
+):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "version: v0.3\nrouting:\n  decisions: []\n", encoding="utf-8"
+    )
+    bootstrap = BootstrapResult(
+        config_path=config_path,
+        output_dir=tmp_path / ".vllm-sr",
+        setup_mode=False,
+    )
+    captured: dict[str, object] = {}
+
+    class _StubBackend:
+        def deploy(self, **kwargs):
+            captured.update(kwargs)
+
+    def capture_materialization(source, effective, **kwargs):
+        captured["materialize_source"] = source
+        captured["materialize_effective"] = effective
+        captured["materialize_options"] = kwargs
+        return source
+
+    monkeypatch.setattr(
+        runtime_commands, "ensure_bootstrap_workspace", lambda _: bootstrap
+    )
+    monkeypatch.setattr(
+        runtime_commands, "_build_backend", lambda *a, **kw: _StubBackend()
+    )
+    monkeypatch.setattr(
+        serve_config, "materialize_runtime_config", capture_materialization
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "serve",
+            "--config",
+            str(config_path),
+            "--replace-active-config",
+            "--image-pull-policy",
+            "never",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["materialize_options"]["replace_active"] is True
+
+
 def test_k8s_serve_keeps_non_persistent_effective_config_flow(
     monkeypatch, tmp_path: Path
 ):
@@ -221,6 +271,28 @@ def test_k8s_serve_keeps_non_persistent_effective_config_flow(
     assert not (tmp_path / ".vllm-sr").exists()
 
 
+def test_k8s_serve_rejects_replace_active_config(tmp_path: Path, caplog):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "version: v0.3\nrouting:\n  decisions: []\n", encoding="utf-8"
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "serve",
+            "--target",
+            "k8s",
+            "--config",
+            str(config_path),
+            "--replace-active-config",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "supported only for local Docker deployments" in caplog.text
+
+
 def test_serve_help_describes_docker_only_runtime():
     runner = CliRunner()
 
@@ -228,6 +300,7 @@ def test_serve_help_describes_docker_only_runtime():
 
     assert result.exit_code == 0
     assert "Local Docker deployment" in result.output
+    assert "--replace-active-config" in result.output
     assert "Podman" not in result.output
     assert "--topology" not in result.output
     assert "--log-level" in result.output
@@ -337,7 +410,7 @@ def test_source_config_keeps_legacy_env_passthrough_and_explicit_package_allowli
 
 
 def test_active_package_is_validated_before_source_materialization(
-    monkeypatch, tmp_path: Path
+    monkeypatch, tmp_path: Path, caplog
 ):
     initial = yaml.safe_dump(
         {
@@ -409,6 +482,15 @@ def test_active_package_is_validated_before_source_materialization(
     assert result.exit_code == 0, result.output
     assert active.read_bytes() == initial
     assert Path(captured["runtime_config_file"]) == active
+
+    captured.clear()
+    rejected = CliRunner().invoke(
+        main,
+        ["serve", "--config", str(source), "--replace-active-config"],
+    )
+    assert rejected.exit_code != 0
+    assert captured == {}
+    assert "cannot replace an active Recipe package" in caplog.text
 
 
 def test_serve_passes_log_level_to_backend_env(monkeypatch, tmp_path: Path):

--- a/src/vllm-sr/tests/test_config_schema.py
+++ b/src/vllm-sr/tests/test_config_schema.py
@@ -51,7 +51,25 @@ def test_config_schema_command_supports_full_section_and_surface_views() -> None
     assert section.exit_code == 0, section.output
     section_document = json.loads(section.output)
     assert section_document["x-vllm-sr-view"]["path"] == "global.router.learning"
+    assert section_document["x-vllm-sr-view"]["detail"] == "summary"
+    assert section_document["fields"]
+    assert "$defs" not in section_document
     assert len(section.output) < len(full.output)
+
+    expanded = runner.invoke(
+        main,
+        [
+            "config",
+            "schema",
+            "--section",
+            "global.router.learning",
+            "--expanded",
+        ],
+    )
+    assert expanded.exit_code == 0, expanded.output
+    expanded_document = json.loads(expanded.output)
+    assert expanded_document["x-vllm-sr-view"]["detail"] == "expanded"
+    assert "$defs" in expanded_document
 
     surface = runner.invoke(main, ["config", "schema", "--surface", "algorithm:static"])
     assert surface.exit_code == 0, surface.output
@@ -110,6 +128,7 @@ def test_config_schema_command_uses_management_origin_and_auth_client(
             "path": None,
             "surface_kind": "algorithm",
             "surface_name": "multi_factor",
+            "expanded": False,
         },
     }
 

--- a/src/vllm-sr/tests/test_config_schema.py
+++ b/src/vllm-sr/tests/test_config_schema.py
@@ -114,6 +114,31 @@ def test_config_schema_command_uses_management_origin_and_auth_client(
     }
 
 
+def test_config_init_creates_valid_minimal_template_without_overwriting(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "nested" / "config.yaml"
+    runner = CliRunner()
+
+    created = runner.invoke(main, ["config", "init", "--output", str(output)])
+
+    assert created.exit_code == 0, created.output
+    config = safe_load_router_config(output.read_text(encoding="utf-8"))
+    assert validate_config_structure(config) == []
+    assert config["providers"]["models"][0]["name"] == (
+        config["routing"]["modelCards"][0]["name"]
+    )
+    assert config["routing"]["decisions"][0]["modelRefs"][0]["model"] == (
+        config["providers"]["models"][0]["name"]
+    )
+
+    original = output.read_text(encoding="utf-8")
+    refused = runner.invoke(main, ["config", "init", "--output", str(output)])
+    assert refused.exit_code != 0
+    assert "already exists" in refused.output
+    assert output.read_text(encoding="utf-8") == original
+
+
 def test_python_progressive_index_covers_every_surface_catalog() -> None:
     index = schema_view(schema_document())
 

--- a/src/vllm-sr/tests/test_install_script_surface.py
+++ b/src/vllm-sr/tests/test_install_script_surface.py
@@ -3,6 +3,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[3]
 INSTALL_SCRIPT_PATH = REPO_ROOT / "install.sh"
 INSTALL_DOC_PATH = REPO_ROOT / "website" / "docs" / "installation" / "installation.md"
+AGENT_INSTALL_DOC_PATH = REPO_ROOT / "website" / "docs" / "installation" / "agent.md"
 INSTALL_DATA_PATH = REPO_ROOT / "website" / "src" / "data" / "installation.ts"
 HOMEPAGE_INSTALL_PATH = (
     REPO_ROOT
@@ -77,6 +78,8 @@ def test_install_script_defaults_to_dev_channel() -> None:
 
 def test_installation_surfaces_offer_minimal_human_and_agent_paths() -> None:
     docs = INSTALL_DOC_PATH.read_text(encoding="utf-8")
+    agent_docs = AGENT_INSTALL_DOC_PATH.read_text(encoding="utf-8")
+    normalized_agent_docs = " ".join(agent_docs.split())
     data = INSTALL_DATA_PATH.read_text(encoding="utf-8")
     homepage = HOMEPAGE_INSTALL_PATH.read_text(encoding="utf-8")
     skill = VLLM_SR_AGENT_SKILL_PATH.read_text(encoding="utf-8")
@@ -95,6 +98,15 @@ def test_installation_surfaces_offer_minimal_human_and_agent_paths() -> None:
     assert "For agents" in homepage
     assert "AGENT_INSTALL_PROMPT" in homepage
     assert "AGENT_SKILL_PATH" in homepage
+    assert "AGENT_INSTALL_DOC_PATH" in homepage
+
+    assert "AGENT_INSTALL_PROMPT" in agent_docs
+    assert "AGENT_SKILL_PATH" in agent_docs
+    assert "Dashboard is optional" in normalized_agent_docs
+    assert "vllm-sr config validate" in agent_docs
+    assert "vllm-sr config plan" in agent_docs
+    assert "vllm-sr route preview" in agent_docs
+    assert "vllm-sr route probe" in agent_docs
 
     assert "name: vllm-sr" in skill
     assert "vllm-sr config schema" in skill

--- a/src/vllm-sr/tests/test_install_script_surface.py
+++ b/src/vllm-sr/tests/test_install_script_surface.py
@@ -98,6 +98,7 @@ def test_installation_surfaces_offer_minimal_human_and_agent_paths() -> None:
 
     assert "name: vllm-sr" in skill
     assert "vllm-sr config schema" in skill
+    assert "vllm-sr config init" in skill
     assert "vllm-sr config validate --config config.yaml" in skill
     assert "vllm-sr config plan --config config.yaml" in skill
     assert "vllm-sr route preview" in skill

--- a/src/vllm-sr/tests/test_route_command.py
+++ b/src/vllm-sr/tests/test_route_command.py
@@ -701,6 +701,30 @@ def test_route_probe_emits_routing_receipt_and_uses_secret_from_environment(
     assert post.call_args.kwargs["headers"]["Authorization"] == "Bearer probe-secret"
 
 
+def test_route_probe_accepts_openai_v1_base_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = MagicMock()
+    response.status_code = 200
+    response.headers = {}
+    response.json.return_value = {"choices": [{"message": {"content": "ok"}}]}
+    post = MagicMock(return_value=response)
+    monkeypatch.setattr(requests, "post", post)
+
+    result = CliRunner().invoke(
+        route_probe_command,
+        [
+            "--prompt",
+            "hello",
+            "--base-url",
+            "http://localhost:8801/v1",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert post.call_args.args[0] == "http://localhost:8801/v1/chat/completions"
+
+
 def test_route_probe_exits_two_when_an_assertion_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/src/vllm-sr/tests/test_route_command.py
+++ b/src/vllm-sr/tests/test_route_command.py
@@ -57,7 +57,12 @@ def _run_cli_subprocess(tmp_path: Path, *args: str) -> subprocess.CompletedProce
 # Fixture: real in-process HTTP server
 
 
-def _make_handler(status: int, body: Any, content_type: str = "application/json"):
+def _make_handler(
+    status: int,
+    body: Any,
+    content_type: str = "application/json",
+    headers: dict[str, str] | None = None,
+):
     """Return a BaseHTTPRequestHandler subclass that always responds with the
     given status code and JSON-encoded body."""
     if isinstance(body, bytes):
@@ -75,6 +80,8 @@ def _make_handler(status: int, body: Any, content_type: str = "application/json"
             self.send_response(status)
             self.send_header("Content-Type", content_type)
             self.send_header("Content-Length", str(len(body_bytes)))
+            for name, value in (headers or {}).items():
+                self.send_header(name, value)
             self.end_headers()
             self.wfile.write(body_bytes)
 
@@ -100,6 +107,7 @@ def router_server(request):
         params["status"],
         params["body"],
         params.get("content_type", "application/json"),
+        params.get("headers"),
     )
     server = HTTPServer(("127.0.0.1", 0), handler)  # port=0 → OS picks a free port
     port = server.server_address[1]
@@ -668,7 +676,10 @@ def test_route_probe_emits_routing_receipt_and_uses_secret_from_environment(
         "x-vsr-selected-algorithm": "multi_factor",
         "x-vsr-selected-model": "qwen",
     }
-    response.json.return_value = {"choices": [{"message": {"content": "ok"}}]}
+    response.json.return_value = {
+        "model": "Qwen/Qwen3.8-Flash-Next",
+        "choices": [{"message": {"content": "ok"}}],
+    }
     post = MagicMock(return_value=response)
     monkeypatch.setattr(requests, "post", post)
     monkeypatch.setenv("PROBE_TOKEN", "probe-secret")
@@ -688,8 +699,10 @@ def test_route_probe_emits_routing_receipt_and_uses_secret_from_environment(
             "coding",
             "--expect-algorithm",
             "multi_factor",
-            "--expect-model",
+            "--expect-selected-model",
             "qwen",
+            "--expect-response-model",
+            "Qwen/Qwen3.8-Flash-Next",
         ],
     )
 
@@ -741,7 +754,7 @@ def test_route_probe_exits_two_when_an_assertion_fails(
             "hello",
             "--base-url",
             "http://localhost:8801",
-            "--expect-model",
+            "--expect-selected-model",
             "expected",
         ],
     )
@@ -750,9 +763,75 @@ def test_route_probe_exits_two_when_an_assertion_fails(
     assert json.loads(result.output)["passed"] is False
 
 
+def test_route_probe_exits_two_when_response_model_is_not_selected_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = MagicMock()
+    response.status_code = 200
+    response.headers = {"x-vsr-selected-model": "qwen"}
+    response.json.return_value = {"model": "smoke-model", "choices": []}
+    monkeypatch.setattr(requests, "post", MagicMock(return_value=response))
+
+    result = CliRunner().invoke(
+        route_probe_command,
+        [
+            "--prompt",
+            "hello",
+            "--base-url",
+            "http://localhost:8801",
+            "--expect-selected-model",
+            "qwen",
+            "--expect-response-model",
+            "Qwen/Qwen3.8-Flash-Next",
+        ],
+    )
+
+    assert result.exit_code == 2
+    receipt = json.loads(result.output)
+    assert receipt["passed"] is False
+    assert receipt["assertions"][-1] == {
+        "actual": "smoke-model",
+        "expected": "Qwen/Qwen3.8-Flash-Next",
+        "field": "response.body.model",
+        "passed": False,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Integration tests: real HTTP server, no mocks
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "router_server",
+    [
+        {
+            "status": 200,
+            "headers": {"x-vsr-selected-model": "qwen"},
+            "body": {"model": "Qwen/Qwen3.8-Flash-Next", "choices": []},
+        }
+    ],
+    indirect=True,
+)
+def test_route_probe_integration_verifies_router_and_upstream_models(
+    router_server: str,
+) -> None:
+    result = CliRunner().invoke(
+        route_probe_command,
+        [
+            "--prompt",
+            "hello",
+            "--base-url",
+            router_server,
+            "--expect-selected-model",
+            "qwen",
+            "--expect-response-model",
+            "Qwen/Qwen3.8-Flash-Next",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["passed"] is True
 
 
 @pytest.mark.parametrize(

--- a/src/vllm-sr/tests/test_router_management_client.py
+++ b/src/vllm-sr/tests/test_router_management_client.py
@@ -97,3 +97,27 @@ def test_management_client_discovers_one_config_schema_view(
         "kind": "algorithm",
         "name": "multi_factor",
     }
+
+
+def test_management_client_requests_expanded_section_schema(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, str, dict[str, Any]]] = []
+
+    def request(method: str, url: str, **kwargs: Any) -> _Response:
+        calls.append((method, url, kwargs))
+        return _Response()
+
+    monkeypatch.setattr("cli.router_management_client.requests.request", request)
+
+    RouterManagementClient("http://localhost:8080").get_config_schema(
+        view="section",
+        path="routing",
+        expanded=True,
+    )
+
+    assert calls[0][2]["params"] == {
+        "view": "section",
+        "path": "routing",
+        "expanded": "true",
+    }

--- a/src/vllm-sr/tests/test_runtime_paths.py
+++ b/src/vllm-sr/tests/test_runtime_paths.py
@@ -1,3 +1,5 @@
+import hashlib
+import json
 import os
 import stat
 from pathlib import Path
@@ -357,6 +359,35 @@ def test_materialize_preserves_dashboard_change_when_source_changes(
     assert preserved == active
     assert active.read_text(encoding="utf-8") == "version: dashboard-edit\n"
     assert "Preserving Dashboard or package changes" in caplog.text
+
+
+def test_materialize_replaces_dashboard_change_when_explicitly_requested(
+    tmp_path: Path,
+):
+    source = tmp_path / "config.yaml"
+    source.write_text("version: first\n", encoding="utf-8")
+    active = materialize_runtime_config(source, b"version: first-effective\n")
+    active.write_text("version: dashboard-edit\n", encoding="utf-8")
+    source.write_text("version: second\n", encoding="utf-8")
+
+    replaced = materialize_runtime_config(
+        source,
+        b"version: second-effective\n",
+        replace_active=True,
+    )
+
+    assert replaced == active
+    assert active.read_text(encoding="utf-8") == "version: second-effective\n"
+    provenance = json.loads(
+        _runtime_config_provenance_path(active).read_text(encoding="utf-8")
+    )
+    assert provenance["source_digest"] == (
+        "sha256:" + hashlib.sha256(source.read_bytes()).hexdigest()
+    )
+    assert (
+        provenance["last_materialized_active_digest"]
+        == "sha256:" + hashlib.sha256(active.read_bytes()).hexdigest()
+    )
 
 
 def test_materialize_uses_custom_host_state_without_container_path_leak(

--- a/tools/agent/skills/vllm-sr-agent-operations/SKILL.md
+++ b/tools/agent/skills/vllm-sr-agent-operations/SKILL.md
@@ -19,7 +19,8 @@ receipts as evidence. Do not invent a second DSL or scrape Dashboard state.
 4. Discover configuration progressively:
    - `vllm-sr config schema --endpoint <management-origin>`
    - add `--section <path>` or `--surface <kind:name>` for one contract;
-   - use `--full` only when a complete schema is necessary.
+   - add `--expanded` only when a self-contained section schema is necessary;
+   - use `--full` only when the complete schema is necessary.
 
 The management origin normally serves `/api/v1/**`, `/openapi.json`, and
 `/docs`. The routed inference origin separately serves OpenAI-compatible
@@ -32,7 +33,9 @@ For configuration changes, follow this exact order:
 1. Edit canonical YAML locally.
 2. Run local validation, then authoritative Router validation.
 3. Plan against current state without writing.
-4. Apply with the ETag returned by the plan.
+4. Apply a Router-hot-reloadable change with the ETag returned by the plan. If
+   planning reports `RESTART_REQUIRED`, activate the candidate through the
+   deployment workflow instead of the Router mutation API.
 5. Confirm readiness and active configuration.
 6. Preview representative routing cases without model calls.
 7. Probe the Envoy-routed endpoint with real model calls and assertions.
@@ -53,7 +56,8 @@ or model-pool changes.
   generation backend. Use it for fast route assertions.
 - `vllm-sr route probe` sends one real request through the routed inference
   listener and emits a JSON receipt containing selected route headers, latency,
-  response, and assertions.
+  response, and assertions. Assert the Router-selected model and the upstream
+  response model separately when the backend exposes a stable model field.
 - `vllm-sr benchmark` runs versioned routing workloads.
 - `vllm-sr benchmark intelligence` plans or runs the six fixed Intelligence
   1.0 model benchmarks against any physical or virtual model ID. A virtual

--- a/tools/agent/skills/vllm-sr-agent-operations/SKILL.md
+++ b/tools/agent/skills/vllm-sr-agent-operations/SKILL.md
@@ -35,7 +35,10 @@ For configuration changes, follow this exact order:
 3. Plan against current state without writing.
 4. Apply a Router-hot-reloadable change with the ETag returned by the plan. If
    planning reports `RESTART_REQUIRED`, activate the candidate through the
-   deployment workflow instead of the Router mutation API.
+   deployment workflow instead of the Router mutation API. For local Docker,
+   the explicit source-authoritative operation is
+   `vllm-sr serve --config <candidate> --replace-active-config`; ask before it
+   replaces the running stack and any Dashboard-edited active config.
 5. Confirm readiness and active configuration.
 6. Preview representative routing cases without model calls.
 7. Probe the Envoy-routed endpoint with real model calls and assertions.

--- a/tools/agent/skills/vllm-sr-agent-operations/references/configuration-loop.md
+++ b/tools/agent/skills/vllm-sr-agent-operations/references/configuration-loop.md
@@ -42,9 +42,12 @@ vllm-sr config apply --config candidate.yaml --mode replace \
 as mutation but writes nothing. `apply` plans again and uses the returned ETag
 as a compare-and-swap precondition. Listener and provider-backend topology is
 rendered into Envoy, so a plan that changes it returns `RESTART_REQUIRED` and
-must be activated through the deployment workflow; the Router apply API is for
-hot-reloadable state. Prefer `replace` for a complete reviewed document; use
-`merge` only for an intentionally partial patch.
+must be activated through the deployment workflow. For local Docker, the
+explicit operation is `vllm-sr serve --config <candidate>
+--replace-active-config`; without that flag, `serve` preserves Dashboard-edited
+runtime state. The Router apply API is for hot-reloadable state. Prefer
+`replace` for a complete reviewed document; use `merge` only for an
+intentionally partial patch.
 
 Inspect or recover state with:
 

--- a/tools/agent/skills/vllm-sr-agent-operations/references/configuration-loop.md
+++ b/tools/agent/skills/vllm-sr-agent-operations/references/configuration-loop.md
@@ -15,9 +15,9 @@ vllm-sr config schema --endpoint http://router-management:8080 \
   --surface algorithm:multi_factor
 ```
 
-Use `--full` only for offline tooling that genuinely needs the entire JSON
-Schema. Query the narrowest section needed because a parent section must carry
-every valid nested choice and can still be large.
+Section requests return compact field directories that link to child paths.
+Add `--expanded` only when tooling needs a self-contained schema for that
+section, and use `--full` only when it genuinely needs the entire JSON Schema.
 
 Read an active document with `vllm-sr config get`. In a fresh workspace, run
 `vllm-sr config init --output candidate.yaml` for a minimal canonical starter.
@@ -40,8 +40,11 @@ vllm-sr config apply --config candidate.yaml --mode replace \
 
 `plan` performs the same canonical parse, merge/replace, and hot-reload checks
 as mutation but writes nothing. `apply` plans again and uses the returned ETag
-as a compare-and-swap precondition. Prefer `replace` for a complete reviewed
-document; use `merge` only for an intentionally partial patch.
+as a compare-and-swap precondition. Listener and provider-backend topology is
+rendered into Envoy, so a plan that changes it returns `RESTART_REQUIRED` and
+must be activated through the deployment workflow; the Router apply API is for
+hot-reloadable state. Prefer `replace` for a complete reviewed document; use
+`merge` only for an intentionally partial patch.
 
 Inspect or recover state with:
 

--- a/tools/agent/skills/vllm-sr-agent-operations/references/configuration-loop.md
+++ b/tools/agent/skills/vllm-sr-agent-operations/references/configuration-loop.md
@@ -8,13 +8,22 @@ editing, discover only the relevant schema surface:
 ```bash
 vllm-sr config schema --endpoint http://router-management:8080
 vllm-sr config schema --endpoint http://router-management:8080 \
-  --section routing
+  --section providers.models
+vllm-sr config schema --endpoint http://router-management:8080 \
+  --section routing.decisions.modelRefs
 vllm-sr config schema --endpoint http://router-management:8080 \
   --surface algorithm:multi_factor
 ```
 
 Use `--full` only for offline tooling that genuinely needs the entire JSON
-Schema.
+Schema. Query the narrowest section needed because a parent section must carry
+every valid nested choice and can still be large.
+
+Read an active document with `vllm-sr config get`. In a fresh workspace, run
+`vllm-sr config init --output candidate.yaml` for a minimal canonical starter.
+The same physical model name must occur under `providers.models`,
+`routing.modelCards`, and the applicable decision's `modelRefs`; a provider or
+Model Card alone does not make a model routable.
 
 ## Validate, plan, apply
 

--- a/tools/agent/skills/vllm-sr-agent-operations/references/deployment-loop.md
+++ b/tools/agent/skills/vllm-sr-agent-operations/references/deployment-loop.md
@@ -33,7 +33,10 @@ send a direct request to every physical backend before testing routing.
 4. Run config validation. Planning against a running Router will report
    `RESTART_REQUIRED` because provider backends are rendered into Envoy.
 5. Ask before disruption, then activate the candidate through the deployment
-   workflow and wait for Router and Envoy readiness.
+   workflow and wait for Router and Envoy readiness. For local Docker, use
+   `vllm-sr serve --config <candidate> --replace-active-config`; ordinary
+   `serve` deliberately preserves Dashboard-edited runtime state. An active
+   Recipe package must be changed through its Recipe workflow instead.
 6. Route-preview representative cases, then probe each direct model alias and
    every affected virtual model. Assert selected-model and response-model
    identity separately where the backend exposes a stable response model.

--- a/tools/agent/skills/vllm-sr-agent-operations/references/deployment-loop.md
+++ b/tools/agent/skills/vllm-sr-agent-operations/references/deployment-loop.md
@@ -30,9 +30,13 @@ send a direct request to every physical backend before testing routing.
 1. Establish backend health and protocol compatibility.
 2. Measure serving latency, throughput, token usage, failure rate, and cost.
 3. Add the physical model and Model Card to candidate YAML.
-4. Run config validate and plan.
-5. Apply, then route-preview representative cases.
-6. Probe each direct model alias and every affected virtual model.
+4. Run config validation. Planning against a running Router will report
+   `RESTART_REQUIRED` because provider backends are rendered into Envoy.
+5. Ask before disruption, then activate the candidate through the deployment
+   workflow and wait for Router and Envoy readiness.
+6. Route-preview representative cases, then probe each direct model alias and
+   every affected virtual model. Assert selected-model and response-model
+   identity separately where the backend exposes a stable response model.
 7. Run the required full benchmarks.
 8. Optimize the Recipe only from comparable evidence.
 

--- a/tools/agent/skills/vllm-sr-agent-operations/references/deployment-loop.md
+++ b/tools/agent/skills/vllm-sr-agent-operations/references/deployment-loop.md
@@ -6,10 +6,12 @@ Install a released CLI or build the repository's CLI through its documented
 development target. Confirm the runtime platform, container engine, available
 accelerators, ports, storage, and credential environment before serving.
 
-Generate a candidate config from the running schema rather than from memory.
-Define each provider, model, backend reference, Model Card, Entrypoint, Recipe,
-and listener explicitly. Custom physical models and virtual models use the
-same evaluation-record and routing-index contracts.
+Read an active config before editing it; use `vllm-sr config init` only for a
+fresh workspace. Discover exact fields from the running schema rather than
+from memory. Define each provider, model, backend reference, Model Card,
+Entrypoint, Recipe, and listener explicitly. A model joins a route only when a
+decision references it through `modelRefs`. Custom physical models and virtual
+models use the same evaluation-record and routing-index contracts.
 
 ## Serve
 

--- a/tools/agent/skills/vllm-sr-agent-operations/references/deployment-loop.md
+++ b/tools/agent/skills/vllm-sr-agent-operations/references/deployment-loop.md
@@ -4,7 +4,9 @@
 
 Install a released CLI or build the repository's CLI through its documented
 development target. Confirm the runtime platform, container engine, available
-accelerators, ports, storage, and credential environment before serving.
+accelerators, ports, storage, and credential environment before serving. Check
+accelerator inventory vendor-neutrally; a missing NVIDIA or AMD utility alone
+does not prove that the host has no GPU.
 
 Read an active config before editing it; use `vllm-sr config init` only for a
 fresh workspace. Discover exact fields from the running schema rather than

--- a/tools/agent/skills/vllm-sr-agent-operations/references/evaluation-loop.md
+++ b/tools/agent/skills/vllm-sr-agent-operations/references/evaluation-loop.md
@@ -21,7 +21,7 @@ Probe sends a real OpenAI-compatible request through the inference listener:
 export OPENAI_API_KEY='...'
 
 vllm-sr route probe \
-  --base-url http://router-inference:8899 \
+  --base-url http://router-inference:8899/v1 \
   --model vllm-sr/auto \
   --prompt 'Implement a lock-free queue' \
   --expect-recipe balanced \
@@ -30,7 +30,8 @@ vllm-sr route probe \
 ```
 
 The JSON receipt includes status, latency, routing headers, body, and every
-assertion. Exit code `2` means an assertion failed.
+assertion. The base URL accepts either the listener origin or its OpenAI `/v1`
+root. Exit code `2` means an assertion failed.
 
 ## 3. Versioned workloads
 

--- a/tools/agent/skills/vllm-sr-agent-operations/references/evaluation-loop.md
+++ b/tools/agent/skills/vllm-sr-agent-operations/references/evaluation-loop.md
@@ -26,12 +26,17 @@ vllm-sr route probe \
   --prompt 'Implement a lock-free queue' \
   --expect-recipe balanced \
   --expect-decision coding \
-  --expect-algorithm multi_factor
+  --expect-algorithm multi_factor \
+  --expect-selected-model qwen \
+  --expect-response-model Qwen/Qwen3.8-Flash-Next
 ```
 
 The JSON receipt includes status, latency, routing headers, body, and every
-assertion. The base URL accepts either the listener origin or its OpenAI `/v1`
-root. Exit code `2` means an assertion failed.
+assertion. `--expect-selected-model` verifies the Router receipt, while
+`--expect-response-model` verifies the upstream response body's top-level
+`model` field when the backend exposes one. The base URL accepts either the
+listener origin or its OpenAI `/v1` root. Exit code `2` means an assertion
+failed.
 
 ## 3. Versioned workloads
 

--- a/website/docs/api/configuration-schema.mdx
+++ b/website/docs/api/configuration-schema.mdx
@@ -21,7 +21,8 @@ agents to load the full schema first:
 
 ```bash
 vllm-sr config schema
-vllm-sr config schema --section global.router.learning
+vllm-sr config schema --section providers.models
+vllm-sr config schema --section routing.decisions.modelRefs
 vllm-sr config schema --surface algorithm:multi_factor
 vllm-sr config schema --full
 ```
@@ -29,6 +30,12 @@ vllm-sr config schema --full
 Against a running Router, `GET /api/v1/config/schema` returns the compact index.
 Use `view=section&path=...` or `view=surface&kind=...&name=...` to expand one
 branch, and `view=full` for the complete schema.
+
+Ask for the narrowest section that answers the current edit. Parent sections
+can legitimately be large because their schema includes every supported nested
+algorithm, plugin, signal, and projection. For a new file, use
+`vllm-sr config init`; the template shows the required provider, Model Card,
+and decision-reference relationship without loading the full schema.
 
 Section views preserve their real shape: list sections such as `listeners`,
 `entrypoints`, and `recipes` expose their item fields, while `version` is shown

--- a/website/docs/api/configuration-schema.mdx
+++ b/website/docs/api/configuration-schema.mdx
@@ -23,16 +23,19 @@ agents to load the full schema first:
 vllm-sr config schema
 vllm-sr config schema --section providers.models
 vllm-sr config schema --section routing.decisions.modelRefs
+vllm-sr config schema --section routing --expanded
 vllm-sr config schema --surface algorithm:multi_factor
 vllm-sr config schema --full
 ```
 
 Against a running Router, `GET /api/v1/config/schema` returns the compact index.
-Use `view=section&path=...` or `view=surface&kind=...&name=...` to expand one
-branch, and `view=full` for the complete schema.
+Use `view=section&path=...` for a compact field directory or
+`view=surface&kind=...&name=...` for one registered routing surface. Add
+`expanded=true` to a section request only when a self-contained JSON Schema is
+required; use `view=full` for the complete schema.
 
-Ask for the narrowest section that answers the current edit. Parent sections
-can legitimately be large because their schema includes every supported nested
+Ask for the narrowest section that answers the current edit. The default field
+directory links to its child paths, so agents do not need to load every nested
 algorithm, plugin, signal, and projection. For a new file, use
 `vllm-sr config init`; the template shows the required provider, Model Card,
 and decision-reference relationship without loading the full schema.

--- a/website/docs/benchmarking/agent-evaluation-loop.md
+++ b/website/docs/benchmarking/agent-evaluation-loop.md
@@ -54,7 +54,10 @@ hot-reload feasibility checks as mutation without writing. `apply` plans again
 and uses the returned ETag as its compare-and-swap precondition. A plan that
 changes listeners or provider backend topology returns `RESTART_REQUIRED`
 because those fields are rendered into Envoy; activate that candidate through
-the deployment workflow instead of the Router mutation API.
+the deployment workflow instead of the Router mutation API. For local Docker,
+ask before replacing the running stack, then use
+`vllm-sr serve --config candidate.yaml --replace-active-config`. Ordinary
+`serve` preserves Dashboard-edited active state.
 
 ## 2. Verify routing in two stages
 

--- a/website/docs/benchmarking/agent-evaluation-loop.md
+++ b/website/docs/benchmarking/agent-evaluation-loop.md
@@ -51,7 +51,10 @@ vllm-sr config apply --config candidate.yaml --mode replace \
 
 `plan` executes the same parse, normalization, semantic validation, and
 hot-reload feasibility checks as mutation without writing. `apply` plans again
-and uses the returned ETag as its compare-and-swap precondition.
+and uses the returned ETag as its compare-and-swap precondition. A plan that
+changes listeners or provider backend topology returns `RESTART_REQUIRED`
+because those fields are rendered into Envoy; activate that candidate through
+the deployment workflow instead of the Router mutation API.
 
 ## 2. Verify routing in two stages
 
@@ -74,15 +77,22 @@ vllm-sr route probe \
   --prompt 'Implement a lock-free queue' \
   --expect-recipe balanced \
   --expect-decision coding \
-  --expect-algorithm multi_factor
+  --expect-algorithm multi_factor \
+  --expect-selected-model qwen \
+  --expect-response-model Qwen/Qwen3.8-Flash-Next
 ```
 
 The probe emits a machine-readable receipt with HTTP status, latency, routing
-headers, response, and assertions. A failed assertion exits with code `2`.
+headers, response, and assertions. `--expect-selected-model` checks the Router
+receipt; `--expect-response-model` checks the upstream OpenAI response body.
+Use the latter when that backend exposes a stable top-level `model` value. A
+failed assertion exits with code `2`.
 The base URL may be either the Envoy listener origin or the standard OpenAI
 root ending in `/v1`.
-Preview success proves decision behavior only; probe success proves one routed
-request only. Neither substitutes for a benchmark.
+Preview success proves decision behavior only. A selected-model header proves
+the Router's choice but not which backend answered; response-model evidence
+closes that gap when available. One probe still does not substitute for a
+benchmark.
 
 ## 3. Run comparable benchmarks
 

--- a/website/docs/benchmarking/agent-evaluation-loop.md
+++ b/website/docs/benchmarking/agent-evaluation-loop.md
@@ -69,7 +69,7 @@ Probe then sends a real request through Envoy and asserts the resulting route:
 
 ```bash
 vllm-sr route probe \
-  --base-url http://localhost:8899 \
+  --base-url http://localhost:8899/v1 \
   --model vllm-sr/auto \
   --prompt 'Implement a lock-free queue' \
   --expect-recipe balanced \
@@ -79,6 +79,8 @@ vllm-sr route probe \
 
 The probe emits a machine-readable receipt with HTTP status, latency, routing
 headers, response, and assertions. A failed assertion exits with code `2`.
+The base URL may be either the Envoy listener origin or the standard OpenAI
+root ending in `/v1`.
 Preview success proves decision behavior only; probe success proves one routed
 request only. Neither substitutes for a benchmark.
 

--- a/website/docs/installation/agent.md
+++ b/website/docs/installation/agent.md
@@ -1,0 +1,81 @@
+---
+sidebar_position: 2
+title: Install with an agent
+description: Give an agent one prompt to install, configure, and verify vLLM Semantic Router through its CLI and Router API.
+---
+
+import CodeBlock from '@theme/CodeBlock'
+import {
+  AGENT_INSTALL_PROMPT,
+  AGENT_SKILL_PATH,
+} from '@site/src/data/installation'
+
+# Install with an agent
+
+Paste this prompt into a coding agent that can use a terminal and access the
+machine where you want to run vLLM Semantic Router:
+
+<CodeBlock language="text">{AGENT_INSTALL_PROMPT}</CodeBlock>
+
+That is the complete bootstrap prompt. It points the agent to the public,
+self-contained <a href={AGENT_SKILL_PATH}>vLLM SR Skill</a>; installation details
+stay in the Skill instead of being copied into every prompt. The Dashboard is
+optional and is not part of the agent workflow.
+
+## What the agent does
+
+The Skill directs the agent to:
+
+1. Inspect the host, existing installation, container runtime, accelerator, and
+   available model endpoints without changing them.
+2. Install the stable CLI when needed, then discover the running Router's
+   supported operations, configuration schema, and OpenAPI contract.
+3. Create or update canonical YAML for the available model pool while keeping
+   credentials in environment variables.
+4. Validate and plan the change before applying it. Changes to listeners or
+   provider topology require an explicit deployment restart.
+5. Preview the routing decision without calling a model, then send a real
+   end-to-end request through the routed inference endpoint.
+6. Leave the config path, active revision, validation result, and routing
+   evidence for review.
+
+Tell the agent your model endpoint URLs, routing objective, or deployment
+constraints in the same message when they are already known. Otherwise, the
+agent will discover what it can and ask only when a choice or permission is
+required.
+
+## Direct contracts
+
+The agent works against the same contracts used by the CLI and Dashboard; it
+does not automate the Dashboard UI.
+
+| Purpose | CLI or Router contract |
+| --- | --- |
+| Discover operations | `GET /api/v1?audience=agent&visibility=primary` |
+| Inspect an operation | `GET /openapi.json?path=...&method=...` |
+| Discover configuration | `vllm-sr config schema` or `GET /api/v1/config/schema` |
+| Validate and plan | `vllm-sr config validate`, then `vllm-sr config plan` |
+| Apply a hot-reloadable change | `vllm-sr config apply` with the planned ETag |
+| Test routing logic | `vllm-sr route preview` |
+| Test the complete data path | `vllm-sr route probe` |
+
+The management origin serves health, discovery, configuration, and OpenAPI.
+The routed inference origin separately serves OpenAI-compatible requests. An
+agent must discover both rather than infer one from the other.
+
+## Safety boundaries
+
+- Keep API keys and provider credentials in environment variables; do not put
+  secret values in prompts, YAML, command arguments, or logs.
+- Review any privileged, destructive, publicly exposed, or service-disrupting
+  action before allowing it.
+- A routing preview proves the decision path but does not call a model. A route
+  probe is the end-to-end check that reaches the selected backend.
+- Use the running Router's discovery, schema, and OpenAPI responses as the
+  authority for its installed version.
+
+For deeper configuration work, continue with the
+[configuration contract](configuration-contract) and
+[configuration workflows](configuration-workflows). For model and
+Mixture-of-Models evaluation, use the
+[agent evaluation loop](../benchmarking/agent-evaluation-loop).

--- a/website/docs/installation/configuration-contract.md
+++ b/website/docs/installation/configuration-contract.md
@@ -140,7 +140,9 @@ An automation or deployment agent should:
 5. omit the bootstrap-only `setup` block and call the semantic validation endpoint;
 6. plan the mutation; apply a hot-reloadable change with the returned
    `current_etag` in `If-Match`, or use the deployment workflow when listener
-   or provider topology returns `RESTART_REQUIRED`;
+   or provider topology returns `RESTART_REQUIRED` (for local Docker, use the
+   explicit `vllm-sr serve --config <candidate> --replace-active-config`
+   operation after approval);
 7. poll `activation_status` and probe the Envoy data plane before keeping the
    change.
 

--- a/website/docs/installation/configuration-contract.md
+++ b/website/docs/installation/configuration-contract.md
@@ -40,10 +40,11 @@ Start with the compact section and routing-surface index bundled with the CLI:
 vllm-sr config schema
 ```
 
-Expand only what the current task needs:
+Follow only the field directory needed by the current task:
 
 ```bash
 vllm-sr config schema --section global.router.learning
+vllm-sr config schema --section global.router.learning --expanded
 vllm-sr config schema --surface signal:keyword
 vllm-sr config schema --surface algorithm:multi_factor
 vllm-sr config schema --full
@@ -58,8 +59,10 @@ vllm-sr config schema \
 
 `--endpoint` works with every progressive option. The Router endpoint is
 `GET /api/v1/config/schema`: omitting `view` returns the compact index; use
-`view=section&path=...` or `view=surface&kind=...&name=...` to expand one branch,
-and `view=full` for the complete JSON Schema.
+`view=section&path=...` for a compact field directory, add `expanded=true` for
+that section's self-contained schema, use
+`view=surface&kind=...&name=...` for one registered routing surface, and use
+`view=full` for the complete JSON Schema.
 
 The Dashboard proxies the deployed Router contract at
 `GET /api/router/config/schema`. If that Router endpoint is unavailable, it
@@ -135,8 +138,9 @@ An automation or deployment agent should:
 4. construct the smallest canonical document from schema fields and routing
    surface references;
 5. omit the bootstrap-only `setup` block and call the semantic validation endpoint;
-6. plan the mutation, then apply it with the returned `current_etag` in
-   `If-Match`;
+6. plan the mutation; apply a hot-reloadable change with the returned
+   `current_etag` in `If-Match`, or use the deployment workflow when listener
+   or provider topology returns `RESTART_REQUIRED`;
 7. poll `activation_status` and probe the Envoy data plane before keeping the
    change.
 

--- a/website/docs/installation/configuration-workflows.md
+++ b/website/docs/installation/configuration-workflows.md
@@ -15,9 +15,17 @@ Use YAML when configuration belongs in source control or an existing deployment
 pipeline:
 
 ```bash
+vllm-sr config init --output config.yaml
 vllm-sr config validate --config config.yaml
 vllm-sr serve --config config.yaml
 ```
+
+`config init` writes the packaged minimal canonical template and refuses to
+replace an existing file unless `--force` is explicit. When a Router is already
+running, start from `vllm-sr config get` instead so unrelated active settings
+are preserved. A model becomes a routing candidate only after the same model
+name appears in `providers.models`, `routing.modelCards`, and the applicable
+decision's `modelRefs`.
 
 The local runtime derives stack-specific service addresses in runtime-owned
 state without rewriting the source file. Concurrent `serve` and `stop`

--- a/website/docs/installation/installation.md
+++ b/website/docs/installation/installation.md
@@ -8,6 +8,7 @@ import Tabs from '@theme/Tabs'
 import TabItem from '@theme/TabItem'
 import CodeBlock from '@theme/CodeBlock'
 import {
+  AGENT_INSTALL_DOC_PATH,
   AGENT_INSTALL_PROMPT,
   AGENT_SKILL_PATH,
   CURL_INSTALL_COMMAND,
@@ -45,7 +46,8 @@ Install vLLM Semantic Router, start the local stack, and send one request.
   <TabItem value="agent">
     Copy this prompt into your coding agent:
     <CodeBlock language="text">{AGENT_INSTALL_PROMPT}</CodeBlock>
-    The prompt points to the self-contained <a href={AGENT_SKILL_PATH}>vLLM SR agent skill</a>.
+    The prompt points to the public, self-contained <a href={AGENT_SKILL_PATH}>vLLM SR agent skill</a>.
+    See <a href={AGENT_INSTALL_DOC_PATH}>Install with an agent</a> for the workflow and safety boundaries.
   </TabItem>
 </Tabs>
 

--- a/website/i18n/zh-Hans/code.json
+++ b/website/i18n/zh-Hans/code.json
@@ -605,10 +605,10 @@
     "message": "安装指南"
   },
   "homepage.install.agentCta": {
-    "message": "查看 Agent Skill"
+    "message": "Agent 安装指南"
   },
   "homepage.install.secondaryCta": {
-    "message": "打开快速上手"
+    "message": "查看原始 Skill"
   },
   "homepage.install.docsCta": {
     "message": "阅读文档"

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -33,6 +33,7 @@ const sidebars: SidebarsConfig = {
       collapsed: false,
       items: [
         'installation/installation',
+        'installation/agent',
         {
           type: 'category',
           label: 'Plan a Deployment',

--- a/website/src/components/InstallQuickStartSection/index.module.css
+++ b/website/src/components/InstallQuickStartSection/index.module.css
@@ -26,22 +26,26 @@
   display: grid;
   width: fit-content;
   margin: 0 auto 1rem;
-  padding: 0.22rem;
-  grid-template-columns: repeat(2, minmax(7.5rem, 1fr));
+  padding: 0.2rem;
+  grid-template-columns: repeat(2, minmax(7rem, 1fr));
   border: 1px solid var(--site-border);
-  border-radius: 0.72rem;
+  border-radius: 0.68rem;
   background: var(--site-surface-alt);
 }
 
 .audienceTab {
-  min-height: 2.3rem;
-  padding: 0.46rem 0.9rem;
+  display: inline-flex;
+  min-height: 2.1rem;
+  align-items: center;
+  justify-content: center;
+  gap: 0.38rem;
+  padding: 0.4rem 0.78rem;
   border: 0;
-  border-radius: 0.52rem;
+  border-radius: 0.49rem;
   background: transparent;
   color: var(--site-muted-bright);
   cursor: pointer;
-  font-size: 0.84rem;
+  font-size: 0.8rem;
   font-weight: 650;
   letter-spacing: -0.005em;
   transition:
@@ -64,6 +68,17 @@
   background: var(--site-bg);
   color: var(--site-text-strong);
   box-shadow: 0 1px 5px rgba(0, 0, 0, 0.16);
+}
+
+.audienceIcon {
+  width: 0.9rem;
+  height: 0.9rem;
+  flex: 0 0 auto;
+  stroke-width: 1.8;
+}
+
+.audienceTabActive .audienceIcon {
+  color: var(--site-accent-strong);
 }
 
 /* Carries the surface the install card used to have, so the command reads as a
@@ -141,6 +156,13 @@
   color: var(--site-brand-blue);
 }
 
+.copyButton svg {
+  display: block;
+  width: 0.92rem;
+  height: 0.92rem;
+  stroke-width: 1.8;
+}
+
 .command {
   display: block;
   overflow-x: auto;
@@ -170,14 +192,14 @@
   margin-top: 1.25rem;
 }
 
-.guideLink:global(.pill) {
+.guideLink.guideLink {
   border-color: var(--site-brand-blue) !important;
   background: var(--site-brand-blue) !important;
   color: #030303 !important;
   box-shadow: 0 10px 24px rgba(48, 162, 255, 0.16) !important;
 }
 
-.guideLink:global(.pill):hover {
+.guideLink.guideLink:hover {
   border-color: var(--site-brand-blue-light) !important;
   background: var(--site-brand-blue-light) !important;
   color: #030303 !important;
@@ -185,7 +207,7 @@
   transform: translateY(-1px);
 }
 
-.docsLink:global(.pill):hover {
+.docsLink.docsLink:hover {
   border-color: var(--site-hover-border) !important;
   background: var(--site-hover-surface-bg-soft) !important;
   color: var(--site-brand-blue) !important;
@@ -219,7 +241,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .guideLink:global(.pill):hover {
+  .guideLink.guideLink:hover {
     transform: none;
   }
 }

--- a/website/src/components/InstallQuickStartSection/index.tsx
+++ b/website/src/components/InstallQuickStartSection/index.tsx
@@ -1,7 +1,9 @@
 import React, { useEffect, useState } from 'react'
 import Translate, { translate } from '@docusaurus/Translate'
+import { FiAlertCircle, FiCheck, FiCopy, FiTerminal, FiUser } from 'react-icons/fi'
 import { PillLink, SectionLabel } from '@site/src/components/site/Chrome'
 import {
+  AGENT_INSTALL_DOC_PATH,
   AGENT_INSTALL_PROMPT,
   AGENT_SKILL_PATH,
   CURL_INSTALL_COMMAND,
@@ -123,6 +125,7 @@ export default function InstallQuickStartSection(): JSX.Element {
             }}
             onKeyDown={handleAudienceNavigation}
           >
+            <FiUser className={styles.audienceIcon} aria-hidden="true" />
             <Translate id="homepage.install.audience.human">For humans</Translate>
           </button>
           <button
@@ -138,6 +141,7 @@ export default function InstallQuickStartSection(): JSX.Element {
             }}
             onKeyDown={handleAudienceNavigation}
           >
+            <FiTerminal className={styles.audienceIcon} aria-hidden="true" />
             <Translate id="homepage.install.audience.agent">For agents</Translate>
           </button>
         </div>
@@ -165,7 +169,9 @@ export default function InstallQuickStartSection(): JSX.Element {
             title={copyLabel}
             aria-label={copyLabel}
           >
-            <span aria-hidden="true">{copied ? '✓' : failed ? '!' : '⧉'}</span>
+            <span aria-hidden="true">
+              {copied ? <FiCheck /> : failed ? <FiAlertCircle /> : <FiCopy />}
+            </span>
           </button>
         </div>
 
@@ -174,10 +180,10 @@ export default function InstallQuickStartSection(): JSX.Element {
             ? (
                 <PillLink
                   className={styles.guideLink}
-                  href={AGENT_SKILL_PATH}
+                  to={AGENT_INSTALL_DOC_PATH}
                 >
                   <Translate id="homepage.install.agentCta">
-                    View agent skill
+                    Agent installation guide
                   </Translate>
                 </PillLink>
               )
@@ -190,8 +196,8 @@ export default function InstallQuickStartSection(): JSX.Element {
               )}
           {activeAudience === 'agent'
             ? (
-                <PillLink className={styles.docsLink} to="/docs/installation" muted>
-                  <Translate id="homepage.install.secondaryCta">Open quickstart</Translate>
+                <PillLink className={styles.docsLink} href={AGENT_SKILL_PATH} muted>
+                  <Translate id="homepage.install.secondaryCta">View raw skill</Translate>
                 </PillLink>
               )
             : (

--- a/website/src/data/installation.ts
+++ b/website/src/data/installation.ts
@@ -1,5 +1,6 @@
 export const AGENT_SKILL_PATH = '/install/agent/vllm-sr/SKILL.md'
 export const AGENT_SKILL_URL = `https://vllm-sr.ai${AGENT_SKILL_PATH}`
+export const AGENT_INSTALL_DOC_PATH = '/docs/installation/agent'
 
 export const CURL_INSTALL_COMMAND = 'curl -fsSL https://vllm-sr.ai/install.sh | bash -s -- --channel stable'
 

--- a/website/static/install/agent/vllm-sr/SKILL.md
+++ b/website/static/install/agent/vllm-sr/SKILL.md
@@ -49,8 +49,9 @@ boundaries take precedence over this skill.
    ```
 
    Use `vllm-sr config schema --surface KIND:NAME` for a selected signal,
-   projection, algorithm, or plugin. Query the narrowest path first; a broad
-   section can still be large because it contains every valid nested choice.
+   projection, algorithm, or plugin. Section requests return compact field
+   directories; follow their child paths and use `--expanded` only when a
+   self-contained section schema is required.
 5. Start from the running configuration when one exists by reading
    `vllm-sr config get`; otherwise create `config.yaml` with
    `vllm-sr config init`. Preserve fields outside the requested change.
@@ -66,7 +67,11 @@ boundaries take precedence over this skill.
    vllm-sr config plan --config config.yaml
    ```
 
-7. Review the plan. Apply only when it matches the user's requested scope:
+7. Review the plan. A `RESTART_REQUIRED` result means the candidate changes a
+   listener or provider backend topology rendered into Envoy. Do not call the
+   Router apply API for that candidate; follow the deployment workflow and ask
+   before disrupting a running stack. Apply a hot-reloadable candidate only
+   when it matches the user's requested scope:
 
    ```bash
    vllm-sr config apply --config config.yaml
@@ -89,9 +94,11 @@ boundaries take precedence over this skill.
 
    Preview proves the decision path without invoking a model. Probe sends a
    real request through Envoy and records end-to-end evidence. `--base-url`
-   accepts either the listener origin or its OpenAI `/v1` root. Use explicit
-   `--expect-*` assertions when the intended recipe, decision, algorithm, or
-   model is known.
+   accepts either the listener origin or its OpenAI `/v1` root. Use
+   `--expect-selected-model` to assert the Router receipt and, when the backend
+   exposes a stable top-level OpenAI `model`, `--expect-response-model` to prove
+   which upstream answered. These are different assertions; a selected-model
+   header alone does not prove data-plane delivery.
 9. For optimization, capture a baseline, make one coherent recipe change,
    validate and plan it, run representative previews and probes, and compare
    the requested quality, cost, latency, or safety objective. Keep a change
@@ -108,8 +115,9 @@ boundaries take precedence over this skill.
 - Ask before privileged actions, destructive changes, public exposure, or
   stopping unrelated services. Resolve exact container and file targets first.
 - Preserve existing user configuration and unrelated workloads.
-- Do not treat routing preview as model-quality evidence or an end-to-end probe
-  as proof that every routing branch is correct; use both where appropriate.
+- Do not treat routing preview as model-quality evidence, a selected-model
+  header as backend-delivery evidence, or one end-to-end probe as proof that
+  every routing branch is correct; use the applicable assertions and benchmarks.
 - Leave the user with the config path, active revision, validation result,
   routing evidence, and any remaining limitation.
 

--- a/website/static/install/agent/vllm-sr/SKILL.md
+++ b/website/static/install/agent/vllm-sr/SKILL.md
@@ -26,7 +26,8 @@ boundaries take precedence over this skill.
 
 1. Clarify the requested outcome and inspect the host, existing installation,
    current config, model endpoints, container runtime, and accelerator with
-   read-only commands.
+   read-only commands. Check accelerator inventory vendor-neutrally; a missing
+   NVIDIA or AMD utility alone is not evidence that the host has no GPU.
 2. If the CLI is missing, install the stable release without starting or
    changing a runtime yet:
 

--- a/website/static/install/agent/vllm-sr/SKILL.md
+++ b/website/static/install/agent/vllm-sr/SKILL.md
@@ -69,9 +69,18 @@ boundaries take precedence over this skill.
 
 7. Review the plan. A `RESTART_REQUIRED` result means the candidate changes a
    listener or provider backend topology rendered into Envoy. Do not call the
-   Router apply API for that candidate; follow the deployment workflow and ask
-   before disrupting a running stack. Apply a hot-reloadable candidate only
-   when it matches the user's requested scope:
+   Router apply API for that candidate. For a local Docker deployment, ask
+   before disrupting the running stack, then explicitly replace its active
+   runtime config from the reviewed source document:
+
+   ```bash
+   vllm-sr serve --config config.yaml --replace-active-config
+   ```
+
+   Without `--replace-active-config`, `serve` preserves Dashboard or Recipe
+   changes in active runtime state. The flag cannot replace an active Recipe
+   package; change that package through its Recipe workflow. Apply a
+   hot-reloadable candidate only when it matches the user's requested scope:
 
    ```bash
    vllm-sr config apply --config config.yaml

--- a/website/static/install/agent/vllm-sr/SKILL.md
+++ b/website/static/install/agent/vllm-sr/SKILL.md
@@ -43,14 +43,22 @@ boundaries take precedence over this skill.
 
    ```bash
    vllm-sr config schema
-   vllm-sr config schema --section providers
-   vllm-sr config schema --section routing
+   vllm-sr config schema --section providers.models
+   vllm-sr config schema --section routing.modelCards
+   vllm-sr config schema --section routing.decisions.modelRefs
    ```
 
    Use `vllm-sr config schema --surface KIND:NAME` for a selected signal,
-   projection, algorithm, or plugin.
-5. Create or update canonical YAML. Keep credentials in environment variables
-   and store only environment references in the config.
+   projection, algorithm, or plugin. Query the narrowest path first; a broad
+   section can still be large because it contains every valid nested choice.
+5. Start from the running configuration when one exists by reading
+   `vllm-sr config get`; otherwise create `config.yaml` with
+   `vllm-sr config init`. Preserve fields outside the requested change.
+   A physical model must be present in `providers.models`, represented by a
+   matching `routing.modelCards` entry, and referenced from the applicable
+   `routing.decisions[].modelRefs` before it can receive routed traffic. Keep
+   credentials in environment variables and store only environment references
+   in the config.
 6. Validate locally, then ask the running Router to plan the exact mutation:
 
    ```bash
@@ -74,12 +82,14 @@ boundaries take precedence over this skill.
 
    vllm-sr route probe \
      --config config.yaml \
+     --base-url http://localhost:8899/v1 \
      --model vllm-sr/auto \
      --prompt 'Return exactly: route-ok'
    ```
 
    Preview proves the decision path without invoking a model. Probe sends a
-   real request through Envoy and records end-to-end evidence. Use explicit
+   real request through Envoy and records end-to-end evidence. `--base-url`
+   accepts either the listener origin or its OpenAI `/v1` root. Use explicit
    `--expect-*` assertions when the intended recipe, decision, algorithm, or
    model is known.
 9. For optimization, capture a baseline, make one coherent recipe change,

--- a/website/static/openapi/apiserver/apiserver.openapi.json
+++ b/website/static/openapi/apiserver/apiserver.openapi.json
@@ -1287,6 +1287,14 @@
             }
           },
           {
+            "name": "expanded",
+            "in": "query",
+            "description": "Return a self-contained JSON Schema for view=section instead of its compact field directory.",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
             "name": "kind",
             "in": "query",
             "description": "Surface kind required by view=surface.",


### PR DESCRIPTION
Related #3695

## Purpose

The merged single-source configuration and agent API work exposed four integration gaps during live dogfood:

- an agent had no minimal command to initialize a canonical candidate config
- schema discovery returned the full document instead of a progressive field directory
- routing evidence conflated the Router-selected model with the actual upstream response model
- a source config could be hidden by preserved runtime state, while Router hot reload accepted fields that require Envoy regeneration

This change closes those gaps, normalizes OpenAI endpoint inputs, and compares planned YAML documents semantically so formatting-only changes do not trigger mutations. The public Skill, CLI/API docs, generated OpenAPI contract, and Dashboard schema consumer are updated from the same contract.

The website now presents one compact Human/Agent installation switch from a shared source. The Agent path is one copyable sentence that resolves to the public, self-contained Skill, with a dedicated installation guide for workflow and safety boundaries; the implementation details remain in the Skill instead of being duplicated in the prompt.

## Test Plan

- run targeted Python CLI/config tests
- run Router configschema and apiserver tests
- run Dashboard frontend and backend tests
- run harness, generated schema, OpenAPI, documentation, and website checks
- visually inspect the homepage installation block at desktop and mobile widths
- deploy the branch on an existing AMD Instinct environment with three live OpenAI-compatible backends
- give one model only the public one-line Skill prompt and observe installation, schema discovery, config validation/plan, route preview, and a real probe
- independently probe all three configured backends through Envoy

## Test Result

- 115 targeted Python tests passed
- Router configschema and apiserver tests passed
- Dashboard backend full suite passed with the repository Python environment
- Dashboard frontend lint and type-check passed; 189 test files / 874 tests passed
- CLI integration suite passed: 49 tests with 9 expected skips
- harness validation passed: 128 registry tests and 33 workflow tests
- generated config schema, OpenAPI, documentation translation, and English/Chinese website builds passed
- the homepage Human/Agent control and responsive actions were visually checked at desktop and mobile widths
- the model agent completed the full CLI-first loop without the Dashboard; its semantic plan returned valid true and changed false, and its selected-model and response-model assertions passed
- all three configured backends passed independent selected-model and response-model probes

The retained validation environment runs the latest PR source and keeps all three model backends available. The public stable package still reflects the current release boundary; the candidate Skill was tested against the source-pinned PR package.
