### PR TITLE
[Bug] Preserve explicit false/0 global values across reconcile

### DIFF
--- a/src/semantic-router/pkg/config/canonical_global_zero_values_test.go
+++ b/src/semantic-router/pkg/config/canonical_global_zero_values_test.go
@@ -1,0 +1,71 @@
+package config
+
+import (
+	"testing"
+
+	yamlv3 "gopkg.in/yaml.v3"
+)
+
+func reconcileRoundTrip(t *testing.T, cfg *RouterConfig) *RouterConfig {
+	t.Helper()
+	canonical := CanonicalStaticConfigFromRouterConfig(cfg)
+	encoded, err := yamlv3.Marshal(canonical)
+	if err != nil {
+		t.Fatalf("marshal canonical config: %v", err)
+	}
+	parsed, err := ParseYAMLBytes(encoded)
+	if err != nil {
+		t.Fatalf("parse canonical config: %v", err)
+	}
+	return parsed
+}
+
+func TestReconcilePreservesResponseCacheTTLZero(t *testing.T) {
+	cfg := &RouterConfig{}
+	cfg.SemanticCache.TTLSeconds = 0
+
+	parsed := reconcileRoundTrip(t, cfg)
+	if parsed.SemanticCache.TTLSeconds != 0 {
+		t.Fatalf("response_cache.ttl_seconds = %d, want 0", parsed.SemanticCache.TTLSeconds)
+	}
+}
+
+func TestReconcilePreservesRouterReplayTTLZero(t *testing.T) {
+	cfg := &RouterConfig{}
+	cfg.RouterReplay.TTLSeconds = 0
+
+	parsed := reconcileRoundTrip(t, cfg)
+	if parsed.RouterReplay.TTLSeconds != 0 {
+		t.Fatalf("router_replay.ttl_seconds = %d, want 0", parsed.RouterReplay.TTLSeconds)
+	}
+}
+
+func TestReconcilePreservesTracingInsecureFalse(t *testing.T) {
+	cfg := &RouterConfig{}
+	cfg.Observability.Tracing.Exporter.Insecure = false
+
+	parsed := reconcileRoundTrip(t, cfg)
+	if parsed.Observability.Tracing.Exporter.Insecure {
+		t.Fatal("tracing.exporter.insecure = true, want false")
+	}
+}
+
+func TestReconcilePreservesTracingSamplingRateZero(t *testing.T) {
+	cfg := &RouterConfig{}
+	cfg.Observability.Tracing.Sampling.Rate = 0
+
+	parsed := reconcileRoundTrip(t, cfg)
+	if parsed.Observability.Tracing.Sampling.Rate != 0 {
+		t.Fatalf("tracing.sampling.rate = %v, want 0", parsed.Observability.Tracing.Sampling.Rate)
+	}
+}
+
+func TestReconcilePreservesNLIFilteringDisabled(t *testing.T) {
+	cfg := &RouterConfig{}
+	cfg.HallucinationMitigation.HallucinationModel.EnableNLIFiltering = false
+
+	parsed := reconcileRoundTrip(t, cfg)
+	if parsed.HallucinationMitigation.HallucinationModel.EnableNLIFiltering {
+		t.Fatal("hallucination detector enable_nli_filtering = true, want false")
+	}
+}

--- a/src/semantic-router/pkg/config/model_config_types.go
+++ b/src/semantic-router/pkg/config/model_config_types.go
@@ -304,7 +304,7 @@ type HallucinationModelConfig struct {
 	MinSpanLength          int     `yaml:"min_span_length,omitempty"`
 	MinSpanConfidence      float32 `yaml:"min_span_confidence,omitempty"`
 	ContextWindowSize      int     `yaml:"context_window_size,omitempty"`
-	EnableNLIFiltering     bool    `yaml:"enable_nli_filtering,omitempty"`
+	EnableNLIFiltering     bool    `yaml:"enable_nli_filtering"`
 	NLIEntailmentThreshold float32 `yaml:"nli_entailment_threshold,omitempty"`
 }
 

--- a/src/semantic-router/pkg/config/observability_config.go
+++ b/src/semantic-router/pkg/config/observability_config.go
@@ -52,12 +52,12 @@ type TracingConfig struct {
 type TracingExporterConfig struct {
 	Type     string `yaml:"type"`
 	Endpoint string `yaml:"endpoint,omitempty"`
-	Insecure bool   `yaml:"insecure,omitempty"`
+	Insecure bool   `yaml:"insecure"`
 }
 
 type TracingSamplingConfig struct {
 	Type string  `yaml:"type"`
-	Rate float64 `yaml:"rate,omitempty"`
+	Rate float64 `yaml:"rate"`
 }
 
 type TracingResourceConfig struct {

--- a/src/semantic-router/pkg/config/runtime_config.go
+++ b/src/semantic-router/pkg/config/runtime_config.go
@@ -215,7 +215,7 @@ type ResponseCacheStoreConfig struct {
 	Enabled             bool          `yaml:"enabled"`
 	SimilarityThreshold *float32      `yaml:"similarity_threshold,omitempty"`
 	MaxEntries          int           `yaml:"max_entries,omitempty"`
-	TTLSeconds          int           `yaml:"ttl_seconds,omitempty"`
+	TTLSeconds          int           `yaml:"ttl_seconds"`
 	EvictionPolicy      string        `yaml:"eviction_policy,omitempty"`
 	Redis               *RedisConfig  `yaml:"redis,omitempty"`
 	Valkey              *ValkeyConfig `yaml:"valkey,omitempty"`
@@ -385,7 +385,7 @@ type ResponseAPIRedisConfig struct {
 type RouterReplayConfig struct {
 	Enabled      bool                        `json:"enabled" yaml:"enabled"`
 	StoreBackend string                      `json:"store_backend,omitempty" yaml:"store_backend,omitempty"`
-	TTLSeconds   int                         `json:"ttl_seconds,omitempty" yaml:"ttl_seconds,omitempty"`
+	TTLSeconds   int                         `json:"ttl_seconds" yaml:"ttl_seconds"`
 	AsyncWrites  bool                        `json:"async_writes,omitempty" yaml:"async_writes,omitempty"`
 	Redis        *RouterReplayRedisConfig    `json:"redis,omitempty" yaml:"redis,omitempty"`
 	Postgres     *RouterReplayPostgresConfig `json:"postgres,omitempty" yaml:"postgres,omitempty"`


### PR DESCRIPTION
Closes #3734

## Purpose

On every CRD reconcile, `validateAndUpdate` exports the static config with
`CanonicalStaticConfigFromRouterConfig`, marshals it with yaml.v3, and re-parses
the result. Several global fields are tagged `omitempty` but default to a
non-zero value, so an explicit `false` or `0` is dropped on export and the
default is restored on re-parse.

Fields fixed (all in `pkg/config`):

| Field | Default that leaked back |
| --- | --- |
| `global.stores.response_cache.ttl_seconds` | `3600` |
| `global.services.router_replay.ttl_seconds` | `2592000` |
| `global.model_catalog.modules.hallucination_mitigation.detector.enable_nli_filtering` | `true` |
| `global.services.observability.tracing.exporter.insecure` | `true` |
| `global.services.observability.tracing.sampling.rate` | `1` |

This is the same class of bug #2735 reported and #2736 fixed for
`router_replay.enabled`; the fix is identical — drop `omitempty` so the explicit
zero survives marshalling.

Impact: an operator who sets `response_cache.ttl_seconds: 0` (no expiration,
since the in-memory cache skips TTL cleanup when `TTLSeconds <= 0`) gets a 1h
expiry back after the first reconcile; one who disabled the NLI filter gets it
re-enabled.

Owner: `wg/enterprise-environment` (the issue's accepted Workgroup).

## Test Plan

New `pkg/config/canonical_global_zero_values_test.go` replays the reconciler's
exact steps (`CanonicalStaticConfigFromRouterConfig` → `yaml.v3 Marshal` →
`ParseYAMLBytes`) for each field and asserts the explicit zero survives.

```
go test ./pkg/config/ -run TestReconcilePreserves -v
go test ./pkg/config/
go vet ./pkg/config/
gofmt -l <changed files>
```

## Test Result

RED→GREEN verified. Before the fix (with the tests in place, source reverted)
all five fail, e.g.:

```
canonical_global_zero_values_test.go:29: response_cache.ttl_seconds = 3600, want 0
canonical_global_zero_values_test.go:39: router_replay.ttl_seconds = 2592000, want 0
canonical_global_zero_values_test.go:49: tracing.exporter.insecure = true, want false
canonical_global_zero_values_test.go:59: tracing.sampling.rate = 1, want 0
canonical_global_zero_values_test.go:69: hallucination detector enable_nli_filtering = true, want false
```

After the fix:

```
ok  github.com/vllm-project/semantic-router/src/semantic-router/pkg/config
--- PASS: TestReconcilePreservesResponseCacheTTLZero
--- PASS: TestReconcilePreservesRouterReplayTTLZero
--- PASS: TestReconcilePreservesTracingInsecureFalse
--- PASS: TestReconcilePreservesTracingSamplingRateZero
--- PASS: TestReconcilePreservesNLIFilteringDisabled
```

The full `pkg/config` suite passes, `go vet ./pkg/config/` is clean and the
changed files are gofmt-clean. I couldn't run `pkg/k8s`/`pkg/apiserver` tests
locally — they link the prebuilt Rust CGO bindings
(`libcandle_semantic_router`) which aren't built in my environment; that's a
link-time limitation unrelated to this change, which is confined to struct tags
in `pkg/config`.

AI/LLM disclosure: this change was prepared with AI assistance and reviewed
before submission.
