### PR TITLE
[Router] Capture stage-aware request demand snapshots

### DIFF
--- a/src/semantic-router/pkg/extproc/processor_req_body.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body.go
@@ -71,6 +71,7 @@ func (r *OpenAIRouter) handleRequestBody(
 	if err != nil {
 		return nil, err
 	}
+	captureRequestDemand(ctx, requestDemandStagePostContext, request, decisionState.selectedModel)
 	return r.handleModelRoutingWithPersonalizedCache(
 		request,
 		originalModel,
@@ -111,6 +112,7 @@ func (r *OpenAIRouter) handleModelRouting(request *llmprotocol.Request, original
 			"decision":   decisionName,
 		})
 	}
+	captureRequestDemand(ctx, requestDemandStagePostToolPolicy, request, selectedModel)
 	isEntrypoint := ctx.Routing.SelectedRecipe() != nil
 	executesLooper := r.routeExecutesLooper(ctx)
 	if !isEntrypoint && !executesLooper && !r.usesExternalGatewayDispatch(originalModel) {

--- a/src/semantic-router/pkg/extproc/processor_req_body_prepare.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body_prepare.go
@@ -27,6 +27,7 @@ func (r *OpenAIRouter) extractRequestSignalSnapshot(
 	}
 	captureOriginalContextHistory(ctx)
 	snapshot := extractSemanticRequestSignals(ctx.SemanticRequest)
+	captureOriginalRequestDemand(ctx, ctx.SemanticRequest, snapshot)
 	if snapshot.Stream {
 		logging.ComponentDebugEvent("extproc", "stream_parameter_detected", map[string]interface{}{
 			"request_id": ctx.RequestID,

--- a/src/semantic-router/pkg/extproc/processor_req_body_routing.go
+++ b/src/semantic-router/pkg/extproc/processor_req_body_routing.go
@@ -371,6 +371,12 @@ func (r *OpenAIRouter) finalizeProviderDispatchResponse(
 	if dispatch == nil || response == nil {
 		return nil, status.Error(codes.Internal, "provider dispatch is unavailable")
 	}
+	captureRequestDemand(
+		ctx,
+		requestDemandStageProviderBound,
+		ctx.SemanticRequest,
+		dispatch.logicalModel,
+	)
 	body, err := r.encodeDispatchRequest(ctx)
 	if err != nil {
 		metrics.RecordRequestError(dispatch.logicalModel, "serialization_error")

--- a/src/semantic-router/pkg/extproc/recorder_route_diagnostics.go
+++ b/src/semantic-router/pkg/extproc/recorder_route_diagnostics.go
@@ -62,6 +62,7 @@ func buildReplayRouteDiagnostics(
 		ContextCompressionQuality:      ctx.ContextCompressionQuality,
 		ContextCompressionFallback:     ctx.ContextCompressionFallback,
 		ContextCompressionCostSaved:    ctx.ContextCompressionCostSaved,
+		RequestDemandSnapshots:         cloneRequestDemandSnapshots(ctx.RequestDemandSnapshots),
 		SignalErrors:                   cloneReplayStringMap(ctx.VSRSignalErrors),
 		AppliedUnknownPolicies:         ctx.VSRDecisionDiagnostics.AppliedUnknownPolicies,
 	}

--- a/src/semantic-router/pkg/extproc/request_context.go
+++ b/src/semantic-router/pkg/extproc/request_context.go
@@ -176,6 +176,10 @@ type RequestContext struct {
 	// Modality routing classification result (AR/DIFFUSION/BOTH)
 	ModalityClassification *ModalityClassificationResult // Set by classifyModality()
 
+	// RequestDemandSnapshots retains at most one content-free demand estimate for
+	// each stable request stage. It is observe-only until final admission lands.
+	RequestDemandSnapshots []routerreplay.RequestDemandSnapshot
+
 	// VSR signal tracking - stores all matched signals for response headers
 	VSRMatchedKeywords        []string // Matched keyword rule names
 	VSRMatchedEmbeddings      []string // Matched embedding rule names

--- a/src/semantic-router/pkg/extproc/request_demand.go
+++ b/src/semantic-router/pkg/extproc/request_demand.go
@@ -1,0 +1,178 @@
+package extproc
+
+import (
+	"math"
+	"strings"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/llmprotocol"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/observability/metrics"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/routerreplay"
+)
+
+const (
+	requestDemandStageOriginal       = "original"
+	requestDemandStagePostContext    = "post_context"
+	requestDemandStagePostToolPolicy = "post_tool_policy"
+	requestDemandStageProviderBound  = "provider_bound"
+
+	requestDemandCountingSourceFallback = "fallback"
+	requestDemandRepresentationSemantic = "semantic"
+	requestDemandOutputReserveExplicit  = "explicit"
+	requestDemandOutputReserveUnknown   = "unknown"
+
+	maxRequestDemandSnapshots = 4
+)
+
+var requestDemandStageOrder = map[string]int{
+	requestDemandStageOriginal:       0,
+	requestDemandStagePostContext:    1,
+	requestDemandStagePostToolPolicy: 2,
+	requestDemandStageProviderBound:  3,
+}
+
+// captureRequestDemand records a bounded, content-free estimate of the neutral
+// request at one lifecycle stage. The representation field makes explicit that
+// provider_bound describes the final semantic request before wire encoding; the
+// estimate deliberately uses the existing provider-neutral fallback until #3050
+// supplies tokenizer-aware accounting. This evidence is observe-only: it never
+// changes routing or admission.
+func captureRequestDemand(
+	ctx *RequestContext,
+	stage string,
+	request *llmprotocol.Request,
+	model string,
+) {
+	if ctx == nil || request == nil {
+		return
+	}
+	if _, ok := requestDemandStageOrder[stage]; !ok {
+		return
+	}
+
+	snapshot, ok := reusableRequestDemandSnapshot(ctx.RequestDemandSnapshots, request.Generation)
+	if ok {
+		snapshot.Stage = stage
+		snapshot.Model = firstNonEmpty(strings.TrimSpace(model), strings.TrimSpace(request.Model))
+	} else {
+		facts := extractSemanticRequestSignals(request)
+		snapshot = requestDemandSnapshot(stage, request, model, facts.ContextTokenFloor)
+	}
+	recordRequestDemandSnapshot(ctx, snapshot)
+}
+
+func captureOriginalRequestDemand(
+	ctx *RequestContext,
+	request *llmprotocol.Request,
+	facts *requestSignalSnapshot,
+) {
+	if ctx == nil || request == nil || facts == nil {
+		return
+	}
+	recordRequestDemandSnapshot(ctx, requestDemandSnapshot(
+		requestDemandStageOriginal,
+		request,
+		request.Model,
+		facts.ContextTokenFloor,
+	))
+}
+
+func recordRequestDemandSnapshot(
+	ctx *RequestContext,
+	snapshot routerreplay.RequestDemandSnapshot,
+) {
+	ctx.RequestDemandSnapshots = upsertRequestDemandSnapshot(ctx.RequestDemandSnapshots, snapshot)
+	metrics.RecordRequestDemand(
+		snapshot.Stage,
+		snapshot.CountingSource,
+		snapshot.PromptTokens,
+		snapshot.ReservedOutputTokens,
+		snapshot.TotalDemandTokens,
+		snapshot.TotalDemandKnown,
+	)
+}
+
+func requestDemandSnapshot(
+	stage string,
+	request *llmprotocol.Request,
+	model string,
+	promptTokens int,
+) routerreplay.RequestDemandSnapshot {
+	if promptTokens < 0 {
+		promptTokens = 0
+	}
+	reservedOutput, reserveSource := requestOutputReserve(request)
+	return routerreplay.RequestDemandSnapshot{
+		Stage:                stage,
+		Representation:       requestDemandRepresentationSemantic,
+		Model:                firstNonEmpty(strings.TrimSpace(model), strings.TrimSpace(request.Model)),
+		PromptTokens:         promptTokens,
+		ReservedOutputTokens: reservedOutput,
+		TotalDemandTokens:    saturatingNeutralAdd(promptTokens, reservedOutput),
+		TotalDemandKnown:     reserveSource == requestDemandOutputReserveExplicit,
+		CountingSource:       requestDemandCountingSourceFallback,
+		OutputReserveSource:  reserveSource,
+		RequestGeneration:    request.Generation,
+	}
+}
+
+func requestOutputReserve(request *llmprotocol.Request) (int, string) {
+	if request == nil || request.Sampling.MaxOutputTokens == nil {
+		return 0, requestDemandOutputReserveUnknown
+	}
+	value := *request.Sampling.MaxOutputTokens
+	if value < 0 {
+		return 0, requestDemandOutputReserveUnknown
+	}
+	if value > int64(math.MaxInt) {
+		return math.MaxInt, requestDemandOutputReserveExplicit
+	}
+	return int(value), requestDemandOutputReserveExplicit
+}
+
+func reusableRequestDemandSnapshot(
+	snapshots []routerreplay.RequestDemandSnapshot,
+	generation uint64,
+) (routerreplay.RequestDemandSnapshot, bool) {
+	if len(snapshots) == 0 {
+		return routerreplay.RequestDemandSnapshot{}, false
+	}
+	latest := snapshots[len(snapshots)-1]
+	return latest, latest.RequestGeneration == generation
+}
+
+func upsertRequestDemandSnapshot(
+	snapshots []routerreplay.RequestDemandSnapshot,
+	snapshot routerreplay.RequestDemandSnapshot,
+) []routerreplay.RequestDemandSnapshot {
+	stageIndex, ok := requestDemandStageOrder[snapshot.Stage]
+	if !ok {
+		return snapshots
+	}
+	for index := range snapshots {
+		if snapshots[index].Stage == snapshot.Stage {
+			snapshots[index] = snapshot
+			return snapshots
+		}
+	}
+	if len(snapshots) >= maxRequestDemandSnapshots {
+		return snapshots
+	}
+
+	insertAt := len(snapshots)
+	for index := range snapshots {
+		if existingIndex, exists := requestDemandStageOrder[snapshots[index].Stage]; exists && existingIndex > stageIndex {
+			insertAt = index
+			break
+		}
+	}
+	snapshots = append(snapshots, routerreplay.RequestDemandSnapshot{})
+	copy(snapshots[insertAt+1:], snapshots[insertAt:])
+	snapshots[insertAt] = snapshot
+	return snapshots
+}
+
+func cloneRequestDemandSnapshots(
+	values []routerreplay.RequestDemandSnapshot,
+) []routerreplay.RequestDemandSnapshot {
+	return append([]routerreplay.RequestDemandSnapshot(nil), values...)
+}

--- a/src/semantic-router/pkg/extproc/request_demand_test.go
+++ b/src/semantic-router/pkg/extproc/request_demand_test.go
@@ -1,0 +1,156 @@
+package extproc
+
+import (
+	"encoding/json"
+	"testing"
+
+	ext_proc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/cache"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/llmprotocol"
+	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/routerreplay"
+)
+
+func TestRequestDemandSnapshotSeparatesPromptAndOutputReserve(t *testing.T) {
+	request := testNeutralRequest("auto", "one two three four")
+	request.Generation = 7
+	request.Sampling.MaxOutputTokens = llmprotocol.Int64(256)
+	promptTokens := extractSemanticRequestSignals(request).ContextTokenFloor
+
+	snapshot := requestDemandSnapshot(
+		requestDemandStageOriginal,
+		request,
+		"",
+		promptTokens,
+	)
+
+	if snapshot.Stage != requestDemandStageOriginal || snapshot.Model != "auto" ||
+		snapshot.Representation != requestDemandRepresentationSemantic {
+		t.Fatalf("unexpected snapshot identity: %+v", snapshot)
+	}
+	if snapshot.PromptTokens != promptTokens || snapshot.ReservedOutputTokens != 256 ||
+		snapshot.TotalDemandTokens != promptTokens+256 || !snapshot.TotalDemandKnown {
+		t.Fatalf("unexpected request demand: %+v", snapshot)
+	}
+	if snapshot.CountingSource != requestDemandCountingSourceFallback ||
+		snapshot.OutputReserveSource != requestDemandOutputReserveExplicit ||
+		snapshot.RequestGeneration != 7 {
+		t.Fatalf("unexpected snapshot provenance: %+v", snapshot)
+	}
+}
+
+func TestRequestDemandSnapshotMarksMissingOutputReserveUnknown(t *testing.T) {
+	request := testNeutralRequest("auto", "hello")
+	snapshot := requestDemandSnapshot(
+		requestDemandStageOriginal,
+		request,
+		"",
+		extractSemanticRequestSignals(request).ContextTokenFloor,
+	)
+
+	if snapshot.OutputReserveSource != requestDemandOutputReserveUnknown || snapshot.TotalDemandKnown ||
+		snapshot.ReservedOutputTokens != 0 || snapshot.TotalDemandTokens != snapshot.PromptTokens {
+		t.Fatalf("missing output reserve was not explicit: %+v", snapshot)
+	}
+}
+
+func TestUpsertRequestDemandSnapshotIsBoundedAndStageOrdered(t *testing.T) {
+	var snapshots []routerreplay.RequestDemandSnapshot
+	for _, stage := range []string{
+		requestDemandStageProviderBound,
+		requestDemandStageOriginal,
+		requestDemandStagePostToolPolicy,
+		requestDemandStagePostContext,
+	} {
+		snapshots = upsertRequestDemandSnapshot(snapshots, routerreplay.RequestDemandSnapshot{
+			Stage: stage, PromptTokens: 1,
+		})
+	}
+	snapshots = upsertRequestDemandSnapshot(snapshots, routerreplay.RequestDemandSnapshot{
+		Stage: requestDemandStagePostContext, PromptTokens: 9,
+	})
+	snapshots = upsertRequestDemandSnapshot(snapshots, routerreplay.RequestDemandSnapshot{
+		Stage: "future_unbounded_stage", PromptTokens: 99,
+	})
+
+	wantStages := []string{
+		requestDemandStageOriginal,
+		requestDemandStagePostContext,
+		requestDemandStagePostToolPolicy,
+		requestDemandStageProviderBound,
+	}
+	if len(snapshots) != len(wantStages) {
+		t.Fatalf("snapshot count = %d, want %d: %+v", len(snapshots), len(wantStages), snapshots)
+	}
+	for index, want := range wantStages {
+		if snapshots[index].Stage != want {
+			t.Fatalf("snapshot[%d].Stage = %q, want %q", index, snapshots[index].Stage, want)
+		}
+	}
+	if snapshots[1].PromptTokens != 9 {
+		t.Fatalf("stage upsert did not replace the prior observation: %+v", snapshots[1])
+	}
+}
+
+func TestConcreteModelDispatchCapturesAllRequestDemandStages(t *testing.T) {
+	router, model := routingTestRouterForFormat(llmprotocol.OpenAIChatV1)
+	router.Cache = cache.NewInMemoryCache(cache.InMemoryCacheOptions{Enabled: false})
+	body, err := json.Marshal(map[string]interface{}{
+		"model": model,
+		"messages": []map[string]interface{}{{
+			"role": "user", "content": "stage-aware demand",
+		}},
+		"max_tokens": 128,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := &RequestContext{Headers: map[string]string{}, RequestID: "demand-stages"}
+
+	response, err := router.HandleRequestBody(&ext_proc.ProcessingRequest_RequestBody{
+		RequestBody: &ext_proc.HttpBody{Body: body},
+	}, ctx)
+	if err != nil {
+		t.Fatalf("HandleRequestBody: %v", err)
+	}
+	if response.GetRequestBody() == nil {
+		t.Fatalf("expected provider dispatch response, got %#v", response)
+	}
+
+	wantStages := []string{
+		requestDemandStageOriginal,
+		requestDemandStagePostContext,
+		requestDemandStagePostToolPolicy,
+		requestDemandStageProviderBound,
+	}
+	if len(ctx.RequestDemandSnapshots) != len(wantStages) {
+		t.Fatalf("request demand snapshots = %+v, want stages %v", ctx.RequestDemandSnapshots, wantStages)
+	}
+	for index, want := range wantStages {
+		snapshot := ctx.RequestDemandSnapshots[index]
+		if snapshot.Stage != want {
+			t.Fatalf("snapshot[%d].Stage = %q, want %q", index, snapshot.Stage, want)
+		}
+		if snapshot.CountingSource != requestDemandCountingSourceFallback ||
+			snapshot.Representation != requestDemandRepresentationSemantic ||
+			snapshot.ReservedOutputTokens != 128 ||
+			snapshot.OutputReserveSource != requestDemandOutputReserveExplicit {
+			t.Fatalf("snapshot[%d] lost demand provenance: %+v", index, snapshot)
+		}
+	}
+}
+
+func TestReplayRouteDiagnosticsCopyRequestDemandSnapshots(t *testing.T) {
+	ctx := &RequestContext{RequestDemandSnapshots: []routerreplay.RequestDemandSnapshot{{
+		Stage: requestDemandStageOriginal, PromptTokens: 12, CountingSource: requestDemandCountingSourceFallback,
+	}}}
+	record := buildReplayRoutingRecord(ctx, "entrypoint", "model-a", "route")
+
+	if record.RouteDiagnostics == nil || len(record.RouteDiagnostics.RequestDemandSnapshots) != 1 {
+		t.Fatalf("Replay demand snapshots missing: %+v", record.RouteDiagnostics)
+	}
+	ctx.RequestDemandSnapshots[0].PromptTokens = 99
+	if record.RouteDiagnostics.RequestDemandSnapshots[0].PromptTokens != 12 {
+		t.Fatalf("Replay demand snapshot aliases request context: %+v", record.RouteDiagnostics.RequestDemandSnapshots)
+	}
+}

--- a/src/semantic-router/pkg/observability/metrics/request_demand_metrics.go
+++ b/src/semantic-router/pkg/observability/metrics/request_demand_metrics.go
@@ -1,0 +1,27 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var requestDemandTokens = promauto.NewHistogramVec(
+	prometheus.HistogramOpts{
+		Name:    "llm_request_demand_tokens",
+		Help:    "Observed request token demand by lifecycle stage, accounting source, and component.",
+		Buckets: prometheus.ExponentialBuckets(128, 2, 14),
+	},
+	[]string{"stage", "counting_source", "component"},
+)
+
+// RecordRequestDemand records bounded, content-free request-demand evidence.
+// Stage, source, and component are closed vocabularies owned by the caller.
+func RecordRequestDemand(stage, countingSource string, prompt, reservedOutput, total int, totalKnown bool) {
+	stage = labelOrUnknown(stage)
+	countingSource = labelOrUnknown(countingSource)
+	requestDemandTokens.WithLabelValues(stage, countingSource, "prompt").Observe(float64(prompt))
+	requestDemandTokens.WithLabelValues(stage, countingSource, "reserved_output").Observe(float64(reservedOutput))
+	if totalKnown {
+		requestDemandTokens.WithLabelValues(stage, countingSource, "total").Observe(float64(total))
+	}
+}

--- a/src/semantic-router/pkg/observability/metrics/request_demand_metrics_test.go
+++ b/src/semantic-router/pkg/observability/metrics/request_demand_metrics_test.go
@@ -1,0 +1,20 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestRequestDemandMetricContract(t *testing.T) {
+	RecordRequestDemand("provider_bound", "fallback", 128, 64, 192, true)
+
+	count, err := testutil.GatherAndCount(prometheus.DefaultGatherer, "llm_request_demand_tokens")
+	if err != nil {
+		t.Fatalf("gather request demand metric: %v", err)
+	}
+	if count != 3 {
+		t.Fatalf("request demand metric series count = %d, want 3 components", count)
+	}
+}

--- a/src/semantic-router/pkg/routerreplay/recorder.go
+++ b/src/semantic-router/pkg/routerreplay/recorder.go
@@ -45,6 +45,7 @@ type (
 	LearningRescueDiagnostics     = store.LearningRescueDiagnostics
 	LearningSamplingDiagnostics   = store.LearningSamplingDiagnostics
 	Outcome                       = store.Outcome
+	RequestDemandSnapshot         = store.RequestDemandSnapshot
 	FusionPanelAttemptDiagnostics = store.FusionPanelAttemptDiagnostics
 	FusionQuorumDiagnostics       = store.FusionQuorumDiagnostics
 	LooperUsage                   = store.LooperUsage

--- a/src/semantic-router/pkg/routerreplay/store/request_demand_snapshot_test.go
+++ b/src/semantic-router/pkg/routerreplay/store/request_demand_snapshot_test.go
@@ -1,0 +1,52 @@
+package store
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestRequestDemandSnapshotsRoundTripAndClone(t *testing.T) {
+	record := Record{RouteDiagnostics: &RouteDiagnostics{
+		RequestDemandSnapshots: []RequestDemandSnapshot{{
+			Stage:                "provider_bound",
+			Representation:       "semantic",
+			Model:                "model-a",
+			PromptTokens:         128,
+			ReservedOutputTokens: 64,
+			TotalDemandTokens:    192,
+			TotalDemandKnown:     true,
+			CountingSource:       "fallback",
+			OutputReserveSource:  "explicit",
+			RequestGeneration:    3,
+		}},
+	}}
+
+	encoded, err := json.Marshal(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded Record
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.RouteDiagnostics == nil || len(decoded.RouteDiagnostics.RequestDemandSnapshots) != 1 ||
+		decoded.RouteDiagnostics.RequestDemandSnapshots[0].TotalDemandTokens != 192 {
+		t.Fatalf("request demand snapshot changed during JSON round trip: %+v", decoded.RouteDiagnostics)
+	}
+
+	cloned := cloneRecord(record)
+	cloned.RouteDiagnostics.RequestDemandSnapshots[0].PromptTokens = 999
+	if record.RouteDiagnostics.RequestDemandSnapshots[0].PromptTokens != 128 {
+		t.Fatalf("clone mutation changed original request demand: %+v", record.RouteDiagnostics.RequestDemandSnapshots)
+	}
+}
+
+func TestRequestDemandSnapshotsRemainOptionalForLegacyReplay(t *testing.T) {
+	var record Record
+	if err := json.Unmarshal([]byte(`{"route_diagnostics":{"selection_method":"static"}}`), &record); err != nil {
+		t.Fatal(err)
+	}
+	if record.RouteDiagnostics == nil || record.RouteDiagnostics.RequestDemandSnapshots != nil {
+		t.Fatalf("legacy replay invented request demand snapshots: %+v", record.RouteDiagnostics)
+	}
+}

--- a/src/semantic-router/pkg/routerreplay/store/store.go
+++ b/src/semantic-router/pkg/routerreplay/store/store.go
@@ -160,6 +160,23 @@ type LooperDiagnostics struct {
 	DroppedUsage        LooperUsage     `json:"dropped_usage,omitempty"`
 }
 
+// RequestDemandSnapshot is one content-free observation of the request demand
+// at a stable lifecycle boundary. Representation says whether the observation
+// describes semantic or wire form; the closed stage/source vocabularies keep
+// Replay records bounded and comparable without retaining request content.
+type RequestDemandSnapshot struct {
+	Stage                string `json:"stage"`
+	Representation       string `json:"representation"`
+	Model                string `json:"model,omitempty"`
+	PromptTokens         int    `json:"prompt_tokens"`
+	ReservedOutputTokens int    `json:"reserved_output_tokens"`
+	TotalDemandTokens    int    `json:"total_demand_tokens"`
+	TotalDemandKnown     bool   `json:"total_demand_known"`
+	CountingSource       string `json:"counting_source"`
+	OutputReserveSource  string `json:"output_reserve_source"`
+	RequestGeneration    uint64 `json:"request_generation"`
+}
+
 // RouteDiagnostics summarizes the final route, Router Learning protection,
 // and memory outcome in a stable replay-facing shape. Detailed per-candidate
 // learning diagnostics live in the typed Learning block.
@@ -208,6 +225,7 @@ type RouteDiagnostics struct {
 	ContextCompressionQuality      string                   `json:"context_compression_quality,omitempty"`
 	ContextCompressionFallback     string                   `json:"context_compression_fallback,omitempty"`
 	ContextCompressionCostSaved    float64                  `json:"context_compression_cost_saved,omitempty"`
+	RequestDemandSnapshots         []RequestDemandSnapshot  `json:"request_demand_snapshots,omitempty"`
 	Annotations                    map[string]interface{}   `json:"annotations,omitempty"`
 	SignalErrors                   map[string]string        `json:"signal_errors,omitempty"`
 	AppliedUnknownPolicies         map[string]string        `json:"applied_unknown_policies,omitempty"`
@@ -587,6 +605,7 @@ func cloneRouteDiagnostics(value *RouteDiagnostics) *RouteDiagnostics {
 	cloned := *value
 	cloned.FusionQuorum = cloneFusionQuorumDiagnostics(value.FusionQuorum)
 	cloned.Looper = cloneLooperDiagnostics(value.Looper)
+	cloned.RequestDemandSnapshots = append([]RequestDemandSnapshot(nil), value.RequestDemandSnapshots...)
 	cloned.Annotations = cloneInterfaceMap(value.Annotations)
 	cloned.SignalErrors = cloneStringMap(value.SignalErrors)
 	cloned.AppliedUnknownPolicies = cloneStringMap(value.AppliedUnknownPolicies)


### PR DESCRIPTION
Related #3704

Accounting dependency: #3050  
Eligibility dependency: #3116

## Purpose

Establish the observe-only evidence contract needed before final request admission can safely change routing.

This first slice records bounded, content-free request-demand snapshots at four stable lifecycle stages:

- `original`
- `post_context`
- `post_tool_policy`
- `provider_bound`

Each snapshot carries prompt demand, explicit output reserve when available, total-demand validity, accounting source, semantic request generation, and model identity. The current implementation deliberately reports `counting_source: fallback`; #3050 owns tokenizer-aware exact/calibrated accounting.

`provider_bound` is explicitly marked `representation: semantic`: it describes the final neutral request immediately before provider encoding. This avoids claiming wire-token exactness before #3050 provides that contract.

The observations are exposed through a fixed-label Prometheus histogram. Snapshots available when Replay starts (`original`, `post_context`, and `post_tool_policy` on the normal dispatch path) are also stored in route diagnostics. This slice deliberately does not move the existing Replay start point: `provider_bound` remains request-local/metric evidence until a later bounded Replay-update seam can persist it without changing Replay duration or failure coverage. Snapshot storage is bounded to one value per known stage and reuses an unchanged request generation rather than rescanning identical semantic content.

## Safety boundary

This PR is observe-only:

- no model reselection;
- no admission rejection;
- no decision or plugin re-execution;
- no cross-decision fallback;
- no Replay lifecycle/timestamp change.

When output reserve is unavailable, `total_demand_known` is false and the total-demand metric is not emitted. A later slice will consume #3050/#3116 and add pure final-admission evaluation after this evidence is validated.

## Test Plan

```bash
make check CHANGED_FILES="src/semantic-router/pkg/extproc/processor_req_body.go src/semantic-router/pkg/extproc/processor_req_body_prepare.go src/semantic-router/pkg/extproc/processor_req_body_routing.go src/semantic-router/pkg/extproc/recorder_route_diagnostics.go src/semantic-router/pkg/extproc/request_context.go src/semantic-router/pkg/extproc/request_demand.go src/semantic-router/pkg/extproc/request_demand_test.go src/semantic-router/pkg/observability/metrics/request_demand_metrics.go src/semantic-router/pkg/observability/metrics/request_demand_metrics_test.go src/semantic-router/pkg/routerreplay/recorder.go src/semantic-router/pkg/routerreplay/store/request_demand_snapshot_test.go src/semantic-router/pkg/routerreplay/store/store.go"

cd src/semantic-router
go test ./pkg/extproc -count=1
go test ./pkg/routerreplay/... ./pkg/observability/metrics -count=1
go vet ./pkg/extproc ./pkg/routerreplay/... ./pkg/observability/metrics
```

## Test Result

- `make check`: passed, including `make test-semantic-router` and `make config-schema-check`
- complete `pkg/extproc`: passed
- Router Replay and request-demand metrics packages: passed
- affected-package `go vet`: passed
