### PR TITLE
[Docs] Point the Helm install output at the Dashboard Service

### DIFF
--- a/deploy/helm/semantic-router/templates/NOTES.txt
+++ b/deploy/helm/semantic-router/templates/NOTES.txt
@@ -37,6 +37,16 @@
 4. Access gRPC API:
   kubectl --namespace {{ include "semantic-router.namespace" . }} port-forward svc/{{ include "semantic-router.fullname" . }} 50051:50051
 
+5. Access the Dashboard:
+{{- if .Values.dashboard.enabled }}
+  kubectl --namespace {{ include "semantic-router.namespace" . }} port-forward svc/{{ include "semantic-router.fullname" . }}-dashboard {{ .Values.dashboard.service.port }}:{{ .Values.dashboard.service.port }}
+  echo "Visit http://localhost:{{ .Values.dashboard.service.port }}"
+{{- else }}
+  The Dashboard runs as its own Deployment and Service, and it is disabled by
+  default. Reinstall or upgrade with --set dashboard.enabled=true, then
+  port-forward svc/{{ include "semantic-router.fullname" . }}-dashboard on port {{ .Values.dashboard.service.port }}.
+{{- end }}
+
 {{- $config := (get .Values "config") | default (dict) -}}
 {{- $global := (get $config "global") | default (dict) -}}
 {{- $services := (get $global "services") | default (dict) -}}

--- a/website/docs/installation/configuration-workflows.md
+++ b/website/docs/installation/configuration-workflows.md
@@ -127,6 +127,20 @@ Choose Kubernetes GPU images, resources, and device plugins through Helm or the
 Operator. The local `--platform amd` and `--platform nvidia` shortcuts do not
 configure Kubernetes scheduling.
 
+The chart runs the Dashboard as its own Deployment and Service, and that
+Deployment is disabled by default. The Router Service carries the gRPC and HTTP
+API ports only, so port 8700 appears in the cluster only after the Dashboard is
+enabled.
+
+```bash
+helm upgrade --install semantic-router \
+  oci://ghcr.io/vllm-project/charts/semantic-router \
+  -f values.yaml --set dashboard.enabled=true
+
+kubectl --namespace vllm-semantic-router-system port-forward \
+  svc/semantic-router-dashboard 8700:8700
+```
+
 ## Operator
 
 The Operator renders a canonical config from two Kubernetes-native inputs:


### PR DESCRIPTION
## Purpose

The chart already deploys the Dashboard as its own Deployment and Service on
port 8700, behind `dashboard.enabled`, which defaults to false. The install
output lists the API, metrics and gRPC ports only, so a default install shows
no port 8700 anywhere and the absence reads as a bind problem. The server
binds every interface already (`addr := ":" + cfg.Port` in
`dashboard/backend/main.go`), so the gap is discoverability, not the bind
address and not the Service.

The install notes now carry a Dashboard entry in both states, and the Helm
workflow page says the same.

Related #3751

## Test Plan

Render the notes with the Dashboard enabled and with the default, then install
the chart on kind with the Dashboard enabled and reach the Service through a
port forward.

## Test Result

Enabled, the notes print `kubectl --namespace demo port-forward svc/t-semantic-router-dashboard 8700:8700`.
Disabled, they print the `--set dashboard.enabled=true` instruction instead.

On kind, the install created `semantic-router-dashboard` with port 8700/TCP,
the pod listened on `[::]:8700`, and `kubectl port-forward svc/...-dashboard 8700:8700`
answered `/` with HTTP 200. A pod in another namespace reached the Service
with HTTP 200 as well.

`make check BASE_REF=origin/main` passed and `npm run build` in `website/`
succeeded.
