### PR TITLE
[Bug] Use success color for verified live verification dot

### DIFF
--- a/dashboard/frontend/src/pages/ConfigPageModelLiveVerification.test.tsx
+++ b/dashboard/frontend/src/pages/ConfigPageModelLiveVerification.test.tsx
@@ -19,6 +19,7 @@ describe('ConfigPageModelLiveVerification', () => {
     expect(markup).toContain('Checking… logical-model with a real inference query')
     expect(markup).toContain('disabled=""')
     expect(markup).not.toContain('Live')
+    expect(markup).not.toContain('liveVerificationDotSuccess')
   })
 
   it('labels runtime inference evidence as live verification, not catalog verification', () => {
@@ -45,6 +46,8 @@ describe('ConfigPageModelLiveVerification', () => {
     )
 
     expect(markup).toContain('Live')
+    expect(markup).toContain('liveVerificationDotSuccess')
+    expect(markup).toContain('liveVerificationLabelSuccess')
     expect(markup).toContain('Check again logical-model with a real inference query')
     expect(markup).not.toContain('OK from provider')
     expect(markup).not.toContain('openai · 18 ms')
@@ -66,6 +69,22 @@ describe('ConfigPageModelLiveVerification', () => {
     expect(markup).toContain('Provider inference returned HTTP 401.')
     expect(markup).toContain('Check again logical-model with a real inference query')
     expect(markup).not.toContain('Live')
+  })
+
+  it('keeps the idle state neutral until a live query has succeeded', () => {
+    const markup = renderToStaticMarkup(
+      <ConfigPageModelLiveVerification
+        model="logical-model"
+        hasBackend
+        allowed
+        state={{ status: 'idle' }}
+        onVerify={vi.fn()}
+      />,
+    )
+
+    expect(markup).toContain('Not checked')
+    expect(markup).not.toContain('liveVerificationDotSuccess')
+    expect(markup).not.toContain('liveVerificationLabelSuccess')
   })
 
   it('disables generation when the model has no backend or the user lacks evaluation.run', () => {

--- a/dashboard/frontend/src/pages/ConfigPageModelLiveVerification.tsx
+++ b/dashboard/frontend/src/pages/ConfigPageModelLiveVerification.tsx
@@ -41,7 +41,13 @@ export default function ConfigPageModelLiveVerification({
           }`}
           aria-hidden="true"
         />
-        <span className={styles.liveVerificationLabel}>
+        <span
+          className={`${styles.liveVerificationLabel} ${
+            hasBackend && allowed && state.status === 'verified'
+              ? styles.liveVerificationLabelSuccess
+              : ''
+          }`}
+        >
           {!hasBackend
             ? 'No backend'
             : !allowed

--- a/dashboard/frontend/src/pages/ConfigPageModelsSection.module.css
+++ b/dashboard/frontend/src/pages/ConfigPageModelsSection.module.css
@@ -111,9 +111,9 @@
 }
 
 .liveVerificationDotSuccess {
-  border-color: rgba(255, 255, 255, 0.5);
-  background: rgba(255, 255, 255, 0.88);
-  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.08);
+  border-color: rgba(74, 222, 128, 0.75);
+  background: var(--color-success, #22c55e);
+  box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.16);
 }
 
 .liveVerificationDotError {
@@ -135,6 +135,10 @@
   font-weight: 690;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.liveVerificationLabelSuccess {
+  color: #bbf7d0;
 }
 
 .liveVerificationEvidence {


### PR DESCRIPTION
Fixes #3741

## Purpose

On Build > Models, the live verification dot for a verified model was white, which only read as a brighter version of the idle "Not checked" dot while pending is yellow and failed is red. This change renders the verified dot and its "Live" label in green so the success state is visually distinct. Idle, pending, and failed states are unchanged. Only the models-row live verification control is touched; no other "live" indicators are affected.

Files: `dashboard/frontend/src/pages/ConfigPageModelsSection.module.css`, `dashboard/frontend/src/pages/ConfigPageModelLiveVerification.tsx`, `dashboard/frontend/src/pages/ConfigPageModelLiveVerification.test.tsx`.

Tests: the verified unit test now asserts both success classes are present, the pending test asserts the success dot class is absent, and a new idle test asserts "Not checked" renders with neither success class.

![before and after](https://raw.githubusercontent.com/Vaivaswat2244/semantic-router/assets/3741-live-verification-screenshots/live-verification-before-after.png)

## Test Plan

From `dashboard/frontend`:

```
npx vitest run src/pages/ConfigPageModelLiveVerification.test.tsx
npx eslint src/pages/ConfigPageModelLiveVerification.tsx src/pages/ConfigPageModelLiveVerification.test.tsx
npx prettier --check src/pages/ConfigPageModelLiveVerification.tsx src/pages/ConfigPageModelLiveVerification.test.tsx src/pages/ConfigPageModelsSection.module.css
npm run type-check
npx playwright test e2e/model-live-verification.spec.ts
```

## Test Result

- vitest: 5 passed (1 file)
- eslint, prettier, tsc: clean
- Playwright `e2e/model-live-verification.spec.ts`: 1 passed, spec unchanged

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category, such as `[Feature]`, `[Bug]`, `[Docs]`, `[Test]`, `[Research]`, `[Community]`, or `[CI/Build]`
- [x] The title does not stack prefixes such as `[Router][Docs]`; affected modules belong in labels and the PR body
- [x] The PR links an `accepted` issue with exactly one owner: one `wg/*` label for project work or `owner/maintainers` for repository governance
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>
