### PR TITLE
[Bug] Stop Live verification column from reflowing the Pricing column

### DIFF
--- a/dashboard/frontend/e2e/model-live-verification.spec.ts
+++ b/dashboard/frontend/e2e/model-live-verification.spec.ts
@@ -111,6 +111,7 @@ test('lets an operator run a real provider-model query and renders pending, veri
   ).toBeEnabled()
   expect(requestBodies).toEqual([{ model: 'logical-model' }, { model: 'logical-model' }])
 })
+
 test('keeps the Pricing column horizontally stable while the Live status changes', async ({
   page,
 }) => {

--- a/dashboard/frontend/e2e/model-live-verification.spec.ts
+++ b/dashboard/frontend/e2e/model-live-verification.spec.ts
@@ -111,3 +111,132 @@ test('lets an operator run a real provider-model query and renders pending, veri
   ).toBeEnabled()
   expect(requestBodies).toEqual([{ model: 'logical-model' }, { model: 'logical-model' }])
 })
+test('keeps the Pricing column horizontally stable while the Live status changes', async ({
+  page,
+}) => {
+  // Wide enough that the Models table (760px min-width, plus selection/expand/actions
+  // columns) never needs horizontal scroll. Otherwise Playwright's own scroll-into-view
+  // before the verify button's click moves the whole table, which would swamp the
+  // sub-column-width reflow this test is isolating.
+  await page.setViewportSize({ width: 1600, height: 1000 })
+  await mockAuthenticatedAppShell(page)
+  await page.route('**/api/router/config/all', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        version: 'v0.3',
+        providers: {
+          defaults: { default_model: 'logical-model' },
+          models: [
+            {
+              name: 'logical-model',
+              provider_model_id: 'provider/real-model',
+              api_format: 'openai',
+              backend_refs: [
+                {
+                  name: 'primary',
+                  endpoint: 'provider.internal:8000',
+                  protocol: 'http',
+                },
+              ],
+              // Pricing must be present for this test: an unpriced model renders a static
+              // "N/A" cell that can't reflow, which would hide the bug this test guards.
+              pricing: { currency: 'USD', prompt_per_1m: 3.5 },
+            },
+          ],
+        },
+        routing: {
+          modelCards: [{ name: 'logical-model', description: 'Physical provider model' }],
+          decisions: [],
+        },
+      }),
+    })
+  })
+  await page.route('**/api/router/config/global', async (route) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+  })
+  await page.route('**/api/recipe', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ managed: false }),
+    })
+  })
+
+  let releaseFirstVerification!: () => void
+  const firstVerificationReleased = new Promise<void>((resolve) => {
+    releaseFirstVerification = resolve
+  })
+  let firstVerificationStarted!: () => void
+  const firstVerificationRequest = new Promise<void>((resolve) => {
+    firstVerificationStarted = resolve
+  })
+  const requestBodies: Array<Record<string, unknown>> = []
+  await page.route('**/api/models/verify', async (route) => {
+    requestBodies.push(route.request().postDataJSON() as Record<string, unknown>)
+    if (requestBodies.length === 1) {
+      firstVerificationStarted()
+      await firstVerificationReleased
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          verified: true,
+          model: 'logical-model',
+          providerModel: 'provider/real-model',
+          backend: 'logical-model/primary',
+          provider: 'openai',
+          summary: 'OK from provider',
+          verifiedAt: '2026-08-15T05:06:07Z',
+          latencyMs: 18,
+        }),
+      })
+      return
+    }
+    await route.fulfill({
+      status: 502,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        error: 'provider_rejected',
+        message: 'Provider inference returned HTTP 503.',
+      }),
+    })
+  })
+
+  await page.goto('/config/models')
+  const pricingCell = page.getByRole('cell', { name: '$3.50 / 1M' })
+  const verifyButton = page.getByRole('button', {
+    name: 'Check logical-model with a real inference query',
+  })
+  await expect(verifyButton).toBeEnabled()
+
+  // idle: baseline position for the column immediately to the right of Live.
+  const idleX = (await pricingCell.boundingBox())?.x
+  expect(idleX).toBeDefined()
+
+  await verifyButton.click()
+  await firstVerificationRequest
+  await expect(page.getByRole('button', { name: /Checking… logical-model/ })).toBeDisabled()
+
+  // pending: the button label ("Checking…") is the widest of the three normal states.
+  const pendingX = (await pricingCell.boundingBox())?.x
+  expect(pendingX).toBe(idleX)
+
+  releaseFirstVerification()
+  await expect(page.getByText('Live', { exact: true })).toBeVisible()
+
+  // verified: label shrinks back to "Check again" — must not un-shift the column either.
+  const verifiedX = (await pricingCell.boundingBox())?.x
+  expect(verifiedX).toBe(idleX)
+
+  await page
+    .getByRole('button', { name: 'Check again logical-model with a real inference query' })
+    .click()
+  await expect(page.getByText('Unavailable', { exact: true })).toBeVisible()
+  await expect(page.getByText('Provider inference returned HTTP 503.')).toBeVisible()
+
+  // failed: an inline error message is inserted into the Live cell alongside the dot/button.
+  const failedX = (await pricingCell.boundingBox())?.x
+  expect(failedX).toBe(idleX)
+})

--- a/dashboard/frontend/src/pages/ConfigPageModelsSection.module.css
+++ b/dashboard/frontend/src/pages/ConfigPageModelsSection.module.css
@@ -88,10 +88,17 @@
 }
 
 .liveVerification {
+  /* Fixed width, not min-width: idle/pending/verified/failed each render different-length
+   * text (status label, button label, and an inline error on failure). A content-driven
+   * width here changes per status and reflows every column to its right (e.g. Pricing) as
+   * the operator watches a verification run. Column layout, not this width, is what should
+   * flex if the Live column itself is ever resized. Matches the Live column's declared
+   * width in ConfigPageModelInventoryPanel.tsx (164px) minus the table cell's 1rem
+   * horizontal padding on each side (DataTable.module.css .td). */
   display: flex;
-  min-width: 145px;
-  align-items: center;
-  gap: 0.5rem;
+  flex-direction: column;
+  width: 132px;
+  gap: 0.3rem;
 }
 
 .liveVerificationHeading {
@@ -130,6 +137,8 @@
 
 .liveVerificationLabel {
   overflow: hidden;
+  min-width: 0;
+  flex: 1 1 auto;
   color: rgba(255, 255, 255, 0.76);
   font-size: 0.72rem;
   font-weight: 690;
@@ -168,14 +177,22 @@
 }
 
 .liveVerificationError {
+  /* Overrides the 220px max-width shared with .liveVerificationEvidence above: this span
+   * sits inside the fixed-width .liveVerification column (see comment there) and must not
+   * exceed it, or the failed state reflows the row the same way the button label does. */
+  max-width: 100%;
   color: #fecaca;
 }
 
 .liveVerificationButton {
+  /* Fixed width (not fit-content): "Check", "Checking…" and "Check again" render at
+   * different natural widths, and a fit-content button resizes with the label, reflowing
+   * the fixed-width .liveVerification column above it. */
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 0.3rem;
-  width: fit-content;
+  width: 100%;
   min-height: 28px;
   padding: 0.28rem 0.58rem;
   border: 1px solid rgba(255, 255, 255, 0.14);


### PR DESCRIPTION
<!-- markdownlint-disable -->
Describe the change and keep commands and results specific to this PR.

Closes #3742
<!-- For split PRs that should not auto-close the issue on merge, use: Related #xxxx -->
<!-- The linked issue must be accepted and have exactly one recognized owner. -->

## Purpose

`ConfigPageModelLiveVerification` (rendered in the Live column of the Models table, `ConfigPageModelInventoryPanel.tsx`) sized itself to its own content: `.liveVerification` used `min-width` only and `.liveVerificationButton` used `width: fit-content`. Idle/pending/verified/failed each render a different-length status label and button label ("Check" / "Checking…" / "Check again"), and the failed state additionally inserts an inline error span into the same row. Because the Models table uses `table-layout: auto` (`DataTable.module.css`), that per-status content width reflowed the whole row, visibly shifting the Pricing column ($ amount) left and right on every verification run, exactly as described in #3742.

This PR gives `.liveVerification` (`ConfigPageModelsSection.module.css`) a fixed width matching its declared table column (164px minus the cell's 1rem horizontal padding on each side = 132px), switches it to a vertical status-row-above-action-row layout, and makes the button and error span fill that fixed width instead of sizing to their own content. The Live cell's rendered footprint is now identical across all four states, so neighboring columns (Pricing, Actions) never move.

## Test Plan

- Added a Playwright test (`e2e/model-live-verification.spec.ts`) that drives a model through idle -> pending -> verified -> failed and asserts the Pricing cell's `boundingBox().x` is unchanged at every step. Confirmed it fails against the pre-fix CSS and passes with this fix.
- `npx playwright test e2e/model-live-verification.spec.ts` (both tests in the file)
- `npx playwright test e2e/model-inventory.spec.ts` (unrelated Models-page coverage, checked for regressions from the shared `ConfigPageModelsSection.module.css`)
- `npx tsc --noEmit`
- `npx eslint e2e/model-live-verification.spec.ts`
- `npx prettier --check e2e/model-live-verification.spec.ts src/pages/ConfigPageModelsSection.module.css`
- `npx vitest run src` (full existing unit suite)

## Test Result

All of the above pass locally. `model-live-verification.spec.ts`: 2/2 passed (the new stability test fails on `main`, passes on this branch). `model-inventory.spec.ts`: 5/5 passed. `tsc --noEmit`: no errors. `eslint`/`prettier`: clean. `vitest run src`: 874/874 passed. This is a CSS-only layout fix plus its regression test; no behavior change to the verification flow itself, and no blockers found.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category, such as `[Feature]`, `[Bug]`, `[Docs]`, `[Test]`, `[Research]`, `[Community]`, or `[CI/Build]`
- [x] The title does not stack prefixes such as `[Router][Docs]`; affected modules belong in labels and the PR body
- [x] The PR links an `accepted` issue with exactly one owner: one `wg/*` label for project work or `owner/maintainers` for repository governance
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
