### PR TITLE
[Bug] Rank external RAG results across query windows

### DIFF
--- a/src/semantic-router/pkg/extproc/req_filter_rag_external.go
+++ b/src/semantic-router/pkg/extproc/req_filter_rag_external.go
@@ -131,8 +131,32 @@ func (r *OpenAIRouter) retrieveFromExternalAPI(traceCtx context.Context, ctx *Re
 		topK = *ragConfig.TopK
 	}
 
-	// A document that several windows retrieve is kept once, at the rank the
-	// first window that found it gave it.
+	documents, totalLatency, err := r.retrieveExternalRAGWindows(traceCtx, apiConfig, requestBodies, topK)
+	if err != nil {
+		return "", err
+	}
+	ctx.RAGRetrievalLatency = totalLatency
+
+	if len(documents) == 0 {
+		return "", fmt.Errorf("no content found in %s response", apiConfig.RequestFormat)
+	}
+
+	logging.Infof("Retrieved %d documents from external API over %d query window(s) (latency: %.3fs, format: %s)",
+		len(documents), len(requestBodies), totalLatency, apiConfig.RequestFormat)
+	return strings.Join(documents, "\n\n---\n\n"), nil
+}
+
+// retrieveExternalRAGWindows sends the query-window requests and combines their
+// results. Vector-search formats are merged by score; single-request formats
+// retain their existing first-seen behavior.
+func (r *OpenAIRouter) retrieveExternalRAGWindows(
+	traceCtx context.Context,
+	apiConfig *config.ExternalAPIRAGConfig,
+	requestBodies [][]byte,
+	topK int,
+) ([]string, float64, error) {
+	rankByScore := apiConfig.RequestFormat == "pinecone" || apiConfig.RequestFormat == "weaviate"
+	var rankedDocuments ragHits
 	var documents []string
 	seen := make(map[string]struct{})
 	var totalLatency float64
@@ -140,11 +164,15 @@ func (r *OpenAIRouter) retrieveFromExternalAPI(traceCtx context.Context, ctx *Re
 		apiResponse, latency, sendErr := r.sendExternalRAGRequest(traceCtx, apiConfig, requestBody)
 		totalLatency += latency
 		if sendErr != nil {
-			return "", sendErr
+			return nil, totalLatency, sendErr
 		}
-		windowDocuments, extractErr := r.extractDocumentsFromResponse(apiResponse, apiConfig.RequestFormat)
+		windowDocuments, windowScores, extractErr := r.extractDocumentsFromResponse(apiResponse, apiConfig.RequestFormat)
 		if extractErr != nil {
-			return "", fmt.Errorf("failed to extract context: %w", extractErr)
+			return nil, totalLatency, fmt.Errorf("failed to extract context: %w", extractErr)
+		}
+		if rankByScore {
+			rankedDocuments.add(windowDocuments, windowScores)
+			continue
 		}
 		for _, document := range windowDocuments {
 			if _, duplicate := seen[document]; duplicate {
@@ -154,18 +182,14 @@ func (r *OpenAIRouter) retrieveFromExternalAPI(traceCtx context.Context, ctx *Re
 			documents = append(documents, document)
 		}
 	}
-	ctx.RAGRetrievalLatency = totalLatency
 
-	if len(documents) == 0 {
-		return "", fmt.Errorf("no content found in %s response", apiConfig.RequestFormat)
+	if rankByScore {
+		documents, _ = rankedDocuments.top(topK)
 	}
 	if topK > 0 && len(documents) > topK {
 		documents = documents[:topK]
 	}
-
-	logging.Infof("Retrieved %d documents from external API over %d query window(s) (latency: %.3fs, format: %s)",
-		len(documents), len(requestBodies), totalLatency, apiConfig.RequestFormat)
-	return strings.Join(documents, "\n\n---\n\n"), nil
+	return documents, totalLatency, nil
 }
 
 // sendExternalRAGRequest posts one request body and decodes the response,
@@ -376,8 +400,8 @@ func (r *OpenAIRouter) buildCustomRequest(ctx *RequestContext, ragConfig *config
 	return []byte(replaced), nil
 }
 
-// extractContextFromResponse extracts context from API response based on format
-func (r *OpenAIRouter) extractDocumentsFromResponse(response map[string]interface{}, format string) ([]string, error) {
+// extractDocumentsFromResponse extracts documents and ranking scores from an API response.
+func (r *OpenAIRouter) extractDocumentsFromResponse(response map[string]interface{}, format string) ([]string, []float32, error) {
 	switch format {
 	case "pinecone":
 		return r.extractPineconeContext(response)
@@ -388,10 +412,10 @@ func (r *OpenAIRouter) extractDocumentsFromResponse(response map[string]interfac
 	case "custom":
 		// For custom format, assume response has a "content" or "text" field
 		if content, ok := response["content"].(string); ok {
-			return []string{content}, nil
+			return []string{content}, nil, nil
 		}
 		if text, ok := response["text"].(string); ok {
-			return []string{text}, nil
+			return []string{text}, nil, nil
 		}
 		// Try to extract from results array
 		if results, ok := response["results"].([]interface{}); ok {
@@ -405,76 +429,97 @@ func (r *OpenAIRouter) extractDocumentsFromResponse(response map[string]interfac
 					}
 				}
 			}
-			return parts, nil
+			return parts, nil, nil
 		}
-		return nil, fmt.Errorf("unable to extract context from custom response format")
+		return nil, nil, fmt.Errorf("unable to extract context from custom response format")
 	default:
-		return nil, fmt.Errorf("unknown response format: %s", format)
+		return nil, nil, fmt.Errorf("unknown response format: %s", format)
 	}
 }
 
 // extractPineconeContext extracts context from Pinecone response
-func (r *OpenAIRouter) extractPineconeContext(response map[string]interface{}) ([]string, error) {
+func (r *OpenAIRouter) extractPineconeContext(response map[string]interface{}) ([]string, []float32, error) {
 	matches, ok := response["matches"].([]interface{})
 	if !ok {
-		return nil, fmt.Errorf("no matches in Pinecone response")
+		return nil, nil, fmt.Errorf("no matches in Pinecone response")
 	}
 
 	var parts []string
+	var scores []float32
 	for _, match := range matches {
 		if matchMap, ok := match.(map[string]interface{}); ok {
 			if metadata, ok := matchMap["metadata"].(map[string]interface{}); ok {
-				if content, ok := metadata["content"].(string); ok {
-					parts = append(parts, content)
+				var content string
+				if value, ok := metadata["content"].(string); ok {
+					content = value
 				} else if text, ok := metadata["text"].(string); ok {
-					parts = append(parts, text)
+					content = text
+				} else {
+					continue
 				}
+				score, ok := matchMap["score"].(float64)
+				if !ok {
+					return nil, nil, fmt.Errorf("pinecone match for %q has no numeric score", content)
+				}
+				parts = append(parts, content)
+				scores = append(scores, float32(score))
 			}
 		}
 	}
 
-	return parts, nil
+	return parts, scores, nil
 }
 
 // extractWeaviateContext extracts context from Weaviate response
-func (r *OpenAIRouter) extractWeaviateContext(response map[string]interface{}) ([]string, error) {
+func (r *OpenAIRouter) extractWeaviateContext(response map[string]interface{}) ([]string, []float32, error) {
 	data, ok := response["data"].(map[string]interface{})
 	if !ok {
-		return nil, fmt.Errorf("no data in Weaviate response")
+		return nil, nil, fmt.Errorf("no data in Weaviate response")
 	}
 
 	get, ok := data["Get"].(map[string]interface{})
 	if !ok {
-		return nil, fmt.Errorf("no Get in Weaviate response")
+		return nil, nil, fmt.Errorf("no Get in Weaviate response")
 	}
 
 	document, ok := get["Document"].([]interface{})
 	if !ok {
-		return nil, fmt.Errorf("no Document in Weaviate response")
+		return nil, nil, fmt.Errorf("no Document in Weaviate response")
 	}
 
 	var parts []string
+	var scores []float32
 	for _, doc := range document {
 		if docMap, ok := doc.(map[string]interface{}); ok {
 			if content, ok := docMap["content"].(string); ok {
+				additional, ok := docMap["_additional"].(map[string]interface{})
+				if !ok {
+					return nil, nil, fmt.Errorf("weaviate document %q has no _additional data", content)
+				}
+				distance, ok := additional["distance"].(float64)
+				if !ok {
+					return nil, nil, fmt.Errorf("weaviate document %q has no numeric distance", content)
+				}
 				parts = append(parts, content)
+				// Weaviate distance is lower-is-better; ragHits expects higher scores.
+				scores = append(scores, -float32(distance))
 			}
 		}
 	}
 
-	return parts, nil
+	return parts, scores, nil
 }
 
 // extractElasticsearchContext extracts context from Elasticsearch response
-func (r *OpenAIRouter) extractElasticsearchContext(response map[string]interface{}) ([]string, error) {
+func (r *OpenAIRouter) extractElasticsearchContext(response map[string]interface{}) ([]string, []float32, error) {
 	hits, ok := response["hits"].(map[string]interface{})
 	if !ok {
-		return nil, fmt.Errorf("no hits in Elasticsearch response")
+		return nil, nil, fmt.Errorf("no hits in Elasticsearch response")
 	}
 
 	hitsArray, ok := hits["hits"].([]interface{})
 	if !ok {
-		return nil, fmt.Errorf("no hits array in Elasticsearch response")
+		return nil, nil, fmt.Errorf("no hits array in Elasticsearch response")
 	}
 
 	var parts []string
@@ -490,5 +535,5 @@ func (r *OpenAIRouter) extractElasticsearchContext(response map[string]interface
 		}
 	}
 
-	return parts, nil
+	return parts, nil, nil
 }

--- a/src/semantic-router/pkg/extproc/req_filter_rag_external_test.go
+++ b/src/semantic-router/pkg/extproc/req_filter_rag_external_test.go
@@ -5,11 +5,114 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/vllm-project/semantic-router/src/semantic-router/pkg/config"
 )
+
+func TestRetrieveExternalRAGWindowsRanksByBestScore(t *testing.T) {
+	tests := []struct {
+		name      string
+		format    string
+		responses []map[string]interface{}
+	}{
+		{
+			name:   "pinecone similarity",
+			format: "pinecone",
+			responses: []map[string]interface{}{
+				pineconeResponse(pineconeMatch("first", 0.1), pineconeMatch("shared", 0.2)),
+				pineconeResponse(pineconeMatch("best", 0.9), pineconeMatch("shared", 0.8)),
+				pineconeResponse(pineconeMatch("third", 0.7)),
+			},
+		},
+		{
+			name:   "weaviate distance",
+			format: "weaviate",
+			responses: []map[string]interface{}{
+				weaviateResponse(weaviateDocument("first", 0.9), weaviateDocument("shared", 0.8)),
+				weaviateResponse(weaviateDocument("best", 0.1), weaviateDocument("shared", 0.2)),
+				weaviateResponse(weaviateDocument("third", 0.3)),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var requestIndex atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				index := int(requestIndex.Add(1)) - 1
+				if index >= len(tt.responses) {
+					t.Errorf("received unexpected request %d", index+1)
+					http.Error(w, "unexpected request", http.StatusInternalServerError)
+					return
+				}
+				response := tt.responses[index]
+				if err := json.NewEncoder(w).Encode(response); err != nil {
+					t.Errorf("encode response: %v", err)
+				}
+			}))
+			defer server.Close()
+
+			requestBodies := make([][]byte, len(tt.responses))
+			for i := range requestBodies {
+				requestBodies[i] = []byte(`{}`)
+			}
+			documents, _, err := (&OpenAIRouter{}).retrieveExternalRAGWindows(
+				context.Background(),
+				&config.ExternalAPIRAGConfig{Endpoint: server.URL, RequestFormat: tt.format},
+				requestBodies,
+				3,
+			)
+			if err != nil {
+				t.Fatalf("retrieveExternalRAGWindows() error = %v", err)
+			}
+			if got := int(requestIndex.Load()); got != len(tt.responses) {
+				t.Fatalf("sent %d requests, want %d", got, len(tt.responses))
+			}
+			want := []string{"best", "shared", "third"}
+			if !reflect.DeepEqual(documents, want) {
+				t.Fatalf("documents = %v, want %v", documents, want)
+			}
+		})
+	}
+}
+
+func pineconeResponse(matches ...map[string]interface{}) map[string]interface{} {
+	values := make([]interface{}, len(matches))
+	for i, match := range matches {
+		values[i] = match
+	}
+	return map[string]interface{}{"matches": values}
+}
+
+func pineconeMatch(content string, score float64) map[string]interface{} {
+	return map[string]interface{}{
+		"metadata": map[string]interface{}{"content": content},
+		"score":    score,
+	}
+}
+
+func weaviateResponse(documents ...map[string]interface{}) map[string]interface{} {
+	values := make([]interface{}, len(documents))
+	for i, document := range documents {
+		values[i] = document
+	}
+	return map[string]interface{}{
+		"data": map[string]interface{}{
+			"Get": map[string]interface{}{"Document": values},
+		},
+	}
+}
+
+func weaviateDocument(content string, distance float64) map[string]interface{} {
+	return map[string]interface{}{
+		"content":     content,
+		"_additional": map[string]interface{}{"distance": distance},
+	}
+}
 
 func TestRetrieveFromExternalAPIResponseLimit(t *testing.T) {
 	responseBody, err := json.Marshal(map[string]interface{}{"content": "retrieved context"})


### PR DESCRIPTION
Closes #3738

## Purpose

Pinecone and Weaviate external RAG requests search every embedding window of a long query, but the router previously discarded provider scores and kept documents in first-seen order. A full first-window response therefore crowded every later window out of the final `top_k`.

This change:

- preserves Pinecone similarity scores and Weaviate distances during response extraction;
- normalizes Weaviate's lower-is-better distance into the existing higher-is-better `ragHits` path;
- keeps each document's best ranking value across query windows before applying `top_k`; and
- retains the existing first-seen behavior for custom and Elasticsearch formats.

The change is owned by the Router Models & Inference Runtime Workgroup.

## Test Plan

- Exercise three sequential `httptest` responses for Pinecone and Weaviate, including a duplicate document whose best result arrives in a later window.
- Run the full ExtProc Go package on the repository's Go 1.25 toolchain.
- Run the focused regression and adjacent RAG tests with the race detector.
- Run `go vet` and changed-line `golangci-lint`.

## Test Result

- `go test ./pkg/extproc -count=1`: passed.
- `go test -race ./pkg/extproc -run "TestRetrieveExternalRAGWindowsRanksByBestScore|TestRetrieveFromExternalAPIResponseLimit|TestRagHits" -count=1`: passed.
- `go vet ./pkg/extproc`: passed.
- `golangci-lint run ./pkg/extproc --config ../../tools/linter/go/.golangci.yml --new-from-rev=origin/main`: 0 issues.
- The repository-wide `make check` wrapper could not bootstrap locally because the configured Python package index does not yet provide its pinned `jsonschema==4.26.0`; the owning Go package checks above were run directly.

No live Pinecone or Weaviate service was used; the regression uses their decoded response shapes through a real HTTP test server.