### PR TITLE
[Bug] Preserve mmBERT long-context classifier correctness

### DIFF
--- a/candle-binding/examples/benchmark_classifier_context.rs
+++ b/candle-binding/examples/benchmark_classifier_context.rs
@@ -1,0 +1,103 @@
+//! Real sequence/token classifier regression; missing models or fixtures fail.
+//!
+//! Usage: benchmark_classifier_context MODEL_DIR sequence|token MAX_TOKENS cpu FIXTURES.json
+//! Fixtures are an array of {"id": "...", "text": "...", "expected_tokens": 1024}.
+//! Token counts include special tokens. Use the checkpoint's own tokenizer to
+//! construct fixtures, and compare probabilities/entities with the same weights.
+
+use candle_semantic_router::model_architectures::traditional::modernbert::{
+    TraditionalModernBertClassifier, TraditionalModernBertTokenClassifier,
+};
+use serde_json::json;
+use std::{error::Error, fs, time::Instant};
+use tokenizers::{Tokenizer, TruncationParams};
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() != 6 {
+        return Err("expected MODEL_DIR sequence|token MAX_TOKENS cpu FIXTURES.json".into());
+    }
+    let limit: usize = args[3].parse()?;
+    if args[4] != "cpu" {
+        return Err("this benchmark requires the cpu provider".into());
+    }
+    let sequence = if args[2] == "sequence" {
+        Some(
+            TraditionalModernBertClassifier::load_from_directory_with_max_sequence_length(
+                &args[1], true, limit,
+            )?,
+        )
+    } else {
+        None
+    };
+    let token = if args[2] == "token" {
+        Some(
+            TraditionalModernBertTokenClassifier::new_with_max_sequence_length(
+                &args[1], true, limit,
+            )?,
+        )
+    } else {
+        None
+    };
+    if sequence.is_none() && token.is_none() {
+        return Err("task must be sequence or token".into());
+    }
+    let mut tokenizer =
+        Tokenizer::from_file(format!("{}/tokenizer.json", args[1])).map_err(|e| e.to_string())?;
+    let config: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(format!("{}/config.json", args[1]))?)?;
+    tokenizer.with_padding(None);
+    tokenizer
+        .with_truncation(Some(TruncationParams {
+            max_length: limit,
+            ..Default::default()
+        }))
+        .map_err(|e| e.to_string())?;
+    let fixtures: Vec<serde_json::Value> = serde_json::from_str(&fs::read_to_string(&args[5])?)?;
+    if fixtures.is_empty() {
+        return Err("fixtures must contain at least one input".into());
+    }
+    for fixture in fixtures {
+        let text = fixture["text"].as_str().ok_or("missing text")?;
+        let count = tokenizer
+            .encode(text, true)
+            .map_err(|e| e.to_string())?
+            .len();
+        if fixture["expected_tokens"].as_u64() != Some(count as u64) {
+            return Err(format!(
+                "fixture {}: expected {} tokens, encoded {count}",
+                fixture["id"], fixture["expected_tokens"]
+            )
+            .into());
+        }
+        let start = Instant::now();
+        let result = if let Some(model) = sequence.as_ref() {
+            let (label_id, confidence, probabilities) =
+                model.classify_text_with_probabilities(text)?;
+            let label = config["id2label"][label_id.to_string()]
+                .as_str()
+                .map(str::to_owned)
+                .unwrap_or_else(|| label_id.to_string());
+            json!({"label":label,"label_id":label_id,"confidence":confidence,
+                "probabilities":probabilities})
+        } else {
+            let model = token.as_ref().unwrap();
+            let entities = model.classify_tokens(text)?;
+            json!({"entities":entities.iter().map(|(text,label_id,confidence,start,end)| {
+                // TokenClassifier's public label accessor currently returns
+                // None. Resolve the checkpoint's BIO labels directly here.
+                let label = config["id2label"][label_id.to_string()].as_str().unwrap_or("UNKNOWN");
+                let entity_type = label.strip_prefix("B-")
+                    .or_else(|| label.strip_prefix("I-")).unwrap_or(label);
+                json!({"text":text,"type":entity_type,"label_id":label_id,
+                    "start":start,"end":end,"confidence":confidence})
+            }).collect::<Vec<_>>()})
+        };
+        println!(
+            "{}",
+            json!({"id":fixture["id"],"tokens":count,"max_tokens":limit,
+                "elapsed_ms":start.elapsed().as_secs_f64()*1000.0,"result":result})
+        );
+    }
+    Ok(())
+}

--- a/candle-binding/src/model_architectures/traditional/candle_models/modernbert.rs
+++ b/candle-binding/src/model_architectures/traditional/candle_models/modernbert.rs
@@ -1,7 +1,7 @@
 //! ModernBERT model implementation
 //!
 //! ModernBERT is a modernized bidirectional encoder-only Transformer model
-//! supporting extended context windows up to 32K tokens via YaRN RoPE scaling.
+//! using the context capacity and RoPE theta declared by each checkpoint.
 
 use candle_core::{DType, Device, IndexOp, Result, Tensor, D};
 use candle_nn::{
@@ -157,6 +157,7 @@ impl ModernBertAttention {
         uses_local_attention: bool,
         window: usize,
         block_size: usize,
+        has_padding: bool,
     ) -> Result<Tensor> {
         let (b, seq_len, d) = hidden_states.dims3()?;
         let (q, k, v) = self.project_qkv(hidden_states)?;
@@ -179,8 +180,14 @@ impl ModernBertAttention {
             q_offset: 0,
         };
 
-        // Use Flash Attention if enabled, otherwise use the shared chunked kernel
-        let xs = if self.use_flash_attn {
+        // The fixed-length Flash API below has neither a padding mask nor a
+        // sliding window. Only unpadded global layers can use it without changing
+        // model semantics; all other cases use the memory-bounded exact kernel.
+        let xs = if self.use_flash_attn
+            && !uses_local_attention
+            && !has_padding
+            && hidden_states.device().is_cuda()
+        {
             #[cfg(feature = "flash-attn")]
             {
                 // Flash Attention path
@@ -313,6 +320,7 @@ impl ModernBertLayer {
         pad_mask: &Tensor,
         window: usize,
         block_size: usize,
+        has_padding: bool,
     ) -> Result<Tensor> {
         let residual = xs.clone();
         let mut xs = xs.clone();
@@ -320,9 +328,14 @@ impl ModernBertLayer {
             xs = xs.apply(norm)?;
         }
 
-        let xs = self
-            .attn
-            .forward(&xs, pad_mask, self.uses_local_attention, window, block_size)?;
+        let xs = self.attn.forward(
+            &xs,
+            pad_mask,
+            self.uses_local_attention,
+            window,
+            block_size,
+            has_padding,
+        )?;
         let xs = (xs + residual)?;
         let mlp_out = xs.apply(&self.mlp_norm)?.apply(&self.mlp)?;
         let xs = (xs + mlp_out)?;
@@ -446,10 +459,20 @@ impl ModernBert {
         // previous (b, 1, seq, seq) expansion and the (seq, seq) sliding-window band
         // were both O(seq^2); the window is now applied inside the kernel per block.
         let pad_mask = prepare_padding_mask(mask, DType::F32)?.to_device(xs.device())?;
+        // Inspect padding once per model call, not once per layer. The transfer
+        // is only needed when Flash Attention is available on this device.
+        let has_padding = if cfg!(feature = "flash-attn") && xs.device().is_cuda() {
+            mask.flatten_all()?
+                .to_dtype(DType::U32)?
+                .to_vec1::<u32>()?
+                .contains(&0)
+        } else {
+            false
+        };
         let window = self.local_attention_size / 2;
         let mut xs = xs.apply(&self.word_embeddings)?.apply(&self.norm)?;
         for layer in self.layers.iter() {
-            xs = layer.forward(&xs, &pad_mask, window, ATTN_QUERY_BLOCK)?;
+            xs = layer.forward(&xs, &pad_mask, window, ATTN_QUERY_BLOCK, has_padding)?;
         }
         let xs = xs.apply(&self.final_norm)?;
         Ok(xs)
@@ -723,7 +746,7 @@ mod tests {
 
                 for &block in &[1usize, 3, 8, 16, ATTN_QUERY_BLOCK] {
                     let chunked = attn
-                        .forward(&hidden, &pad_mask, uses_local, window, block)
+                        .forward(&hidden, &pad_mask, uses_local, window, block, false)
                         .unwrap();
                     let diff = max_abs_diff(&chunked, &reference);
                     assert!(
@@ -761,7 +784,7 @@ mod tests {
                 dense_reference_attention(&attn, &hidden, &raw_mask, uses_local, window);
             for &block in &[3usize, 8, ATTN_QUERY_BLOCK] {
                 let chunked = attn
-                    .forward(&hidden, &pad_mask, uses_local, window, block)
+                    .forward(&hidden, &pad_mask, uses_local, window, block, true)
                     .unwrap();
                 let diff = max_abs_diff(&chunked, &reference);
                 assert!(
@@ -771,6 +794,33 @@ mod tests {
                     block,
                     diff
                 );
+            }
+        }
+    }
+
+    #[test]
+    fn test_chunked_attention_crosses_default_context_and_query_blocks() {
+        let device = Device::Cpu;
+        let mut config = tiny_config();
+        config.hidden_size = 8;
+        config.num_attention_heads = 2;
+        config.max_position_embeddings = 32768;
+        let attn = make_test_attention(&config, &device);
+        let seq_len = 1025;
+        let mut mask = vec![1f32; seq_len];
+        mask[seq_len - 17..].fill(0.0);
+        let raw_mask = Tensor::from_vec(mask, (1, seq_len), &device).unwrap();
+        let pad_mask = prepare_padding_mask(&raw_mask, DType::F32).unwrap();
+        let hidden = Tensor::randn(0f32, 1f32, (1, seq_len, config.hidden_size), &device).unwrap();
+        let window = config.local_attention / 2;
+        for uses_local in [false, true] {
+            let reference =
+                dense_reference_attention(&attn, &hidden, &raw_mask, uses_local, window);
+            for block in [256, ATTN_QUERY_BLOCK] {
+                let actual = attn
+                    .forward(&hidden, &pad_mask, uses_local, window, block, true)
+                    .unwrap();
+                assert!(max_abs_diff(&actual, &reference) < 1e-4);
             }
         }
     }

--- a/candle-binding/src/model_architectures/traditional/mod.rs
+++ b/candle-binding/src/model_architectures/traditional/mod.rs
@@ -20,11 +20,10 @@ pub mod modernbert;
 
 // Local copy of candle-transformers models with Flash Attention support
 // IMPORTANT: This local copy is necessary because:
-// 1. Flash Attention 2 support: The upstream candle-transformers ModernBERT doesn't support
-//    Flash Attention 2, which is required for efficient 32K context processing
-// 2. Extended context support: We need custom handling for Extended32K variant with YaRN RoPE scaling
-// 3. Runtime max_position_embeddings override: We need to override config values at runtime
-//    for Extended32K models, which requires mutable Config fields
+// 1. Memory-bounded attention preserves global and local attention at long context lengths.
+// 2. Flash Attention 2 is used only when its API preserves the layer's mask semantics.
+// 3. Classifier loaders share checkpoint-defined RoPE/cache capacity and an explicit
+//    input budget; variant names do not expand the model's context capacity.
 //
 // This creates a type shadowing situation where local types (Config, ModernBert, etc.) are used
 // instead of upstream types. This is intentional but should be documented.

--- a/candle-binding/src/model_architectures/traditional/modernbert.rs
+++ b/candle-binding/src/model_architectures/traditional/modernbert.rs
@@ -4,20 +4,13 @@
 //! that preserves all bug fixes from FixedModernBertClassifier.
 //!
 //! Supports both standard ModernBERT and mmBERT (multilingual ModernBERT) variants:
-//! - ModernBERT: Standard English-focused model, 512 max length
+//! - ModernBERT: Standard English-focused model
 //! - mmBERT: Multilingual model (1800+ languages), 256k vocab, 8192 max length
 //!
 //! The variant is auto-detected from config.json or can be explicitly specified.
 
-/// Maximum input length (in tokens) used for classification inference.
-///
-/// ModernBERT-32K and mmBERT-32K use global attention (full quadratic O(n²))
-/// every `global_attn_every_n_layers` layers (≈7–8 out of 22). At 4000 tokens
-/// those layers allocate ~6–8 GB of activation memory per batch item, which
-/// reliably triggers an OOM kill with no container logs. Classification tasks
-/// (intent, jailbreak, PII, feedback, fact-check) don't benefit from sequences
-/// longer than 512 tokens. This cap matches `max_length` in tokenizer_config.json.
-pub(crate) const MAX_CLASSIFICATION_SEQ_LEN: usize = 512;
+/// Existing callers keep a bounded default; longer inputs require explicit opt-in.
+pub(crate) const DEFAULT_CLASSIFICATION_SEQ_LEN: usize = 512;
 
 use crate::core::{
     config_errors, drain_loader_queue, processing_errors, resolve_device, run_on_inference_pool,
@@ -32,7 +25,7 @@ use candle_nn::{ops, LayerNorm, Linear, Module, VarBuilder};
 use super::{ClassifierConfig, ClassifierPooling, Config, ModernBert};
 use std::collections::HashMap;
 use std::sync::{Arc, OnceLock};
-use tokenizers::{PaddingParams, PaddingStrategy, Tokenizer};
+use tokenizers::{PaddingParams, PaddingStrategy, PostProcessor, Tokenizer};
 
 use crate::core::tokenization::DualPathTokenizer;
 use crate::model_architectures::traits::*;
@@ -58,7 +51,8 @@ pub enum ModernBertVariant {
 }
 
 impl ModernBertVariant {
-    /// Get the max sequence length for this variant
+    /// Historical variant hint; loaders use config.max_position_embeddings as
+    /// the capacity and an explicit request (default 512) as the input budget.
     pub fn max_length(&self) -> usize {
         match self {
             ModernBertVariant::Standard => 512,
@@ -94,7 +88,8 @@ impl ModernBertVariant {
         }
     }
 
-    /// Check if this variant uses YaRN RoPE scaling
+    /// Whether this variant has a historical YaRN label. This metadata does not
+    /// implement RoPE scaling or override the checkpoint's positional capacity.
     pub fn uses_yarn_scaling(&self) -> bool {
         matches!(
             self,
@@ -609,19 +604,134 @@ impl TraditionalModernBertClassifier {
             }
         }
 
-        // If local_rope_theta is missing, use the same value as global_rope_theta
+        // Local and global layers can have different RoPE parameters.
         if !obj.contains_key("local_rope_theta") {
-            let global_theta = obj
-                .get("global_rope_theta")
+            let local_theta = obj
+                .get("rope_parameters")
+                .and_then(|v| v.get("sliding_attention"))
+                .and_then(|v| v.get("rope_theta"))
                 .and_then(|v| v.as_f64())
+                .or_else(|| obj.get("global_rope_theta").and_then(|v| v.as_f64()))
                 .unwrap_or(160000.0);
             obj.insert(
                 "local_rope_theta".to_string(),
-                serde_json::Value::from(global_theta),
+                serde_json::Value::from(local_theta),
             );
         }
 
         serde_json::to_string(&config_json).unwrap_or_else(|_| config_str.to_string())
+    }
+
+    /// A variant or training metadata cannot enlarge the backbone's declared
+    /// capacity. The same config sets the tokenizer limit and RoPE cache size.
+    pub(super) fn parse_model_config(config_str: &str) -> Result<Config, candle_core::Error> {
+        let raw: serde_json::Value =
+            serde_json::from_str(config_str).map_err(candle_core::Error::wrap)?;
+        // This implementation supports theta-based RoPE, not arbitrary scaling
+        // algorithms. Do not silently discard YaRN frequency/attention factors.
+        let check_rope = |params: &serde_json::Value| -> Result<(), candle_core::Error> {
+            if params.is_null() {
+                return Ok(());
+            }
+            let rope_type = params
+                .get("rope_type")
+                .or_else(|| params.get("type"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("default");
+            if rope_type != "default"
+                || ["factor", "beta_fast", "beta_slow", "attention_factor"]
+                    .iter()
+                    .any(|field| params.get(*field).is_some())
+            {
+                candle_core::bail!(
+                    "unsupported ModernBERT RoPE scaling {rope_type:?}; this loader supports theta-based RoPE"
+                );
+            }
+            Ok(())
+        };
+        if let Some(params) = raw.get("rope_scaling") {
+            check_rope(params)?;
+        }
+        if let Some(params) = raw.get("rope_parameters") {
+            check_rope(params)?;
+            for layer_type in ["full_attention", "sliding_attention"] {
+                if let Some(layer_params) = params.get(layer_type) {
+                    check_rope(layer_params)?;
+                }
+            }
+        }
+        let config: Config = serde_json::from_str(&Self::normalize_config_json(config_str))
+            .map_err(candle_core::Error::wrap)?;
+        if config.max_position_embeddings == 0
+            || u32::try_from(config.max_position_embeddings).is_err()
+        {
+            candle_core::bail!("ModernBERT max_position_embeddings must be a positive u32");
+        }
+        if config.pad_token_id as usize >= config.vocab_size {
+            candle_core::bail!("ModernBERT pad_token_id is outside the vocabulary");
+        }
+        for theta in [config.global_rope_theta, config.local_rope_theta] {
+            if !theta.is_finite() || theta <= 0.0 {
+                candle_core::bail!("ModernBERT RoPE theta must be finite and positive");
+            }
+        }
+        Ok(config)
+    }
+
+    pub(super) fn resolve_sequence_length(
+        config: &Config,
+        requested: Option<usize>,
+    ) -> Result<usize, candle_core::Error> {
+        let max_length =
+            requested.unwrap_or(DEFAULT_CLASSIFICATION_SEQ_LEN.min(config.max_position_embeddings));
+        if max_length == 0 || max_length > config.max_position_embeddings {
+            candle_core::bail!(
+                "max_sequence_length must be between 1 and {}, got {max_length}",
+                config.max_position_embeddings
+            );
+        }
+        Ok(max_length)
+    }
+
+    pub(super) fn tokenizer_for_config(
+        mut tokenizer: Tokenizer,
+        config: &Config,
+        variant: ModernBertVariant,
+        device: Device,
+        max_sequence_length: usize,
+    ) -> Result<Box<dyn DualPathTokenizer>> {
+        let max_sequence_length = Self::resolve_sequence_length(config, Some(max_sequence_length))?;
+        let special_tokens = tokenizer
+            .get_post_processor()
+            .map_or(0, |processor| processor.added_tokens(false));
+        // UnifiedTokenizer configures truncation on its next encode. Validate
+        // now: tokenizers subtracts the special-token count with usize arithmetic.
+        if max_sequence_length < special_tokens {
+            anyhow::bail!(
+                "max_sequence_length {max_sequence_length} is smaller than the tokenizer's {special_tokens} special tokens"
+            );
+        }
+        let pad_token = tokenizer
+            .id_to_token(config.pad_token_id)
+            .unwrap_or_else(|| variant.pad_token().to_string());
+        // Exported fixed padding can exceed the backbone capacity even after
+        // truncation. UnifiedTokenizer supplies batch padding; singles need none.
+        tokenizer.with_padding(None);
+        let tokenizer_config = crate::core::tokenization::TokenizationConfig {
+            max_length: max_sequence_length,
+            add_special_tokens: true,
+            truncation_strategy: tokenizers::TruncationStrategy::LongestFirst,
+            truncation_direction: tokenizers::TruncationDirection::Right,
+            pad_token_id: config.pad_token_id,
+            pad_token,
+            tokenization_strategy: variant.tokenization_strategy(),
+            token_data_type: crate::core::tokenization::TokenDataType::U32,
+        };
+        Ok(Box::new(crate::core::tokenization::UnifiedTokenizer::new(
+            tokenizer,
+            tokenizer_config,
+            device,
+        )?))
     }
 
     /// Load from directory with auto-detected variant (Standard or Multilingual/mmBERT)
@@ -641,6 +751,44 @@ impl TraditionalModernBertClassifier {
         use_cpu: bool,
         variant: ModernBertVariant,
     ) -> Result<Self, candle_core::Error> {
+        Self::load_from_directory_with_limit(model_path, use_cpu, variant, None)
+    }
+
+    /// Load a classifier with an explicit input budget bounded by the model config.
+    pub fn load_from_directory_with_max_sequence_length(
+        model_path: &str,
+        use_cpu: bool,
+        max_sequence_length: usize,
+    ) -> Result<Self, candle_core::Error> {
+        let variant = ModernBertVariant::detect_from_config(&format!("{model_path}/config.json"))?;
+        Self::load_from_directory_with_variant_and_max_sequence_length(
+            model_path,
+            use_cpu,
+            variant,
+            max_sequence_length,
+        )
+    }
+
+    pub fn load_from_directory_with_variant_and_max_sequence_length(
+        model_path: &str,
+        use_cpu: bool,
+        variant: ModernBertVariant,
+        max_sequence_length: usize,
+    ) -> Result<Self, candle_core::Error> {
+        Self::load_from_directory_with_limit(
+            model_path,
+            use_cpu,
+            variant,
+            Some(max_sequence_length),
+        )
+    }
+
+    fn load_from_directory_with_limit(
+        model_path: &str,
+        use_cpu: bool,
+        variant: ModernBertVariant,
+        max_sequence_length: Option<usize>,
+    ) -> Result<Self, candle_core::Error> {
         // 1. Determine device
         let device = resolve_device(use_cpu);
         // 2. Load config.json
@@ -650,27 +798,12 @@ impl TraditionalModernBertClassifier {
             candle_core::Error::from(unified_err)
         })?;
 
-        // Pre-process config to handle different HuggingFace config formats
-        // Some models use top-level global_rope_theta/local_rope_theta, others use nested rope_parameters
-        let config_str = Self::normalize_config_json(&config_str);
-
-        let mut config: Config = serde_json::from_str(&config_str).map_err(|e| {
+        let config = Self::parse_model_config(&config_str).map_err(|e| {
             let unified_err = config_errors::invalid_json(&config_path, &e.to_string());
             candle_core::Error::from(unified_err)
         })?;
 
-        // Override max_position_embeddings for Extended32K variant to support full 32K context
-        // The Candle library's ModernBERT uses config.max_position_embeddings to initialize RoPE cache
-        // For Extended32K variant, we need to ensure it's set to 32768 even if config.json has a lower value
-        // NOTE: This override is safe because Extended32K models use YaRN RoPE scaling which dynamically
-        // generates position embeddings for any length up to 32K, even if the base config.json specifies
-        // a lower max_position_embeddings value.
-        if variant == ModernBertVariant::Extended32K {
-            let expected_max_len = variant.max_length(); // 32768
-            if config.max_position_embeddings < expected_max_len {
-                config.max_position_embeddings = expected_max_len;
-            }
-        }
+        let max_sequence_length = Self::resolve_sequence_length(&config, max_sequence_length)?;
 
         // 3. Dynamic class detection from id2label using unified config loader
         let num_classes = Self::load_modernbert_num_classes(model_path)?;
@@ -753,62 +886,14 @@ impl TraditionalModernBertClassifier {
             candle_core::Error::from(unified_err)
         })?;
 
-        // 9. Load training_config.json for 32K models to get actual max_length.
-        // The architectural max from training_config is recorded but then capped at
-        // MAX_CLASSIFICATION_SEQ_LEN. ModernBERT-32K / mmBERT-32K have global-attention
-        // layers that scale O(n²); at 4000 tokens they OOM the container with no logs.
-        // Classification tasks don't benefit from sequences longer than 512 tokens.
-        let model_max_length = if variant == ModernBertVariant::Extended32K {
-            let training_config_path = format!("{}/training_config.json", model_path);
-            if let Ok(training_config_str) = std::fs::read_to_string(&training_config_path) {
-                if let Ok(training_config_json) =
-                    serde_json::from_str::<serde_json::Value>(&training_config_str)
-                {
-                    // Use model_max_length from training_config if available
-                    training_config_json
-                        .get("model_max_length")
-                        .and_then(|v| v.as_u64())
-                        .map(|v| v as usize)
-                        .unwrap_or(variant.max_length())
-                } else {
-                    variant.max_length()
-                }
-            } else {
-                variant.max_length()
-            }
-        } else {
-            variant.max_length()
-        };
-        let effective_max_length = model_max_length.min(MAX_CLASSIFICATION_SEQ_LEN);
-
-        // 10. Create unified tokenizer wrapper with variant-specific config
-        let tokenizer_config = crate::core::tokenization::TokenizationConfig {
-            max_length: effective_max_length,
-            add_special_tokens: true,
-            truncation_strategy: tokenizers::TruncationStrategy::LongestFirst,
-            truncation_direction: tokenizers::TruncationDirection::Right,
-            pad_token_id: config.pad_token_id,
-            pad_token: variant.pad_token().to_string(),
-            tokenization_strategy: variant.tokenization_strategy(),
-            token_data_type: crate::core::tokenization::TokenDataType::U32,
-        };
-
-        let tokenizer_wrapper = Box::new(
-            crate::core::tokenization::UnifiedTokenizer::new(
-                tokenizer,
-                tokenizer_config,
-                device.clone(),
-            )
-            .map_err(|e| {
-                let unified_err = model_error!(
-                    ModelErrorType::Tokenizer,
-                    "tokenizer wrapper creation",
-                    format!("Failed to create tokenizer wrapper: {}", e),
-                    model_path
-                );
-                candle_core::Error::from(unified_err)
-            })?,
-        ) as Box<dyn DualPathTokenizer>;
+        let tokenizer_wrapper = Self::tokenizer_for_config(
+            tokenizer,
+            &config,
+            variant,
+            device.clone(),
+            max_sequence_length,
+        )
+        .map_err(candle_core::Error::wrap)?;
 
         drain_loader_queue(&device);
         Ok(Self {
@@ -854,7 +939,9 @@ impl TraditionalModernBertClassifier {
     ///     true, // use_cpu
     /// )?;
     ///
-    /// // Now classify text with 32K context support
+    /// // This compatibility loader keeps the default 512-token input budget.
+    /// // Use load_with_custom_base_model_and_max_sequence_length to opt in to
+    /// // a larger budget supported by the base model's config.json.
     /// let (class_id, confidence) = classifier.classify_text("My email is john@example.com")?;
     /// ```
     pub fn load_with_custom_base_model(
@@ -862,6 +949,38 @@ impl TraditionalModernBertClassifier {
         classifier_path: &str,
         variant: ModernBertVariant,
         use_cpu: bool,
+    ) -> Result<Self, candle_core::Error> {
+        Self::load_with_custom_base_model_and_limit(
+            base_model_path,
+            classifier_path,
+            variant,
+            use_cpu,
+            None,
+        )
+    }
+
+    pub fn load_with_custom_base_model_and_max_sequence_length(
+        base_model_path: &str,
+        classifier_path: &str,
+        variant: ModernBertVariant,
+        use_cpu: bool,
+        max_sequence_length: usize,
+    ) -> Result<Self, candle_core::Error> {
+        Self::load_with_custom_base_model_and_limit(
+            base_model_path,
+            classifier_path,
+            variant,
+            use_cpu,
+            Some(max_sequence_length),
+        )
+    }
+
+    fn load_with_custom_base_model_and_limit(
+        base_model_path: &str,
+        classifier_path: &str,
+        variant: ModernBertVariant,
+        use_cpu: bool,
+        max_sequence_length: Option<usize>,
     ) -> Result<Self, candle_core::Error> {
         // 1. Determine device
         let device = if use_cpu {
@@ -877,10 +996,12 @@ impl TraditionalModernBertClassifier {
             candle_core::Error::from(unified_err)
         })?;
 
-        let config: Config = serde_json::from_str(&base_config_str).map_err(|e| {
+        let config = Self::parse_model_config(&base_config_str).map_err(|e| {
             let unified_err = config_errors::invalid_json(&base_config_path, &e.to_string());
             candle_core::Error::from(unified_err)
         })?;
+
+        let max_sequence_length = Self::resolve_sequence_length(&config, max_sequence_length)?;
 
         // 3. Load number of classes from classifier config.json
         let num_classes = Self::load_modernbert_num_classes(classifier_path)?;
@@ -992,58 +1113,14 @@ impl TraditionalModernBertClassifier {
             candle_core::Error::from(unified_err)
         })?;
 
-        // 9. Determine effective max length (for Extended32K, check training_config.json).
-        // Always cap at MAX_CLASSIFICATION_SEQ_LEN — see comment in load_from_directory_with_variant.
-        let model_max_length_custom = if variant == ModernBertVariant::Extended32K {
-            let training_config_path = format!("{}/training_config.json", base_model_path);
-            if let Ok(training_config_str) = std::fs::read_to_string(&training_config_path) {
-                if let Ok(training_config_json) =
-                    serde_json::from_str::<serde_json::Value>(&training_config_str)
-                {
-                    training_config_json
-                        .get("model_max_length")
-                        .and_then(|v| v.as_u64())
-                        .map(|v| v as usize)
-                        .unwrap_or_else(|| variant.max_length())
-                } else {
-                    variant.max_length()
-                }
-            } else {
-                variant.max_length()
-            }
-        } else {
-            variant.max_length()
-        };
-        let effective_max_length = model_max_length_custom.min(MAX_CLASSIFICATION_SEQ_LEN);
-
-        // 10. Create unified tokenizer wrapper with variant-specific config
-        let tokenizer_config = crate::core::tokenization::TokenizationConfig {
-            max_length: effective_max_length,
-            add_special_tokens: true,
-            truncation_strategy: tokenizers::TruncationStrategy::LongestFirst,
-            truncation_direction: tokenizers::TruncationDirection::Right,
-            pad_token_id: config.pad_token_id,
-            pad_token: variant.pad_token().to_string(),
-            tokenization_strategy: variant.tokenization_strategy(),
-            token_data_type: crate::core::tokenization::TokenDataType::U32,
-        };
-
-        let tokenizer_wrapper = Box::new(
-            crate::core::tokenization::UnifiedTokenizer::new(
-                tokenizer,
-                tokenizer_config,
-                device.clone(),
-            )
-            .map_err(|e| {
-                let unified_err = model_error!(
-                    ModelErrorType::Tokenizer,
-                    "tokenizer wrapper creation",
-                    format!("Failed to create tokenizer wrapper: {}", e),
-                    base_model_path
-                );
-                candle_core::Error::from(unified_err)
-            })?,
-        ) as Box<dyn DualPathTokenizer>;
+        let tokenizer_wrapper = Self::tokenizer_for_config(
+            tokenizer,
+            &config,
+            variant,
+            device.clone(),
+            max_sequence_length,
+        )
+        .map_err(candle_core::Error::wrap)?;
 
         // 11. Determine classifier pooling from classifier config
         let classifier_config_path = format!("{}/config.json", classifier_path);
@@ -1088,9 +1165,11 @@ impl TraditionalModernBertClassifier {
         Self::load_from_directory_with_variant(model_path, use_cpu, ModernBertVariant::Multilingual)
     }
 
-    /// Load mmBERT-32K (YaRN-scaled multilingual) model from directory
-    /// Convenience method that explicitly loads as Multilingual32K variant
-    /// This variant supports 32K context length with YaRN RoPE scaling (theta=160000)
+    /// Load an mmBERT-32K checkpoint with the default 512-token input budget.
+    /// Convenience method that explicitly loads as Multilingual32K variant.
+    /// Use load_from_directory_with_max_sequence_length to request a larger
+    /// budget. Capacity and RoPE parameters come from the checkpoint config;
+    /// the variant name does not enable a scaling algorithm.
     /// Reference: https://huggingface.co/llm-semantic-router/mmbert-32k-yarn
     pub fn load_mmbert_32k_from_directory(
         model_path: &str,
@@ -1387,39 +1466,58 @@ impl TraditionalModernBertTokenClassifier {
         use_cpu: bool,
         variant: ModernBertVariant,
     ) -> Result<Self> {
+        Self::new_with_limit(model_id, use_cpu, variant, None)
+    }
+
+    pub fn new_with_max_sequence_length(
+        model_id: &str,
+        use_cpu: bool,
+        max_sequence_length: usize,
+    ) -> Result<Self> {
+        let variant = ModernBertVariant::detect_from_config(&format!("{model_id}/config.json"))?;
+        Self::new_with_variant_and_max_sequence_length(
+            model_id,
+            use_cpu,
+            variant,
+            max_sequence_length,
+        )
+    }
+
+    pub fn new_with_variant_and_max_sequence_length(
+        model_id: &str,
+        use_cpu: bool,
+        variant: ModernBertVariant,
+        max_sequence_length: usize,
+    ) -> Result<Self> {
+        Self::new_with_limit(model_id, use_cpu, variant, Some(max_sequence_length))
+    }
+
+    fn new_with_limit(
+        model_id: &str,
+        use_cpu: bool,
+        variant: ModernBertVariant,
+        max_sequence_length: Option<usize>,
+    ) -> Result<Self> {
         let device = resolve_device(use_cpu);
 
         // Load model configuration
         let config_path = std::path::Path::new(model_id).join("config.json");
         let config_str = std::fs::read_to_string(&config_path)
             .map_err(|e| E::msg(format!("Failed to read config.json: {}", e)))?;
-        // Pre-process config to handle different HuggingFace config formats
-        let config_str = TraditionalModernBertClassifier::normalize_config_json(&config_str);
-        let config: Config = serde_json::from_str(&config_str)
-            .map_err(|e| E::msg(format!("Failed to parse config.json: {}", e)))?;
+        let config = TraditionalModernBertClassifier::parse_model_config(&config_str)?;
+        let max_sequence_length =
+            TraditionalModernBertClassifier::resolve_sequence_length(&config, max_sequence_length)?;
 
-        // Load tokenizer
         let tokenizer_path = std::path::Path::new(model_id).join("tokenizer.json");
         let base_tokenizer = Tokenizer::from_file(&tokenizer_path)
             .map_err(|e| E::msg(format!("Failed to load tokenizer: {}", e)))?;
-
-        // Create dual-path compatible tokenizer based on variant.
-        // Always cap at MAX_CLASSIFICATION_SEQ_LEN — see comment at the top of this file.
-        let tokenizer = match variant {
-            ModernBertVariant::Multilingual | ModernBertVariant::Multilingual32K => {
-                crate::core::tokenization::create_mmbert_compatibility_tokenizer_with_max_length(
-                    base_tokenizer,
-                    device.clone(),
-                    MAX_CLASSIFICATION_SEQ_LEN,
-                )?
-            }
-            ModernBertVariant::Standard | ModernBertVariant::Extended32K => {
-                crate::core::tokenization::create_modernbert_compatibility_tokenizer(
-                    base_tokenizer,
-                    device.clone(),
-                )?
-            }
-        };
+        let tokenizer = TraditionalModernBertClassifier::tokenizer_for_config(
+            base_tokenizer,
+            &config,
+            variant,
+            device.clone(),
+            max_sequence_length,
+        )?;
 
         // Load model weights
         let weights_path = std::path::Path::new(model_id).join("model.safetensors");

--- a/candle-binding/src/model_architectures/traditional/modernbert_test.rs
+++ b/candle-binding/src/model_architectures/traditional/modernbert_test.rs
@@ -1601,261 +1601,257 @@ fn test_load_with_custom_base_model_parameter_validation() {
     println!("load_with_custom_base_model parameter validation test passed");
 }
 
-// =============================================================================
-// Long-prompt truncation tests
-//
-// These tests verify that the tokenizer enforces MAX_CLASSIFICATION_SEQ_LEN
-// (512) regardless of raw input length, preventing the quadratic global-
-// attention OOM observed at ~4 000 tokens (GitHub issue #1843).
-//
-// Tests that load tokenizer.json from disk are skipped automatically when the
-// `CI` environment variable is set (CI environments have no model files) or
-// when the tokenizer file is simply not present.
-// =============================================================================
-
-/// Return the path to the mmBERT-32K candle tokenizer.
-fn mmbert_candle_tokenizer_path() -> std::path::PathBuf {
-    std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .unwrap()
-        .join("models/mmbert32k-intent-classifier-merged/tokenizer.json")
+// Explicit classification input budgets, using a real tokenizer without model downloads.
+fn context_test_config(max_length: usize) -> serde_json::Value {
+    serde_json::json!({
+        "vocab_size": 6, "hidden_size": 8, "num_hidden_layers": 2,
+        "num_attention_heads": 2, "intermediate_size": 16,
+        "max_position_embeddings": max_length, "layer_norm_eps": 1e-5,
+        "pad_token_id": 5, "global_attn_every_n_layers": 3,
+        "global_rope_theta": 160000.0, "local_rope_theta": 10000.0,
+        "local_attention": 8, "id2label": {"0": "NEGATIVE", "1": "POSITIVE"},
+        "label2id": {"NEGATIVE": "0", "POSITIVE": "1"}, "classifier_pooling": "cls"
+    })
 }
 
-/// Load the long-prompt fixture JSON bundled in `test_data/`.
-fn load_long_prompt_fixtures() -> serde_json::Value {
-    let fixture_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("test_data/long_prompt_fixtures.json");
-    let raw = std::fs::read_to_string(&fixture_path)
-        .unwrap_or_else(|_| panic!("fixture not found at {:?}", fixture_path));
-    serde_json::from_str(&raw).expect("invalid fixture JSON")
-}
-
-/// Tokenize `text` with the given `DualPathTokenizer` and return the number
-/// of tokens after truncation.
-fn candle_token_count(tokenizer: &dyn DualPathTokenizer, text: &str) -> usize {
+fn context_test_tokenizer() -> tokenizers::Tokenizer {
+    use tokenizers::models::wordlevel::WordLevel;
+    use tokenizers::pre_tokenizers::whitespace::WhitespaceSplit;
+    use tokenizers::processors::template::TemplateProcessing;
+    let vocab = ["[UNK]", "[CLS]", "[SEP]", "word", "tail", "[PAD]"]
+        .into_iter()
+        .enumerate()
+        .map(|(id, token)| (token.to_string(), id as u32))
+        .collect();
+    let model = WordLevel::builder()
+        .vocab(vocab)
+        .unk_token("[UNK]".into())
+        .build()
+        .unwrap();
+    let mut tokenizer = tokenizers::Tokenizer::new(model);
+    tokenizer.with_pre_tokenizer(Some(WhitespaceSplit));
+    tokenizer.with_post_processor(Some(
+        TemplateProcessing::builder()
+            .try_single("[CLS] $A [SEP]")
+            .unwrap()
+            .special_tokens(vec![("[CLS]", 1), ("[SEP]", 2)])
+            .build()
+            .unwrap(),
+    ));
+    // Reproduce an artifact whose inherited fixed padding exceeds the requested limit.
+    tokenizer.with_padding(Some(tokenizers::PaddingParams {
+        strategy: tokenizers::PaddingStrategy::Fixed(65536),
+        pad_id: 5,
+        pad_token: "[PAD]".into(),
+        ..Default::default()
+    }));
     tokenizer
-        .tokenize(text)
-        .expect("tokenize failed")
-        .token_ids_u32
-        .len()
 }
 
-/// Confirm the constant that guards against OOM is the expected value.
-#[rstest]
-fn test_candle_max_classification_seq_len_is_512() {
-    assert_eq!(
-        MAX_CLASSIFICATION_SEQ_LEN, 512,
-        "MAX_CLASSIFICATION_SEQ_LEN must be 512 to prevent quadratic-attention OOM"
-    );
-}
-
-/// Verify that `ModernBertVariant::max_length()` returns the architectural
-/// limit, while `effective_max_length` (after the `.min(MAX_CLASSIFICATION_SEQ_LEN)` cap)
-/// never exceeds 512 for any classification variant.
-#[rstest]
-fn test_candle_effective_max_length_capped_for_all_variants() {
-    let variants = [
-        ModernBertVariant::Standard,
-        ModernBertVariant::Multilingual,
-        ModernBertVariant::Extended32K,
-        ModernBertVariant::Multilingual32K,
-    ];
-    for variant in variants {
-        let arch_max = variant.max_length();
-        // Replicate the capping logic from load_from_directory_with_variant.
-        let effective = arch_max.min(MAX_CLASSIFICATION_SEQ_LEN);
-        assert!(
-            effective <= MAX_CLASSIFICATION_SEQ_LEN,
-            "variant {:?}: effective_max_length {} exceeds MAX_CLASSIFICATION_SEQ_LEN {}",
-            variant,
-            effective,
-            MAX_CLASSIFICATION_SEQ_LEN,
-        );
-    }
-}
-
-/// Verify that for the Multilingual32K variant the architectural window (32 768)
-/// is correctly reduced to MAX_CLASSIFICATION_SEQ_LEN by the cap.
-#[rstest]
-fn test_candle_multilingual32k_effective_length_is_512() {
-    let variant = ModernBertVariant::Multilingual32K;
-    let effective = variant.max_length().min(MAX_CLASSIFICATION_SEQ_LEN);
-    assert_eq!(
-        effective, MAX_CLASSIFICATION_SEQ_LEN,
-        "Multilingual32K effective_max_length should be {}, got {}",
-        MAX_CLASSIFICATION_SEQ_LEN, effective,
-    );
-}
-
-/// Verify that the `UnifiedTokenizer` created for mmBERT classification
-/// truncates a ~4 000-token prompt to ≤ MAX_CLASSIFICATION_SEQ_LEN tokens.
-///
-/// Requires tokenizer.json on disk → skipped in CI.
-#[rstest]
-fn test_candle_tokenizer_truncates_long_prompt() {
-    if std::env::var("CI").is_ok() {
-        eprintln!("skipping test_candle_tokenizer_truncates_long_prompt: CI environment");
-        return;
-    }
-
-    let tokenizer_path = mmbert_candle_tokenizer_path();
-    if !tokenizer_path.exists() {
-        eprintln!(
-            "skipping test_candle_tokenizer_truncates_long_prompt: tokenizer not found at {:?}",
-            tokenizer_path
-        );
-        return;
-    }
-
-    let fixtures = load_long_prompt_fixtures();
-    let prompts = fixtures["prompts"].as_array().expect("prompts array");
-
-    let base_tok = tokenizers::Tokenizer::from_file(&tokenizer_path).expect("load tokenizer");
-    let unified = crate::core::tokenization::create_mmbert_compatibility_tokenizer_with_max_length(
-        base_tok,
-        candle_core::Device::Cpu,
-        MAX_CLASSIFICATION_SEQ_LEN,
+#[test]
+fn test_candle_context_budget_reserves_actual_postprocessor_special_tokens() {
+    let config = TraditionalModernBertClassifier::parse_model_config(
+        &context_test_config(32768).to_string(),
     )
-    .expect("create tokenizer wrapper");
-
-    // Downcast back to UnifiedTokenizer to call tokenize().
-    // We use the DualPathTokenizer trait method instead.
-    for prompt in prompts {
-        let id = prompt["id"].as_str().unwrap_or("?");
-        let text = prompt["text"].as_str().expect("text field");
-        let approx_untruncated = prompt["approx_tokens_untruncated"].as_u64().unwrap_or(0);
-
-        let result = unified.tokenize(text).expect("tokenize failed");
-        let count = result.token_ids_u32.len();
-
-        assert!(
-            count <= MAX_CLASSIFICATION_SEQ_LEN,
-            "prompt '{}' produced {} tokens (approx untruncated: {}); expected ≤ {}",
-            id,
-            count,
-            approx_untruncated,
-            MAX_CLASSIFICATION_SEQ_LEN,
-        );
-    }
-}
-
-/// Regression test for GitHub issue #1843: a ~4 000-token prompt must be
-/// truncated to exactly MAX_CLASSIFICATION_SEQ_LEN tokens by the candle
-/// mmBERT tokenizer wrapper.
-///
-/// Skipped in CI.
-#[rstest]
-fn test_candle_4k_prompt_truncated_to_safe_length() {
-    if std::env::var("CI").is_ok() {
-        eprintln!("skipping test_candle_4k_prompt_truncated_to_safe_length: CI environment");
-        return;
-    }
-
-    let tokenizer_path = mmbert_candle_tokenizer_path();
-    if !tokenizer_path.exists() {
-        eprintln!(
-            "skipping test_candle_4k_prompt_truncated_to_safe_length: tokenizer not found at {:?}",
-            tokenizer_path
-        );
-        return;
-    }
-
-    let fixtures = load_long_prompt_fixtures();
-    let long_prompt = fixtures["prompts"]
-        .as_array()
-        .and_then(|p| p.iter().find(|x| x["id"] == "long_4k"))
-        .expect("long_4k fixture missing");
-
-    let text = long_prompt["text"].as_str().expect("text");
-    let approx_raw = long_prompt["approx_tokens_untruncated"]
-        .as_u64()
-        .unwrap_or(0);
-
-    assert!(
-        approx_raw > 2048,
-        "fixture too short ({} est. tokens); rebuild long_prompt_fixtures.json",
-        approx_raw
-    );
-
-    let base_tok = tokenizers::Tokenizer::from_file(&tokenizer_path).expect("load tokenizer");
-    let unified = crate::core::tokenization::create_mmbert_compatibility_tokenizer_with_max_length(
-        base_tok,
-        candle_core::Device::Cpu,
-        MAX_CLASSIFICATION_SEQ_LEN,
-    )
-    .expect("create tokenizer wrapper");
-
-    let result = unified.tokenize(text).expect("tokenize failed");
-    let count = result.token_ids_u32.len();
-
-    assert_eq!(
-        count, MAX_CLASSIFICATION_SEQ_LEN,
-        "4k prompt must produce exactly {} tokens after truncation, got {}",
-        MAX_CLASSIFICATION_SEQ_LEN, count
-    );
-}
-
-/// Verify a short prompt is not over-truncated by the classification cap.
-///
-/// Skipped in CI.
-#[rstest]
-fn test_candle_short_prompt_not_truncated() {
-    if std::env::var("CI").is_ok() {
-        eprintln!("skipping test_candle_short_prompt_not_truncated: CI environment");
-        return;
-    }
-
-    let tokenizer_path = mmbert_candle_tokenizer_path();
-    if !tokenizer_path.exists() {
-        eprintln!(
-            "skipping test_candle_short_prompt_not_truncated: tokenizer not found at {:?}",
-            tokenizer_path
-        );
-        return;
-    }
-
-    let fixtures = load_long_prompt_fixtures();
-    let short = fixtures["prompts"]
-        .as_array()
-        .and_then(|p| p.iter().find(|x| x["id"] == "short_baseline"))
-        .expect("short_baseline fixture missing");
-    let text = short["text"].as_str().expect("text");
-
-    // Baseline: tokenizer with no cap.
-    let base_tok_uncapped = tokenizers::Tokenizer::from_file(&tokenizer_path).expect("load");
-    let uncapped =
-        crate::core::tokenization::create_mmbert_compatibility_tokenizer_with_max_length(
-            base_tok_uncapped,
+    .unwrap();
+    let configure = |tokenizer, limit| {
+        TraditionalModernBertClassifier::tokenizer_for_config(
+            tokenizer,
+            &config,
+            ModernBertVariant::Multilingual32K,
             candle_core::Device::Cpu,
-            65536, // far above any practical input
+            limit,
         )
-        .expect("create uncapped tokenizer");
-    let baseline_count = uncapped
-        .tokenize(text)
-        .expect("tokenize")
-        .token_ids_u32
-        .len();
-
-    // Production: tokenizer with the 512 cap.
-    let base_tok_capped = tokenizers::Tokenizer::from_file(&tokenizer_path).expect("load");
-    let capped = crate::core::tokenization::create_mmbert_compatibility_tokenizer_with_max_length(
-        base_tok_capped,
-        candle_core::Device::Cpu,
-        MAX_CLASSIFICATION_SEQ_LEN,
-    )
-    .expect("create capped tokenizer");
-    let capped_count = capped.tokenize(text).expect("tokenize").token_ids_u32.len();
-
+    };
+    let error = configure(context_test_tokenizer(), 1).err().unwrap();
+    assert!(error.to_string().contains("2 special tokens"));
+    let tokenizer = configure(context_test_tokenizer(), 2).unwrap();
     assert_eq!(
-        baseline_count, capped_count,
-        "short prompt ({} tokens) must not be truncated; got {} after capping",
-        baseline_count, capped_count
+        tokenizer.tokenize("word tail").unwrap().token_ids_u32,
+        vec![1, 2]
     );
-    assert!(
-        capped_count < MAX_CLASSIFICATION_SEQ_LEN,
-        "short prompt is unexpectedly long ({} tokens)",
-        capped_count
+
+    let mut tokenizer = context_test_tokenizer();
+    tokenizer.with_post_processor(None::<tokenizers::processors::template::TemplateProcessing>);
+    let tokenizer = configure(tokenizer, 1).unwrap();
+    assert_eq!(
+        tokenizer.tokenize("word tail").unwrap().token_ids_u32,
+        vec![3]
     );
+}
+
+#[test]
+fn test_candle_context_default_and_explicit_limits() {
+    for capacity in [256, 8192, 32768] {
+        let config = TraditionalModernBertClassifier::parse_model_config(
+            &context_test_config(capacity).to_string(),
+        )
+        .unwrap();
+        assert_eq!(
+            TraditionalModernBertClassifier::resolve_sequence_length(&config, None).unwrap(),
+            capacity.min(512)
+        );
+        assert_eq!(
+            TraditionalModernBertClassifier::resolve_sequence_length(&config, Some(capacity))
+                .unwrap(),
+            capacity
+        );
+        for invalid in [0, capacity + 1] {
+            assert!(TraditionalModernBertClassifier::resolve_sequence_length(
+                &config,
+                Some(invalid)
+            )
+            .is_err());
+        }
+    }
+}
+
+#[test]
+fn test_candle_context_tokenization_preserves_tail_and_model_padding() {
+    let config = TraditionalModernBertClassifier::parse_model_config(
+        &context_test_config(32768).to_string(),
+    )
+    .unwrap();
+    for limit in [512, 513, 1025, 32768] {
+        let tokenizer = TraditionalModernBertClassifier::tokenizer_for_config(
+            context_test_tokenizer(),
+            &config,
+            ModernBertVariant::Multilingual32K,
+            candle_core::Device::Cpu,
+            limit,
+        )
+        .unwrap();
+        let text = format!("{}tail", "word ".repeat(limit - 3));
+        let result = tokenizer.tokenize(&text).unwrap();
+        assert_eq!(result.token_ids_u32.len(), limit);
+        assert_eq!(
+            result.token_ids_u32[limit - 2],
+            4,
+            "tail must survive past 512"
+        );
+        assert_eq!(
+            result.token_ids_u32[limit - 1],
+            2,
+            "reserve the final special token"
+        );
+        assert_eq!(result.offsets[limit - 2].1, text.len());
+        let oversized = tokenizer.tokenize(&format!("{text} word word")).unwrap();
+        assert_eq!(oversized.token_ids_u32.len(), limit);
+        assert_eq!(oversized.token_ids_u32[limit - 1], 2);
+        let short = tokenizer.tokenize("word").unwrap();
+        assert_eq!(
+            short.token_ids_u32.len(),
+            3,
+            "remove inherited fixed padding"
+        );
+        let batch = tokenizer.tokenize_batch(&["word", "word tail"]).unwrap();
+        assert_eq!(batch.token_ids_u32[0], vec![1, 3, 2, 5]);
+        assert_eq!(batch.attention_masks[0], vec![1, 1, 1, 0]);
+    }
+}
+
+#[test]
+fn test_candle_context_config_preserves_separate_rope_theta() {
+    let mut value = context_test_config(32768);
+    value.as_object_mut().unwrap().remove("global_rope_theta");
+    value.as_object_mut().unwrap().remove("local_rope_theta");
+    value["rope_parameters"] = serde_json::json!({
+        "full_attention": {"rope_type": "default", "rope_theta": 160000.0},
+        "sliding_attention": {"rope_type": "default", "rope_theta": 10000.0}
+    });
+    let config = TraditionalModernBertClassifier::parse_model_config(&value.to_string()).unwrap();
+    assert_eq!(config.max_position_embeddings, 32768);
+    assert_eq!(config.global_rope_theta, 160000.0);
+    assert_eq!(config.local_rope_theta, 10000.0);
+    value["rope_parameters"]["full_attention"]["rope_type"] = "yarn".into();
+    assert!(TraditionalModernBertClassifier::parse_model_config(&value.to_string()).is_err());
+    let mut value = context_test_config(32768);
+    value["rope_scaling"] = serde_json::json!({"type": "yarn", "factor": 4.0});
+    assert!(TraditionalModernBertClassifier::parse_model_config(&value.to_string()).is_err());
+    value.as_object_mut().unwrap().remove("rope_scaling");
+    value["max_position_embeddings"] = 0.into();
+    assert!(TraditionalModernBertClassifier::parse_model_config(&value.to_string()).is_err());
+}
+
+#[test]
+fn test_candle_context_loaders_reject_invalid_limits_before_weights() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("config.json"),
+        context_test_config(8192).to_string(),
+    )
+    .unwrap();
+    // Legacy metadata and the explicit variant must not silently expand the cache.
+    std::fs::write(dir.path().join("training_config.json"),
+        r#"{"model_max_length":32768,"rope_scaling_type":"yarn","rope_original_max_position_embeddings":8192}"#,
+    ).unwrap();
+    let path = dir.path().to_str().unwrap();
+    for invalid in [0, 8193, 32768] {
+        let errors = [
+            TraditionalModernBertClassifier::load_from_directory_with_variant_and_max_sequence_length(
+                path, true, ModernBertVariant::Extended32K, invalid,
+            ).unwrap_err().to_string(),
+            TraditionalModernBertClassifier::load_with_custom_base_model_and_max_sequence_length(
+                path, path, ModernBertVariant::Extended32K, true, invalid,
+            ).unwrap_err().to_string(),
+            TraditionalModernBertTokenClassifier::new_with_variant_and_max_sequence_length(
+                path, true, ModernBertVariant::Extended32K, invalid,
+            ).unwrap_err().to_string(),
+        ];
+        for error in errors {
+            assert!(error.contains("max_sequence_length"), "{error}");
+        }
+    }
+}
+
+#[test]
+fn test_candle_context_classifier_loaders_execute_beyond_default() {
+    use candle_core::{DType, Device};
+    use candle_nn::{VarBuilder, VarMap};
+    let dir = tempfile::tempdir().unwrap();
+    let value = context_test_config(2048);
+    let config = TraditionalModernBertClassifier::parse_model_config(&value.to_string()).unwrap();
+    std::fs::write(dir.path().join("config.json"), value.to_string()).unwrap();
+    context_test_tokenizer()
+        .save(dir.path().join("tokenizer.json"), false)
+        .unwrap();
+    let vars = VarMap::new();
+    let vb = VarBuilder::from_varmap(&vars, DType::F32, &Device::Cpu);
+    super::ModernBert::load(vb.clone(), &config).unwrap();
+    FixedModernBertClassifier::load_with_classes(vb.pp("classifier"), &config, 2).unwrap();
+    vars.save(dir.path().join("model.safetensors")).unwrap();
+    let path = dir.path().to_str().unwrap();
+    let prefix = "word ".repeat(1020);
+    let text = format!("{prefix}tail");
+    let sequence = TraditionalModernBertClassifier::load_from_directory_with_max_sequence_length(
+        path, true, 1025,
+    )
+    .unwrap();
+    assert_eq!(
+        sequence.fit_prefix_to_window(&prefix, "tail").unwrap(),
+        prefix
+    );
+    assert!(sequence.classify_text(&text).unwrap().1.is_finite());
+    let custom =
+        TraditionalModernBertClassifier::load_with_custom_base_model_and_max_sequence_length(
+            path,
+            path,
+            ModernBertVariant::Extended32K,
+            true,
+            1025,
+        )
+        .unwrap();
+    assert!(custom.classify_text(&text).unwrap().1.is_finite());
+    let token =
+        TraditionalModernBertTokenClassifier::new_with_max_sequence_length(path, true, 1025)
+            .unwrap();
+    assert!(token
+        .classify_tokens(&text)
+        .unwrap()
+        .iter()
+        .any(|result| result.4 == text.len()));
+    let default = TraditionalModernBertClassifier::load_from_directory(path, true).unwrap();
+    assert!(default.fit_prefix_to_window(&prefix, "tail").unwrap().len() < prefix.len());
 }
 
 /// The confidence of a merged entity must be the arithmetic mean of the

--- a/onnx-binding/examples/benchmark_classifier_context.rs
+++ b/onnx-binding/examples/benchmark_classifier_context.rs
@@ -1,0 +1,88 @@
+//! Real sequence/token classifier regression; missing models or fixtures fail.
+//!
+//! Usage: benchmark_classifier_context MODEL_DIR sequence|token MAX_TOKENS cpu|rocm FIXTURES.json
+//! Fixtures are an array of {"id": "...", "text": "...", "expected_tokens": 1024}.
+//! Token counts include special tokens. Use the checkpoint's own tokenizer to
+//! construct fixtures, and compare probabilities/entities with the same weights.
+
+use onnx_semantic_router::model_architectures::classification::{
+    ClassifierExecutionProvider, MmBertSequenceClassifier, MmBertTokenClassifier,
+};
+use serde_json::json;
+use std::{error::Error, fs, time::Instant};
+use tokenizers::{Tokenizer, TruncationParams};
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() != 6 {
+        return Err("expected MODEL_DIR sequence|token MAX_TOKENS cpu|rocm FIXTURES.json".into());
+    }
+    let limit: usize = args[3].parse()?;
+    let provider = match args[4].as_str() {
+        "cpu" => ClassifierExecutionProvider::Cpu,
+        "rocm" => ClassifierExecutionProvider::Rocm,
+        _ => return Err("provider must be cpu or rocm".into()),
+    };
+    let fixtures: Vec<serde_json::Value> = serde_json::from_str(&fs::read_to_string(&args[5])?)?;
+    if fixtures.is_empty() {
+        return Err("fixtures must contain at least one input".into());
+    }
+    let mut sequence = if args[2] == "sequence" {
+        Some(MmBertSequenceClassifier::load_with_max_sequence_length(
+            &args[1], provider, limit,
+        )?)
+    } else {
+        None
+    };
+    let mut token = if args[2] == "token" {
+        Some(MmBertTokenClassifier::load_with_max_sequence_length(
+            &args[1], provider, limit,
+        )?)
+    } else {
+        None
+    };
+    if sequence.is_none() && token.is_none() {
+        return Err("task must be sequence or token".into());
+    }
+    // The loader validates that the budget can hold the tokenizer's special
+    // tokens before the benchmark configures its independent count check.
+    let mut tokenizer =
+        Tokenizer::from_file(format!("{}/tokenizer.json", args[1])).map_err(|e| e.to_string())?;
+    tokenizer.with_padding(None);
+    tokenizer
+        .with_truncation(Some(TruncationParams {
+            max_length: limit,
+            ..Default::default()
+        }))
+        .map_err(|e| e.to_string())?;
+    for fixture in fixtures {
+        let text = fixture["text"].as_str().ok_or("missing text")?;
+        let count = tokenizer
+            .encode(text, true)
+            .map_err(|e| e.to_string())?
+            .len();
+        if fixture["expected_tokens"].as_u64() != Some(count as u64) {
+            return Err(format!(
+                "fixture {}: expected {} tokens, encoded {count}",
+                fixture["id"], fixture["expected_tokens"]
+            )
+            .into());
+        }
+        let start = Instant::now();
+        let result = if let Some(model) = sequence.as_mut() {
+            let result = model.classify(text)?;
+            json!({"label": result.label, "probabilities": result.probabilities})
+        } else {
+            let result = token.as_mut().unwrap().detect_entities(text)?;
+            json!({"entities": result.entities.iter().map(|e| json!({
+                "text":e.text,"type":e.entity_type,"start":e.start,"end":e.end,"confidence":e.confidence
+            })).collect::<Vec<_>>()})
+        };
+        println!(
+            "{}",
+            json!({"id":fixture["id"],"tokens":count,"max_tokens":limit,
+            "elapsed_ms":start.elapsed().as_secs_f64()*1000.0,"result":result})
+        );
+    }
+    Ok(())
+}

--- a/onnx-binding/ort-ck-flash-attn/README.md
+++ b/onnx-binding/ort-ck-flash-attn/README.md
@@ -47,18 +47,44 @@ rewriter keeps the weights as it finds them and, for an FP32 graph, adds fp32↔
 `CKFlashAttention` node. A rewrite of the FP32 `model.onnx` must therefore be
 named `model_fa.onnx`; `model_fa_fp16.onnx` needs an FP16 input graph. The
 script refuses an fp16 name for an FP32 graph, because `find_onnx_models`
-ranks candidates by name alone. `make ck-rewrite-test` runs the rewriter's
+ranks candidates by name alone. A recognized RoPE position-to-sin/cos branch
+may keep its FP32 frequency constant and calculations before casting to FP16;
+this numerical constant is not counted as an encoder or classifier weight.
+`make ck-rewrite-test` runs the rewriter's
 unit tests (`scripts/test_rewrite_graph.py`); the changed-file gate runs them
 for any change under this directory.
 
-The matcher expects the attention subgraph of the FP32 `model.onnx` export:
-`Softmax` fed by `Add(MatMul(Mul(q), Mul(k)), mask)` and consumed directly by
-the AV `MatMul`. The published `model_sdpa_fp16.onnx` graphs differ (a NaN
-guard of `IsNaN` and `Where` between `Softmax` and the AV `MatMul`, or the
-scale applied after the QK `MatMul`) and are reported as
-`No attention blocks found`, so an FP16 FA artifact cannot be produced from
-them until the matcher covers that shape
-(vllm-project/semantic-router#3256).
+The matcher accepts `Softmax` fed by
+`Add(MatMul(Mul(q), Mul(k)), mask)`, including the published intent FP16
+export's `Where(IsNaN(probabilities), 0, probabilities)` guard before the AV
+`MatMul` and its reshape/transpose/reshape K path. A post-QK scaling export
+is not supported; unmatched or partially matched graphs are refused.
+
+Local/global attention is determined from the mask's positional comparisons,
+not exporter tensor names or layer frequency. The inclusive ModernBERT
+condition `abs(query_position - key_position) <= 64` becomes CK windows
+`(64, 64)`. For the 22-layer intent model with global attention every third
+layer, expect **8 global and 14 local nodes**. `--local-attention` checks the
+source window; it does not override it. Unknown mask comparisons are refused.
+The matcher also accepts the Transformers 4.57.6 / Torch 2.10 token export's
+`Where(bool(1-padding), negative, 1-padding)` and separate local-window fill,
+with the key-padding broadcast axes checked explicitly.
+The old dense mask computation is removed after all layers are rewritten;
+each custom op receives one `[B, 1, 1, S]` padding bias.
+
+Recognized FP16 masked mean-pooling heads accumulate and divide in FP32 before
+casting back to the head dtype, preventing long-sequence sum overflow. This
+does not add pooling to token-classification graphs or change their output rank.
+
+Check the original SDPA graph's task and output rank against the native Hugging
+Face model before using it as a correctness reference: a sequence-classification
+export cannot validate a token-classification task. Re-export the native task
+when they disagree; changing output shape metadata does not fix its computation.
+Existing published FA artifacts may contain different window assignments and
+must not be used to validate a new rewrite. Run the Python graph tests and the
+GPU SDPA tests (including local windows, one-dimensional padding bias, mixed
+batch lengths, and non-tile-aligned lengths) before model-level comparison.
+Graph tests alone do not establish GPU correctness or 32K task accuracy.
 
 ## Load the custom op
 

--- a/onnx-binding/ort-ck-flash-attn/scripts/rewrite_graph.py
+++ b/onnx-binding/ort-ck-flash-attn/scripts/rewrite_graph.py
@@ -20,6 +20,11 @@ import sys
 import numpy as np
 import onnx
 from onnx import TensorProto, helper, numpy_helper
+from stable_pooling import stabilize_mean_pooling
+
+WHERE_INPUT_COUNT = 3
+MASKED_ATTENTION_MAX = -10000.0
+ROPE_FREQUENCY_RANK = 3  # [1, rotary_dimension / 2, 1]
 
 
 def build_maps(graph):
@@ -32,7 +37,48 @@ def build_maps(graph):
     return out2node, name2node
 
 
-def find_attention_blocks(graph, out2node):  # noqa: C901,PLR0912
+def scalar_value(graph, out2node, name):
+    """Read a scalar export constant without materialising any model weights."""
+    tensor = next((t for t in graph.initializer if t.name == name), None)
+    if tensor is not None and math.prod(tensor.dims) == 1:
+        return float(numpy_helper.to_array(tensor).item())
+    node = out2node.get(name)
+    if node is None:
+        return None
+    if node.op_type == "Constant":
+        for attr in node.attribute:
+            if attr.name == "value" and math.prod(attr.t.dims) == 1:
+                return float(numpy_helper.to_array(attr.t).item())
+    if node.op_type == "Cast":
+        return scalar_value(graph, out2node, node.input[0])
+    return None
+
+
+def attention_probability_path(graph, out2node, softmax):
+    """Accept only direct probabilities or Where(IsNaN(p), scalar_zero, p)."""
+    probability = softmax.output[0]
+    extra = []
+    for node in graph.node:
+        if node.op_type != "Where" or len(node.input) != WHERE_INPUT_COUNT:
+            continue
+        guard = out2node.get(node.input[0])
+        if (
+            node.input[2] == probability
+            and guard is not None
+            and guard.op_type == "IsNaN"
+            and list(guard.input) == [probability]
+            and scalar_value(graph, out2node, node.input[1]) == 0
+        ):
+            probability = node.output[0]
+            extra = [guard, node]
+            break
+    consumers = [
+        n for n in graph.node if n.op_type == "MatMul" and n.input[0] == probability
+    ]
+    return consumers, extra
+
+
+def find_attention_blocks(graph, out2node):
     blocks = []
     softmaxes = [n for n in graph.node if n.op_type == "Softmax"]
 
@@ -71,10 +117,10 @@ def find_attention_blocks(graph, out2node):  # noqa: C901,PLR0912
         if not k_transpose:
             continue
 
-        av_consumers = [
-            n for n in graph.node if sm.output[0] in n.input and n.op_type == "MatMul"
-        ]
-        if not av_consumers:
+        av_consumers, probability_nodes = attention_probability_path(
+            graph, out2node, sm
+        )
+        if len(av_consumers) != 1:
             continue
         av_mm = av_consumers[0]
 
@@ -102,6 +148,7 @@ def find_attention_blocks(graph, out2node):  # noqa: C901,PLR0912
                 "k_transpose": k_transpose,
                 "k_extra_nodes": k_extra_nodes,
                 "av_matmul": av_mm,
+                "probability_nodes": probability_nodes,
                 "q_tensor": q_mul.input[0],
                 "k_tensor": k_tensor,
                 "v_tensor": av_mm.input[1],
@@ -113,7 +160,11 @@ def find_attention_blocks(graph, out2node):  # noqa: C901,PLR0912
     return blocks
 
 
-def compute_scale(graph, out2node, q_mul_node):
+def compute_scale(graph, out2node, q_mul_node, k_mul_node=None, hdim=64):
+    q_scale = scalar_value(graph, out2node, q_mul_node.input[1])
+    k_scale = scalar_value(graph, out2node, (k_mul_node or q_mul_node).input[1])
+    if q_scale is not None and k_scale is not None:
+        return q_scale * k_scale
     try:
         scale_name = q_mul_node.input[1]
         sqrt_node = out2node[scale_name]
@@ -126,32 +177,157 @@ def compute_scale(graph, out2node, q_mul_node):
             return 1.0 / math.sqrt(hdim_val)
     except (KeyError, IndexError):
         pass
-    return 1.0 / math.sqrt(64.0)
+    return 1.0 / math.sqrt(hdim)
 
 
-def classify_mask(mask_tensor_name, local_mask_name=None):
-    """Determine if a mask tensor represents local or global attention.
+def inverted_padding_fill(graph, out2node, mask):
+    """Recognise HF's Where(bool(1-padding), negative, 1-padding) export.
 
-    Two naming conventions are supported:
-      - Classifier models:  Where_1 = local, Where_2 = global
-      - Embedding models:   masked_fill = local, masked_fill_1 = global
+    The broadcast axes are part of the contract: attention_mask [B,S] becomes
+    [B,1,1,S], so only key padding is masked. Do not accept arbitrary inversions.
     """
-    # Classifier convention
-    if "Where_1" in mask_tensor_name:
-        return "local"
-    if "Where_2" in mask_tensor_name:
-        return "global"
-    # Embedding convention (fewer layers use the base mask = local)
-    if local_mask_name is not None:
-        return "local" if mask_tensor_name == local_mask_name else "global"
-    if mask_tensor_name == "masked_fill":
-        return "local"
-    if "masked_fill" in mask_tensor_name:
-        return "global"
-    return "unknown"
+    condition = out2node.get(mask.input[0])
+    if (
+        condition is None
+        or condition.op_type != "Cast"
+        or list(condition.input) != [mask.input[2]]
+        or not any(
+            a.name == "to" and a.i == TensorProto.BOOL for a in condition.attribute
+        )
+    ):
+        return False
+    sub = out2node.get(mask.input[2])
+    if (
+        sub is None
+        or sub.op_type != "Sub"
+        or scalar_value(graph, out2node, sub.input[0]) != 1
+    ):
+        return False
+    padding = out2node.get(sub.input[1])
+    if padding is not None and padding.op_type == "Cast":
+        padding = out2node.get(padding.input[0])
+    if padding is None or padding.op_type != "Expand":
+        return False
+    padding = out2node.get(padding.input[0])
+    if (
+        padding is None
+        or padding.op_type != "Unsqueeze"
+        or padding.input[0] != "attention_mask"
+    ):
+        return False
+    axes = next((t for t in graph.initializer if t.name == padding.input[1]), None)
+    if axes is None:
+        node = out2node.get(padding.input[1])
+        if node is not None and node.op_type == "Constant":
+            axes = next((a.t for a in node.attribute if a.name == "value"), None)
+    return axes is not None and list(numpy_helper.to_array(axes)) == [1, 2]
 
 
-def find_mask_only_nodes(graph, out2node):  # noqa: C901
+def attention_window(graph, out2node, mask_tensor_name):
+    """Read symmetric positional windows from mask semantics, never names/counts.
+
+    ModernBERT exports abs(query_position - key_position) <= local_attention/2.
+    Both endpoints are inclusive: a radius of 64 means (64, 64), not (63, 64).
+    Unknown comparisons are refused instead of silently becoming global attention.
+    """
+    mask = out2node.get(mask_tensor_name)
+    if mask is None or mask.op_type != "Where" or len(mask.input) != WHERE_INPUT_COUNT:
+        raise ValueError(f"unsupported additive attention mask {mask_tensor_name!r}")
+    keep = scalar_value(graph, out2node, mask.input[1])
+    masked = scalar_value(graph, out2node, mask.input[2])
+    positive_condition = (
+        keep == 0 and masked is not None and masked <= MASKED_ATTENTION_MAX
+    )
+    negative_condition = False
+    if keep is not None and keep <= MASKED_ATTENTION_MAX:
+        negative_condition = inverted_padding_fill(graph, out2node, mask)
+        condition = out2node.get(mask.input[0])
+        if condition is not None and condition.op_type == "Not":
+            window = out2node.get(condition.input[0])
+            while window is not None and window.op_type == "Unsqueeze":
+                window = out2node.get(window.input[0])
+            if window is not None and window.op_type in {"Less", "LessOrEqual"}:
+                # HF applies the window after the padding mask. A recursive
+                # global-mask check rejects reversed or otherwise unknown fills.
+                negative_condition = attention_window(
+                    graph, out2node, mask.input[2]
+                ) == (-1, -1)
+    if not positive_condition and not negative_condition:
+        raise ValueError(
+            f"mask {mask_tensor_name!r} must map allowed positions to zero"
+        )
+    ancestors = {}
+    pending = [mask_tensor_name]
+    leaves = set()
+    while pending:
+        name = pending.pop()
+        node = out2node.get(name)
+        if node is None:
+            leaves.add(name)
+        elif node.name not in ancestors:
+            ancestors[node.name] = node
+            pending.extend(node.input)
+    if "attention_mask" not in leaves:
+        raise ValueError(f"mask {mask_tensor_name!r} does not depend on attention_mask")
+
+    def position_range(name):
+        node = out2node.get(name)
+        while node is not None:
+            if node.op_type in {
+                "Cast",
+                "Identity",
+                "Unsqueeze",
+                "Squeeze",
+                "Reshape",
+            } or (
+                node.op_type == "Transpose"
+                and any(
+                    a.name == "perm" and list(a.ints) == [1, 0] for a in node.attribute
+                )
+            ):
+                node = out2node.get(node.input[0])
+            else:
+                break
+        return node.output[0] if node is not None and node.op_type == "Range" else None
+
+    radii = set()
+    for node in ancestors.values():
+        if node.op_type not in {
+            "Less",
+            "LessOrEqual",
+            "Greater",
+            "GreaterOrEqual",
+            "Equal",
+        }:
+            continue
+        lhs = out2node.get(node.input[0])
+        bound = scalar_value(graph, out2node, node.input[1])
+        if (
+            node.op_type == "GreaterOrEqual"
+            and bound == 0
+            and position_range(node.input[0]) is not None
+        ):
+            continue  # exporter bounds-checks non-negative query positions
+        if node.op_type in {"Less", "LessOrEqual"} and lhs is not None:
+            sub = out2node.get(lhs.input[0]) if lhs.op_type == "Abs" else None
+            if sub is not None and sub.op_type == "Sub" and bound is not None:
+                q_pos, k_pos = map(position_range, sub.input)
+                radius = bound - (1 if node.op_type == "Less" else 0)
+                if (
+                    q_pos is not None
+                    and q_pos == k_pos
+                    and radius >= 0
+                    and radius.is_integer()
+                ):
+                    radii.add(int(radius))
+                    continue
+        raise ValueError(f"unsupported attention-mask comparison {node.name!r}")
+    if len(radii) > 1:
+        raise ValueError(f"mask {mask_tensor_name!r} has conflicting local windows")
+    return (next(iter(radii)),) * 2 if radii else (-1, -1)
+
+
+def find_mask_only_nodes(graph, out2node):
     """Find nodes that are exclusively part of the 2-D mask computation."""
     mask_roots = set()
     for n in graph.node:
@@ -296,7 +472,81 @@ def create_1d_padding_bias_nodes(graph):
     return nodes, unsqueeze_out
 
 
-def weight_precision(initializers):
+def rotary_fp32_initializers(graph, out2node):
+    """Identify FP32 RoPE frequencies used only with positions, then cast to FP16.
+
+    Torch exports this intentional FP32 numerical island as an initializer.
+    It is not an encoder/head weight, and must not be narrowed to satisfy the
+    weight-name guard. Require the complete observed position-to-sin/cos path.
+    """
+    consumers = {}
+    for node in graph.node:
+        for name in set(node.input):
+            consumers.setdefault(name, []).append(node)
+    graph_outputs = {v.name for v in graph.output}
+
+    def only_consumer(name, op):
+        uses = consumers.get(name, [])
+        if name not in graph_outputs and len(uses) == 1 and uses[0].op_type == op:
+            return uses[0]
+        return None
+
+    def attr(node, name):
+        return next(
+            (helper.get_attribute_value(a) for a in node.attribute if a.name == name),
+            None,
+        )
+
+    exempt = set()
+    for tensor in graph.initializer:
+        if (
+            tensor.data_type != TensorProto.FLOAT
+            or len(tensor.dims) != ROPE_FREQUENCY_RANK
+        ):
+            continue
+        if tensor.dims[0] != 1 or tensor.dims[2] != 1:
+            continue
+        multiply = only_consumer(tensor.name, "MatMul")
+        if multiply is None or multiply.input[0] != tensor.name:
+            continue
+        position = out2node.get(multiply.input[1])
+        if position is None or position.op_type != "Cast" or attr(position, "to") != 1:
+            continue
+        position = out2node.get(position.input[0])
+        while position is not None and position.op_type == "Unsqueeze":
+            position = out2node.get(position.input[0])
+        if (
+            position is None
+            or position.op_type != "Range"
+            or scalar_value(graph, out2node, position.input[0]) != 0
+            or scalar_value(graph, out2node, position.input[2]) != 1
+        ):
+            continue
+        transpose = only_consumer(multiply.output[0], "Transpose")
+        if transpose is None or attr(transpose, "perm") != [0, 2, 1]:
+            continue
+        concat = only_consumer(transpose.output[0], "Concat")
+        if (
+            concat is None
+            or list(concat.input) != [transpose.output[0]] * 2
+            or attr(concat, "axis") not in (-1, 2)
+            or concat.output[0] in graph_outputs
+        ):
+            continue
+        trig = consumers.get(concat.output[0], [])
+        expected_trig = {"Cos", "Sin"}
+        if (
+            len(trig) != len(expected_trig)
+            or {n.op_type for n in trig} != expected_trig
+        ):
+            continue
+        casts = [only_consumer(n.output[0], "Cast") for n in trig]
+        if all(n is not None and attr(n, "to") == TensorProto.FLOAT16 for n in casts):
+            exempt.add(tensor.name)
+    return exempt
+
+
+def weight_precision(initializers, *, position_constants=frozenset()):
     """Return the one floating-point elem_type every weight tensor shares.
 
     Integer initializers (shapes, gather indices) carry no precision and are
@@ -307,7 +557,7 @@ def weight_precision(initializers):
     """
     counts = {}
     for tensor in initializers:
-        if tensor.data_type in _FLOAT_TYPES:
+        if tensor.data_type in _FLOAT_TYPES and tensor.name not in position_constants:
             counts[tensor.data_type] = counts.get(tensor.data_type, 0) + 1
     if not counts:
         raise ValueError("the graph holds no floating-point weight tensors")
@@ -367,9 +617,7 @@ def enforce_output_precision(output_path, model_is_fp16):
         )
 
 
-def rewrite(  # noqa: C901,PLR0912,PLR0915
-    model_path, output_path, hdim=64, local_attention=128
-):
+def rewrite(model_path, output_path, hdim=64, local_attention=128):
     model = onnx.load(model_path)
     graph = model.graph
 
@@ -380,31 +628,29 @@ def rewrite(  # noqa: C901,PLR0912,PLR0915
         print("No attention blocks found -- nothing to rewrite.")
         sys.exit(1)
 
-    scale = compute_scale(graph, out2node, blocks[0]["q_mul"])
-    print(f"Found {len(blocks)} attention blocks, scale={scale:.6f}")
-
-    # Auto-detect the local mask name: the mask tensor used by the fewest
-    # layers is the local (sliding-window) mask.
-    mask_names = [b["mask_tensor"] for b in blocks]
-    mask_freq = {}
-    for m in mask_names:
-        mask_freq[m] = mask_freq.get(m, 0) + 1
-    local_mask_name = min(mask_freq, key=mask_freq.get) if mask_freq else None
-
-    n_local = sum(
-        1 for b in blocks if classify_mask(b["mask_tensor"], local_mask_name) == "local"
-    )
-    n_global = sum(
-        1
+    softmax_count = sum(n.op_type == "Softmax" for n in graph.node)
+    if len(blocks) != softmax_count:
+        raise ValueError(
+            f"matched {len(blocks)} of {softmax_count} Softmax nodes; "
+            "refusing a partial rewrite that retains dense attention"
+        )
+    windows = {
+        b["mask_tensor"]: attention_window(graph, out2node, b["mask_tensor"])
         for b in blocks
-        if classify_mask(b["mask_tensor"], local_mask_name) == "global"
+    }
+    for window in windows.values():
+        if window[0] >= 0 and window != (local_attention // 2,) * 2:
+            raise ValueError(
+                f"source mask window {window} disagrees with "
+                f"--local-attention={local_attention}"
+            )
+    n_local = sum(windows[b["mask_tensor"]][0] >= 0 for b in blocks)
+    n_global = len(blocks) - n_local
+    print(f"Found {len(blocks)} attention blocks")
+    print(
+        f"  Local attention layers: {n_local} (source windows={set(windows.values())})"
     )
-    print(f"  Local attention layers: {n_local} (window={local_attention})")
     print(f"  Global attention layers: {n_global}")
-
-    # Window sizes for local attention (symmetric window around diagonal)
-    wl = local_attention // 2 - 1  # 63 for window=128
-    wr = local_attention // 2  # 64 for window=128
 
     # Create 1-D padding bias nodes
     pad_bias_nodes, pad_bias_tensor = create_1d_padding_bias_nodes(graph)
@@ -413,7 +659,11 @@ def rewrite(  # noqa: C901,PLR0912,PLR0915
     # optional and describes activations, so a valid FP16 export that carries
     # none would read as FP32, and one activation cannot vouch for every weight.
     try:
-        model_is_fp16 = weight_precision(graph.initializer) == TensorProto.FLOAT16
+        position_constants = rotary_fp32_initializers(graph, out2node)
+        model_is_fp16 = (
+            weight_precision(graph.initializer, position_constants=position_constants)
+            == TensorProto.FLOAT16
+        )
     except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
         sys.exit(1)
@@ -421,6 +671,8 @@ def rewrite(  # noqa: C901,PLR0912,PLR0915
         print("  Model precision: FP16 (skipping input/output Cast nodes)")
     else:
         print("  Model precision: FP32 (adding fp32↔fp16 Cast nodes)")
+    if position_constants:
+        print(f"  Preserved {len(position_constants)} FP32 RoPE frequency constants")
 
     enforce_output_precision(output_path, model_is_fp16)
 
@@ -429,7 +681,7 @@ def rewrite(  # noqa: C901,PLR0912,PLR0915
     new_nodes = []
 
     for i, blk in enumerate(blocks):
-        mask_type = classify_mask(blk["mask_tensor"], local_mask_name)
+        scale = compute_scale(graph, out2node, blk["q_mul"], blk["k_mul"], hdim)
 
         for key in (
             "q_mul",
@@ -443,12 +695,10 @@ def rewrite(  # noqa: C901,PLR0912,PLR0915
             nodes_to_remove.add(blk[key].name)
         for extra in blk.get("k_extra_nodes", []):
             nodes_to_remove.add(extra.name)
+        for extra in blk["probability_nodes"]:
+            nodes_to_remove.add(extra.name)
 
-        # Set window attributes based on local vs global
-        if mask_type == "local":
-            fa_wl, fa_wr = wl, wr
-        else:
-            fa_wl, fa_wr = -1, -1
+        fa_wl, fa_wr = windows[blk["mask_tensor"]]
 
         # Derive a clean layer prefix for the FA node name
         sm_name = blk["softmax"].name
@@ -609,6 +859,10 @@ def rewrite(  # noqa: C901,PLR0912,PLR0915
 
     # Rebuild node list: keep original order, then append new nodes
     kept = [n for n in graph.node if n.name not in nodes_to_remove]
+    if any(output in windows for node in kept for output in node.output):
+        raise ValueError(
+            "dense attention mask is still live after rewriting every layer"
+        )
     kept.extend(pad_bias_nodes)
     kept.extend(new_nodes)
 
@@ -617,6 +871,8 @@ def rewrite(  # noqa: C901,PLR0912,PLR0915
 
     del graph.node[:]
     graph.node.extend(kept)
+    pooling_repairs = stabilize_mean_pooling(graph)
+    print(f"  Stabilized {pooling_repairs} FP16 masked mean-pooling paths")
 
     # For fp16 models, cast graph outputs from fp16 to fp32 so that older
     # ONNX Runtime host code (which only tries extract_tensor::<f32>) works.
@@ -661,6 +917,25 @@ def rewrite(  # noqa: C901,PLR0912,PLR0915
     has_ck = any(op.domain == "com.ck" for op in model.opset_import)
     if not has_ck:
         model.opset_import.append(helper.make_opsetid("com.ck", 1))
+
+    # Replacement nodes were appended after their original consumers. Keep the
+    # serialized graph valid without depending on an ORT-specific reordering.
+    available = (
+        {v.name for v in graph.input} | {t.name for t in graph.initializer} | {""}
+    )
+    pending = list(graph.node)
+    ordered = []
+    while pending:
+        ready = [n for n in pending if all(name in available for name in n.input)]
+        if not ready:
+            raise ValueError("rewritten graph has unresolved inputs or a cycle")
+        for node in ready:
+            ordered.append(node)
+            available.update(node.output)
+        ready_names = {n.name for n in ready}
+        pending = [n for n in pending if n.name not in ready_names]
+    del graph.node[:]
+    graph.node.extend(ordered)
 
     onnx.save(model, output_path)
     print(f"Saved rewritten model to {output_path}")

--- a/onnx-binding/ort-ck-flash-attn/scripts/stable_pooling.py
+++ b/onnx-binding/ort-ck-flash-attn/scripts/stable_pooling.py
@@ -1,0 +1,280 @@
+"""Keep an FP16 classifier's masked mean finite at long sequence lengths.
+
+Only the typed, mask-derived ReduceSum/Div path into a dense head is changed.
+The encoder, mask multiplication, head, and public tensor dtypes stay intact.
+Apply this after any whole-model FP16 conversion so its FP32 reduction and
+division are not narrowed again.
+"""
+
+from collections import defaultdict
+from dataclasses import dataclass
+
+from onnx import NodeProto, TensorProto, helper, numpy_helper
+
+
+def _standard(node, op):
+    return (
+        node is not None
+        and node.op_type == op
+        and node.domain in ("", "ai.onnx")
+        and len(node.output) == 1
+    )
+
+
+def _attribute(node, name, default=None):
+    return next(
+        (helper.get_attribute_value(a) for a in node.attribute if a.name == name),
+        default,
+    )
+
+
+class _GraphView:
+    def __init__(self, graph):
+        self.nodes = list(graph.node)
+        self.producers = {out: node for node in self.nodes for out in node.output}
+        self.consumers = defaultdict(list)
+        for node in self.nodes:
+            for name in node.input:
+                self.consumers[name].append(node)
+        self.initializers = {tensor.name: tensor for tensor in graph.initializer}
+        self.tensors = {}
+        for value in (*graph.input, *graph.value_info, *graph.output):
+            if value.type.HasField("tensor_type"):
+                tensor = value.type.tensor_type
+                if tensor.HasField("shape"):
+                    shape = [
+                        (
+                            dim.dim_value
+                            if dim.HasField("dim_value")
+                            else dim.dim_param or None
+                        )
+                        for dim in tensor.shape.dim
+                    ]
+                    self.tensors[value.name] = (tensor.elem_type, shape)
+        for tensor in graph.initializer:
+            self.tensors[tensor.name] = (tensor.data_type, list(tensor.dims))
+        self.outputs = {value.name for value in graph.output}
+        self.names = set(self.tensors) | set(self.producers)
+        self.names.update(node.name for node in self.nodes)
+
+    def typed(self, name, dtype, rank):
+        info = self.tensors.get(name)
+        return info is not None and info[0] == dtype and len(info[1]) == rank
+
+    def axes(self, node, rank):
+        axes = _attribute(node, "axes")
+        # ReduceSum/Unsqueeze have an optional second, axes input.
+        if axes is None and len(node.input) == 2:  # noqa: PLR2004
+            tensor = self.initializers.get(node.input[1])
+            if tensor is None:
+                producer = self.producers.get(node.input[1])
+                if _standard(producer, "Constant"):
+                    tensor = _attribute(producer, "value")
+            if (
+                tensor is None
+                or tensor.data_type != TensorProto.INT64
+                or list(tensor.dims) != [1]
+            ):
+                return None
+            try:
+                axes = numpy_helper.to_array(tensor).tolist()
+            except (ValueError, OSError):
+                return None
+        if axes is None or len(axes) != 1 or not -rank <= axes[0] < rank:
+            return None
+        return tuple(axis % rank for axis in axes)
+
+    def fresh(self, base):
+        name, suffix = base, 0
+        while name in self.names:
+            suffix += 1
+            name = f"{base}_{suffix}"
+        self.names.add(name)
+        return name
+
+
+@dataclass
+class _MeanPool:
+    divide: NodeProto
+    numerator: NodeProto
+    denominator_cast: NodeProto
+    count: NodeProto
+
+
+def _masked_product(view, product):
+    """Return the original rank-two integer mask, accepting either Mul order."""
+    if (
+        not _standard(product, "Mul")
+        or len(product.input) != 2  # noqa: PLR2004 - binary op
+    ):
+        return None
+    if not view.typed(product.output[0], TensorProto.FLOAT16, 3):
+        return None
+    for hidden, mask in (product.input, list(reversed(product.input))):
+        cast = view.producers.get(mask)
+        if (
+            not view.typed(hidden, TensorProto.FLOAT16, 3)
+            or not _standard(cast, "Cast")
+            or len(cast.input) != 1
+            or _attribute(cast, "to") != TensorProto.FLOAT16
+        ):
+            continue
+        unsqueeze = view.producers.get(cast.input[0])
+        if (
+            not _standard(unsqueeze, "Unsqueeze")
+            or len(unsqueeze.input) not in (1, 2)
+            or view.axes(unsqueeze, 3) != (2,)
+        ):
+            continue
+        original_mask = unsqueeze.input[0]
+        if not view.typed(original_mask, TensorProto.INT64, 2):
+            continue
+        hidden_length = view.tensors[hidden][1][1]
+        mask_length = view.tensors[original_mask][1][1]
+        # A single-token mask broadcasting across the sequence is not this
+        # mean: its denominator would count one token, rather than the sequence.
+        if (
+            hidden_length is not None
+            and mask_length is not None
+            and hidden_length != mask_length
+        ):
+            continue
+        return original_mask
+    return None
+
+
+def _match_mean_pool(view, divide):
+    if (
+        not _standard(divide, "Div")
+        or len(divide.input) != 2  # noqa: PLR2004 - binary op
+        or not view.typed(divide.output[0], TensorProto.FLOAT16, 2)
+    ):
+        return None
+    # This repair belongs to a sequence classifier, not an arbitrary attention
+    # normalization or a reduction feeding the encoder.
+    heads = view.consumers[divide.output[0]]
+    if not any(
+        _standard(head, "Gemm")
+        and len(head.input) >= 2  # noqa: PLR2004 - Gemm inputs A/B, optional C
+        and head.input[0] == divide.output[0]
+        and _attribute(head, "transA", 0) == 0
+        and view.typed(head.input[1], TensorProto.FLOAT16, 2)
+        for head in heads
+    ):
+        return None
+    numerator = view.producers.get(divide.input[0])
+    denominator_cast = view.producers.get(divide.input[1])
+    if (
+        not _standard(numerator, "ReduceSum")
+        or len(numerator.input) not in (1, 2)
+        or view.axes(numerator, 3) != (1,)
+        or _attribute(numerator, "keepdims", 1) != 0
+        or not view.typed(numerator.output[0], TensorProto.FLOAT16, 2)
+        or not _standard(denominator_cast, "Cast")
+        or len(denominator_cast.input) != 1
+        or _attribute(denominator_cast, "to") != TensorProto.FLOAT16
+        or not view.typed(denominator_cast.output[0], TensorProto.FLOAT16, 2)
+    ):
+        return None
+    mask = _masked_product(view, view.producers.get(numerator.input[0]))
+    count = view.producers.get(denominator_cast.input[0])
+    if (
+        mask is None
+        or not _standard(count, "ReduceSum")
+        or len(count.input) not in (1, 2)
+        or count.input[0] != mask
+        or view.axes(count, 2) != (1,)
+        or _attribute(count, "keepdims", 1) != 1
+        or not view.typed(count.output[0], TensorProto.INT64, 2)
+    ):
+        return None
+    return _MeanPool(divide, numerator, denominator_cast, count)
+
+
+def stabilize_mean_pooling(graph):
+    """Repair recognized FP16 masked means in place; return the number changed.
+
+    Required type/rank evidence comes from graph inputs, initializers and
+    value_info. Unrecognized, untyped and FP32 paths are left byte-for-byte
+    unchanged. Shared FP16 intermediates remain available to other consumers.
+    The original mean output name/type is preserved, making the pass idempotent.
+    """
+    view = _GraphView(graph)
+    pools = [pool for node in view.nodes if (pool := _match_mean_pool(view, node))]
+    if not pools:
+        return 0
+
+    replacements, removed, new_info = {}, set(), []
+    for pool in pools:
+        original_mean = pool.divide.output[0]
+        prefix = original_mean + "__stable_pool"
+        product = view.fresh(prefix + "_product_fp32")
+        total = view.fresh(prefix + "_sum_fp32")
+        count = view.fresh(prefix + "_count_fp32")
+        mean = view.fresh(prefix + "_mean_fp32")
+        nodes = [
+            helper.make_node(
+                "Cast",
+                [pool.numerator.input[0]],
+                [product],
+                name=view.fresh(prefix + "_cast_product"),
+                to=TensorProto.FLOAT,
+            ),
+        ]
+        wider_sum = type(pool.numerator)()
+        wider_sum.CopyFrom(pool.numerator)
+        wider_sum.name = view.fresh(prefix + "_sum")
+        wider_sum.input[0] = product
+        wider_sum.output[0] = total
+        nodes.extend(
+            [
+                wider_sum,
+                helper.make_node(
+                    "Cast",
+                    [pool.count.output[0]],
+                    [count],
+                    name=view.fresh(prefix + "_cast_count"),
+                    to=TensorProto.FLOAT,
+                ),
+                helper.make_node(
+                    "Div", [total, count], [mean], name=view.fresh(prefix + "_divide")
+                ),
+                helper.make_node(
+                    "Cast",
+                    [mean],
+                    [original_mean],
+                    name=view.fresh(prefix + "_cast_mean"),
+                    to=TensorProto.FLOAT16,
+                ),
+            ]
+        )
+        replacements[original_mean] = nodes
+        for node in (pool.numerator, pool.denominator_cast):
+            output = node.output[0]
+            if output not in view.outputs and view.consumers[output] == [pool.divide]:
+                removed.add(output)
+        for name, source in (
+            (product, pool.numerator.input[0]),
+            (total, pool.numerator.output[0]),
+            (count, pool.denominator_cast.output[0]),
+            (mean, original_mean),
+        ):
+            new_info.append(
+                helper.make_tensor_value_info(
+                    name, TensorProto.FLOAT, view.tensors[source][1]
+                )
+            )
+
+    rewritten = []
+    for node in view.nodes:
+        output = node.output[0] if len(node.output) == 1 else None
+        if output in replacements:
+            rewritten.extend(replacements[output])
+        elif output not in removed:
+            rewritten.append(node)
+    kept_info = [value for value in graph.value_info if value.name not in removed]
+    del graph.node[:]
+    graph.node.extend(rewritten)
+    del graph.value_info[:]
+    graph.value_info.extend(kept_info + new_info)
+    return len(pools)

--- a/onnx-binding/ort-ck-flash-attn/scripts/test_rewrite_graph.py
+++ b/onnx-binding/ort-ck-flash-attn/scripts/test_rewrite_graph.py
@@ -5,11 +5,22 @@ Run from this directory with the rewriter's own dependencies installed:
     python3 -m unittest test_rewrite_graph
 """
 
+import tempfile
 import unittest
+from pathlib import Path
 
 import numpy as np
+import onnx
 from onnx import TensorProto, helper, numpy_helper
-from rewrite_graph import output_precision_conflict, weight_precision
+from rewrite_graph import (
+    attention_window,
+    build_maps,
+    find_attention_blocks,
+    output_precision_conflict,
+    rewrite,
+    rotary_fp32_initializers,
+    weight_precision,
+)
 
 
 def graph_with_weights(*weights):
@@ -74,6 +85,66 @@ class WeightPrecision(unittest.TestCase):
         self.assertIn("BFLOAT16", str(refused.exception))
 
 
+def graph_with_fp32_rotary_constant():
+    graph = graph_with_weights(
+        ("encoder.weight", np.ones((2, 2), np.float16)),
+        ("frequencies", np.ones((1, 32, 1), np.float32)),
+        ("start", np.array(0, np.int64)),
+        ("length", np.array(64, np.int64)),
+        ("step", np.array(1, np.int64)),
+        ("axes", np.array([0, 1], np.int64)),
+    )
+    for op, inputs, output, attrs in (
+        ("Range", ["start", "length", "step"], "positions", {}),
+        ("Unsqueeze", ["positions", "axes"], "position_3d", {}),
+        ("Cast", ["position_3d"], "position_float", {"to": TensorProto.FLOAT}),
+        ("MatMul", ["frequencies", "position_float"], "angles", {}),
+        ("Transpose", ["angles"], "angles_t", {"perm": [0, 2, 1]}),
+        ("Concat", ["angles_t", "angles_t"], "angles_cat", {"axis": -1}),
+        ("Cos", ["angles_cat"], "cos", {}),
+        ("Sin", ["angles_cat"], "sin", {}),
+        ("Cast", ["cos"], "cos_half", {"to": TensorProto.FLOAT16}),
+        ("Cast", ["sin"], "sin_half", {"to": TensorProto.FLOAT16}),
+    ):
+        graph.node.append(helper.make_node(op, inputs, [output], name=output, **attrs))
+    return graph
+
+
+class RotaryPrecision(unittest.TestCase):
+    def test_fp32_rotary_island_is_preserved_but_not_counted_as_weight(self):
+        graph = graph_with_fp32_rotary_constant()
+        before = graph.SerializeToString()
+        exempt = rotary_fp32_initializers(graph, build_maps(graph)[0])
+        self.assertEqual(exempt, {"frequencies"})
+        self.assertEqual(
+            weight_precision(graph.initializer, position_constants=exempt),
+            TensorProto.FLOAT16,
+        )
+        self.assertEqual(before, graph.SerializeToString())
+
+    def test_fp32_weight_with_extra_consumer_is_still_refused(self):
+        graph = graph_with_fp32_rotary_constant()
+        graph.node.append(
+            helper.make_node("MatMul", ["frequencies", "x"], ["other"], name="other")
+        )
+        exempt = rotary_fp32_initializers(graph, build_maps(graph)[0])
+        self.assertEqual(exempt, set())
+        with self.assertRaisesRegex(ValueError, "mixes weight precisions"):
+            weight_precision(graph.initializer, position_constants=exempt)
+
+    def test_non_position_or_non_fp16_output_is_not_exempt(self):
+        for variant in ("activation", "fp32_output"):
+            graph = graph_with_fp32_rotary_constant()
+            if variant == "activation":
+                next(n for n in graph.node if n.name == "position_float").input[0] = "x"
+            else:
+                cast = next(n for n in graph.node if n.name == "sin_half")
+                cast.attribute[0].i = TensorProto.FLOAT
+            self.assertEqual(
+                rotary_fp32_initializers(graph, build_maps(graph)[0]), set()
+            )
+
+
 class OutputPrecisionConflict(unittest.TestCase):
     def test_fp32_graph_under_an_fp16_name_is_refused(self):
         message = output_precision_conflict(
@@ -100,6 +171,270 @@ class OutputPrecisionConflict(unittest.TestCase):
         self.assertIsNone(
             output_precision_conflict("fp16/model_fa.onnx", model_is_fp16=False)
         )
+
+
+def exported_attention_graph(layers=22, guard=True, inverted_fill=False):
+    """Small, weight-free reproduction of the published intent FP16 export.
+
+    Preserve its K reshape/transpose chain, scalar Q/K pre-scaling,
+    Softmax/IsNaN/Where guard and inclusive positional mask. Names intentionally
+    resemble neither exporter: classification must follow mask computation.
+    """
+    initializers = [
+        numpy_helper.from_array(np.array(value, dtype=dtype), name)
+        for name, value, dtype in (
+            ("zero", 0, np.float16),
+            ("negative", -65504, np.float16),
+            ("qk_scale", np.sqrt(1 / 8), np.float16),
+            ("start", 0, np.int64),
+            ("length", 130, np.int64),
+            ("step", 1, np.int64),
+            ("radius", 64, np.int64),
+            ("row_axis", [0], np.int64),
+            ("column_axis", [1], np.int64),
+            ("pad_axes", [1, 2], np.int64),
+            ("dense_shape", [1, 1, 130, 130], np.int64),
+            ("k_flat_shape", [1, 130, 64], np.int64),
+            ("k_shape", [1, 1, 64, 130], np.int64),
+        )
+    ]
+    nodes = []
+
+    def add(op, inputs, output, **attrs):
+        nodes.append(
+            helper.make_node(op, inputs, [output], name="node_" + output, **attrs)
+        )
+
+    add("Cast", ["attention_mask"], "padding", to=TensorProto.BOOL)
+    add("Unsqueeze", ["padding", "pad_axes"], "padding_4d")
+    add("Expand", ["padding_4d", "dense_shape"], "global_keep")
+    add("Range", ["start", "length", "step"], "positions")
+    add("Unsqueeze", ["positions", "row_axis"], "keys")
+    add("Unsqueeze", ["positions", "column_axis"], "queries")
+    add("Sub", ["queries", "keys"], "difference")
+    add("Abs", ["difference"], "distance")
+    add("LessOrEqual", ["distance", "radius"], "within_window")
+    add("And", ["global_keep", "within_window"], "local_keep")
+    add("Where", ["global_keep", "zero", "negative"], "arbitrary_global")
+    add("Where", ["local_keep", "zero", "negative"], "arbitrary_local")
+    if inverted_fill:
+        # Transformers 4.57.6 / Torch 2.10 TokenClassification export uses
+        # Where(bool(1-padding), negative, 1-padding), then a separate window
+        # masked_fill. Preserve key-only padding axes [1,2] and predicate polarity.
+        initializers.append(
+            numpy_helper.from_array(np.array(1, dtype=np.float16), "one")
+        )
+        nodes = [
+            n
+            for n in nodes
+            if n.output[0]
+            not in {"padding", "local_keep", "arbitrary_global", "arbitrary_local"}
+        ]
+        next(n for n in nodes if n.output[0] == "padding_4d").input[
+            0
+        ] = "attention_mask"
+        queries = next(n for n in nodes if n.output[0] == "queries")
+        queries.CopyFrom(
+            helper.make_node(
+                "Transpose", ["keys"], ["queries"], name="node_queries", perm=[1, 0]
+            )
+        )
+        add("Cast", ["global_keep"], "float_padding", to=TensorProto.FLOAT16)
+        add("Sub", ["one", "float_padding"], "inverted_padding")
+        add("Cast", ["inverted_padding"], "is_padding", to=TensorProto.BOOL)
+        add(
+            "Where",
+            ["is_padding", "negative", "inverted_padding"],
+            "arbitrary_global",
+        )
+        add("Not", ["within_window"], "outside_window")
+        add(
+            "Where",
+            ["outside_window", "negative", "arbitrary_global"],
+            "arbitrary_local",
+        )
+    inputs = [
+        helper.make_tensor_value_info("attention_mask", TensorProto.INT64, [1, 130])
+    ]
+    outputs = []
+    for layer in range(layers):
+        p = f"layer_{layer}_"
+        for name in ("q", "k", "v"):
+            inputs.append(
+                helper.make_tensor_value_info(
+                    p + name, TensorProto.FLOAT16, [1, 1, 130, 64]
+                )
+            )
+        add("Reshape", [p + "k", "k_flat_shape"], p + "k_flat")
+        add("Transpose", [p + "k_flat"], p + "k_transposed", perm=[0, 2, 1])
+        add("Reshape", [p + "k_transposed", "k_shape"], p + "kt")
+        add("Mul", [p + "q", "qk_scale"], p + "qs")
+        add("Mul", [p + "kt", "qk_scale"], p + "ks")
+        add("MatMul", [p + "qs", p + "ks"], p + "qk")
+        mask = "arbitrary_global" if layer % 3 == 0 else "arbitrary_local"
+        add("Add", [p + "qk", mask], p + "masked")
+        add("Softmax", [p + "masked"], p + "probability", axis=-1)
+        probability = p + "probability"
+        if guard:
+            add("IsNaN", [probability], p + "isnan")
+            add("Where", [p + "isnan", "zero", probability], p + "guarded")
+            probability = p + "guarded"
+        add("MatMul", [probability, p + "v"], p + "out")
+        outputs.append(
+            helper.make_tensor_value_info(
+                p + "out", TensorProto.FLOAT16, [1, 1, 130, 64]
+            )
+        )
+    return helper.make_model(
+        helper.make_graph(nodes, "published_sdpa_shape", inputs, outputs, initializers),
+        opset_imports=[helper.make_opsetid("", 18)],
+    )
+
+
+class PublishedExportShape(unittest.TestCase):
+    def test_nan_guard_and_reshape_k_match_all_22_layers(self):
+        model = exported_attention_graph()
+        blocks = find_attention_blocks(model.graph, build_maps(model.graph)[0])
+        self.assertEqual(len(blocks), 22)
+        self.assertEqual(blocks[0]["k_tensor"], "layer_0_k")
+        self.assertEqual(len(blocks[0]["probability_nodes"]), 2)
+
+    def test_direct_softmax_remains_supported(self):
+        model = exported_attention_graph(guard=False)
+        self.assertEqual(
+            len(find_attention_blocks(model.graph, build_maps(model.graph)[0])), 22
+        )
+
+    def test_semantic_window_does_not_reverse_global_and_local(self):
+        graph = exported_attention_graph().graph
+        out2node, _ = build_maps(graph)
+        self.assertEqual(
+            attention_window(graph, out2node, "arbitrary_global"), (-1, -1)
+        )
+        self.assertEqual(attention_window(graph, out2node, "arbitrary_local"), (64, 64))
+
+    def test_unsupported_mask_is_not_silently_global(self):
+        graph = exported_attention_graph().graph
+        next(n for n in graph.node if n.op_type == "LessOrEqual").op_type = "Greater"
+        with self.assertRaisesRegex(
+            ValueError, "unsupported attention-mask comparison"
+        ):
+            attention_window(graph, build_maps(graph)[0], "arbitrary_local")
+
+    def test_inverted_padding_mask_is_refused(self):
+        graph = exported_attention_graph().graph
+        mask = next(n for n in graph.node if n.output[0] == "arbitrary_global")
+        mask.input[1], mask.input[2] = mask.input[2], mask.input[1]
+        with self.assertRaisesRegex(ValueError, "allowed positions to zero"):
+            attention_window(graph, build_maps(graph)[0], "arbitrary_global")
+
+    def test_token_reexport_masked_fill_matches_global_and_local(self):
+        graph = exported_attention_graph(inverted_fill=True).graph
+        out2node, _ = build_maps(graph)
+        self.assertEqual(
+            attention_window(graph, out2node, "arbitrary_global"), (-1, -1)
+        )
+        self.assertEqual(attention_window(graph, out2node, "arbitrary_local"), (64, 64))
+
+    def test_token_reexport_rejects_wrong_inversion_and_query_padding(self):
+        for variant in ("zero_minus_padding", "query_axes", "not_padding"):
+            with self.subTest(variant=variant):
+                graph = exported_attention_graph(inverted_fill=True).graph
+                if variant == "zero_minus_padding":
+                    next(
+                        n for n in graph.node if n.output[0] == "inverted_padding"
+                    ).input[0] = "zero"
+                elif variant == "query_axes":
+                    axes = next(t for t in graph.initializer if t.name == "pad_axes")
+                    axes.CopyFrom(numpy_helper.from_array(np.array([1, 3]), "pad_axes"))
+                else:
+                    next(n for n in graph.node if n.output[0] == "is_padding").input[
+                        0
+                    ] = "float_padding"
+                with self.assertRaisesRegex(ValueError, "allowed positions to zero"):
+                    attention_window(graph, build_maps(graph)[0], "arbitrary_global")
+
+    def test_token_reexport_all_22_dense_masks_are_removed(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = Path(directory) / "model_sdpa_fp16.onnx"
+            target = Path(directory) / "model_fa_fp16.onnx"
+            onnx.save(exported_attention_graph(guard=False, inverted_fill=True), source)
+            rewrite(source, target)
+            model = onnx.load(target)
+        onnx.checker.check_model(model)
+        self.assertEqual(
+            sum(n.op_type == "CKFlashAttention" for n in model.graph.node), 22
+        )
+        self.assertFalse(
+            {"Softmax", "Where", "Expand", "Not", "Abs", "LessOrEqual"}
+            & {n.op_type for n in model.graph.node}
+        )
+        self.assertFalse(
+            {"inverted_padding", "difference"}
+            & {o for n in model.graph.node for o in n.output}
+        )
+
+    def test_rewrite_removes_dense_masks_and_guards_in_every_layer(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = Path(directory) / "model_sdpa_fp16.onnx"
+            target = Path(directory) / "model_fa_fp16.onnx"
+            onnx.save(exported_attention_graph(), source)
+            rewrite(source, target)
+            model = onnx.load(target)
+        onnx.checker.check_model(model)
+        flash = [n for n in model.graph.node if n.op_type == "CKFlashAttention"]
+        self.assertEqual(len(flash), 22)
+        windows = [
+            tuple(
+                helper.get_attribute_value(a)
+                for a in n.attribute
+                if a.name.startswith("window_size")
+            )
+            for n in flash
+        ]
+        self.assertEqual(windows.count((-1, -1)), 8)
+        self.assertEqual(windows.count((64, 64)), 14)
+        self.assertTrue(
+            all(n.input[3] == "/model/_fa_pad_bias/Unsqueeze_output_0" for n in flash)
+        )
+        self.assertFalse(
+            {"Softmax", "IsNaN", "Where", "Expand", "Abs", "LessOrEqual"}
+            & {n.op_type for n in model.graph.node}
+        )
+
+    def test_partial_match_and_nonzero_nan_replacement_are_refused(self):
+        model = exported_attention_graph()
+        guard = next(n for n in model.graph.node if n.output[0] == "layer_0_guarded")
+        guard.input[1] = "negative"
+        with tempfile.TemporaryDirectory() as directory:
+            source = Path(directory) / "model_sdpa_fp16.onnx"
+            onnx.save(model, source)
+            with self.assertRaisesRegex(ValueError, "matched 21 of 22"):
+                rewrite(source, Path(directory) / "model_fa_fp16.onnx")
+
+    def test_requested_window_must_match_source(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = Path(directory) / "model_sdpa_fp16.onnx"
+            onnx.save(exported_attention_graph(), source)
+            with self.assertRaisesRegex(ValueError, "disagrees"):
+                rewrite(
+                    source, Path(directory) / "model_fa_fp16.onnx", local_attention=256
+                )
+
+    def test_exported_dense_mask_output_prevents_unsafe_memory_claim(self):
+        model = exported_attention_graph()
+        model.graph.output.append(
+            helper.make_tensor_value_info(
+                "arbitrary_global", TensorProto.FLOAT16, [1, 1, 130, 130]
+            )
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            source = Path(directory) / "model_sdpa_fp16.onnx"
+            onnx.save(model, source)
+            with self.assertRaisesRegex(
+                ValueError, "dense attention mask is still live"
+            ):
+                rewrite(source, Path(directory) / "model_fa_fp16.onnx")
 
 
 if __name__ == "__main__":

--- a/onnx-binding/ort-ck-flash-attn/scripts/test_stable_pooling.py
+++ b/onnx-binding/ort-ck-flash-attn/scripts/test_stable_pooling.py
@@ -1,0 +1,321 @@
+"""Executable ONNX reference tests for stable classifier mean pooling.
+
+Run with the rewriter's existing onnx/numpy dependencies:
+    python -m unittest test_stable_pooling
+"""
+
+import copy
+import unittest
+
+import numpy as np
+import onnx
+from onnx import TensorProto, helper, numpy_helper
+from onnx.reference import ReferenceEvaluator
+from stable_pooling import stabilize_mean_pooling
+
+
+def mean_classifier(dtype=TensorProto.FLOAT16, swap_product=False):
+    np_dtype = np.float16 if dtype == TensorProto.FLOAT16 else np.float32
+    initializers = [
+        numpy_helper.from_array(np.array([1], np.int64), "sequence_axis"),
+        numpy_helper.from_array(np.array([2], np.int64), "last_axis"),
+        numpy_helper.from_array(np.ones((1, 1), np_dtype), "head_weight"),
+    ]
+    inputs = [
+        helper.make_tensor_value_info("encoder_input", dtype, [1, "sequence", 1]),
+        helper.make_tensor_value_info(
+            "attention_mask", TensorProto.INT64, [1, "sequence"]
+        ),
+    ]
+    nodes = [
+        helper.make_node("Identity", ["encoder_input"], ["hidden"], name="encoder"),
+        helper.make_node("Unsqueeze", ["attention_mask", "last_axis"], ["mask_3d"]),
+        helper.make_node("Cast", ["mask_3d"], ["floating_mask"], to=dtype),
+        helper.make_node(
+            "Mul",
+            (
+                ["floating_mask", "hidden"]
+                if swap_product
+                else ["hidden", "floating_mask"]
+            ),
+            ["masked"],
+        ),
+        helper.make_node("ReduceSum", ["masked", "sequence_axis"], ["sum"], keepdims=0),
+        helper.make_node(
+            "ReduceSum", ["attention_mask", "sequence_axis"], ["count"], keepdims=1
+        ),
+        helper.make_node("Cast", ["count"], ["floating_count"], to=dtype),
+        helper.make_node("Div", ["sum", "floating_count"], ["mean"]),
+        helper.make_node(
+            "Gemm", ["mean", "head_weight"], ["logits"], name="head", transB=1
+        ),
+    ]
+    infos = [
+        helper.make_tensor_value_info(name, tensor_dtype, shape)
+        for name, tensor_dtype, shape in (
+            ("hidden", dtype, [1, "sequence", 1]),
+            ("floating_mask", dtype, [1, "sequence", 1]),
+            ("masked", dtype, [1, "sequence", 1]),
+            ("sum", dtype, [1, 1]),
+            ("count", TensorProto.INT64, [1, 1]),
+            ("floating_count", dtype, [1, 1]),
+            ("mean", dtype, [1, 1]),
+        )
+    ]
+    graph = helper.make_graph(
+        nodes,
+        "mean_classifier",
+        inputs,
+        [helper.make_tensor_value_info("logits", dtype, [1, 1])],
+        initializer=initializers,
+        value_info=infos,
+    )
+    return helper.make_model(graph, opset_imports=[helper.make_opsetid("", 18)])
+
+
+def output_node(graph, output):
+    return next(node for node in graph.node if output in node.output)
+
+
+def evaluate(model, hidden, mask, outputs=None):
+    with np.errstate(over="ignore", invalid="ignore"):
+        return ReferenceEvaluator(model).run(
+            outputs, {"encoder_input": hidden, "attention_mask": mask}
+        )
+
+
+class StableMeanNumerics(unittest.TestCase):
+    def test_long_fp16_mean_is_finite_without_changing_encoder_or_head(self):
+        original = mean_classifier()
+        fixed = copy.deepcopy(original)
+        self.assertEqual(stabilize_mean_pooling(fixed.graph), 1)
+        onnx.checker.check_model(fixed, full_check=True)
+        self.assertEqual(
+            output_node(original.graph, "hidden"), output_node(fixed.graph, "hidden")
+        )
+        self.assertEqual(
+            output_node(original.graph, "logits"), output_node(fixed.graph, "logits")
+        )
+        self.assertEqual(original.graph.initializer, fixed.graph.initializer)
+        for length, finite_before in (
+            (512, True),
+            (8192, True),
+            (16384, False),
+            (32768, False),
+        ):
+            with self.subTest(length=length):
+                hidden = np.full((1, length, 1), 5, np.float16)
+                mask = np.ones((1, length), np.int64)
+                (old,) = evaluate(original, hidden, mask)
+                (new,) = evaluate(fixed, hidden, mask)
+                self.assertEqual(new.dtype, np.dtype(np.float16))
+                np.testing.assert_array_equal(new, [[5]])
+                self.assertEqual(bool(np.isfinite(old).all()), finite_before)
+
+    def test_padding_uses_integer_count_before_float32_cast(self):
+        model = mean_classifier()
+        self.assertEqual(stabilize_mean_pooling(model.graph), 1)
+        count_name = next(
+            node.output[0]
+            for node in model.graph.node
+            if node.op_type == "Cast" and list(node.input) == ["count"]
+        )
+        for length, valid in ((16384, 1025), (32768, 2051), (32768, 16384)):
+            for side in ("left", "right"):
+                with self.subTest(length=length, valid=valid, side=side):
+                    mask = np.zeros((1, length), np.int64)
+                    mask[:, :valid] = 1
+                    if side == "left":
+                        mask = np.ascontiguousarray(mask[:, ::-1])
+                    # Ignored padding differs sharply from the valid values.
+                    hidden = np.where(mask[..., None], 1, 2000).astype(np.float16)
+                    result, count = evaluate(
+                        model, hidden, mask, ["logits", count_name]
+                    )
+                    np.testing.assert_array_equal(result, [[1]])
+                    self.assertEqual(count.dtype, np.dtype(np.float32))
+                    np.testing.assert_array_equal(count, [[valid]])
+        # Casting the count via FP16 would round 2051 to 2052 and fail this test.
+        self.assertNotEqual(int(np.float16(2051)), 2051)
+
+    def test_nonconstant_masked_mean_matches_float64_reference(self):
+        model = mean_classifier(swap_product=True)
+        self.assertEqual(stabilize_mean_pooling(model.graph), 1)
+        rng = np.random.default_rng(42)
+        hidden = rng.uniform(-12, 16, (1, 32768, 1)).astype(np.float16)
+        padding_probability = 0.2
+        mask = (rng.random((1, 32768)) > padding_probability).astype(np.int64)
+        (result,) = evaluate(model, hidden, mask)
+        expected = (
+            (hidden.astype(np.float64) * mask[..., None]).sum(axis=1)
+            / mask.sum(axis=1, keepdims=True)
+        ).astype(np.float16)
+        np.testing.assert_array_equal(result, expected)
+
+    def test_all_masked_input_is_not_silently_made_valid(self):
+        model = mean_classifier()
+        stabilize_mean_pooling(model.graph)
+        (result,) = evaluate(
+            model, np.ones((1, 8, 1), np.float16), np.zeros((1, 8), np.int64)
+        )
+        self.assertTrue(np.isnan(result).all())
+
+
+class StableMeanGraphContract(unittest.TestCase):
+    def assert_unchanged(self, model):
+        before = model.SerializeToString()
+        self.assertEqual(stabilize_mean_pooling(model.graph), 0)
+        self.assertEqual(model.SerializeToString(), before)
+
+    def test_fp32_graph_is_unchanged(self):
+        self.assert_unchanged(mean_classifier(TensorProto.FLOAT))
+
+    def test_pass_is_idempotent(self):
+        model = mean_classifier()
+        self.assertEqual(stabilize_mean_pooling(model.graph), 1)
+        self.assert_unchanged(model)
+
+    def test_preserves_shared_sum_and_count_cast(self):
+        model = mean_classifier()
+        for name in ("sum", "floating_count"):
+            model.graph.output.append(
+                helper.make_tensor_value_info(name, TensorProto.FLOAT16, [1, 1])
+            )
+        old_sum = copy.deepcopy(output_node(model.graph, "sum"))
+        old_cast = copy.deepcopy(output_node(model.graph, "floating_count"))
+        self.assertEqual(stabilize_mean_pooling(model.graph), 1)
+        self.assertEqual(output_node(model.graph, "sum"), old_sum)
+        self.assertEqual(output_node(model.graph, "floating_count"), old_cast)
+        onnx.checker.check_model(model, full_check=True)
+        logits, total, count = evaluate(
+            model, np.full((1, 32768, 1), 5, np.float16), np.ones((1, 32768), np.int64)
+        )
+        np.testing.assert_array_equal(logits, [[5]])
+        self.assertTrue(np.isinf(total).all())
+        np.testing.assert_array_equal(count, [[32768]])
+
+    def test_other_reductions_are_unchanged(self):
+        model = mean_classifier()
+        unrelated = helper.make_node(
+            "ReduceSum", ["encoder_input", "last_axis"], ["unrelated_sum"], keepdims=0
+        )
+        model.graph.node.insert(0, unrelated)
+        model.graph.output.append(
+            helper.make_tensor_value_info(
+                "unrelated_sum", TensorProto.FLOAT16, [1, "sequence"]
+            )
+        )
+        self.assertEqual(stabilize_mean_pooling(model.graph), 1)
+        self.assertEqual(output_node(model.graph, "unrelated_sum"), unrelated)
+        onnx.checker.check_model(model, full_check=True)
+
+    def test_preserves_intermediate_with_another_consumer(self):
+        model = mean_classifier()
+        alias = helper.make_node("Identity", ["sum"], ["debug_sum"])
+        model.graph.node.append(alias)
+        model.graph.output.append(
+            helper.make_tensor_value_info("debug_sum", TensorProto.FLOAT16, [1, 1])
+        )
+        original_sum = copy.deepcopy(output_node(model.graph, "sum"))
+        self.assertEqual(stabilize_mean_pooling(model.graph), 1)
+        self.assertEqual(output_node(model.graph, "sum"), original_sum)
+        self.assertEqual(output_node(model.graph, "debug_sum"), alias)
+        onnx.checker.check_model(model, full_check=True)
+
+    def test_constant_axes_and_negative_unsqueeze_axis(self):
+        model = mean_classifier()
+        constants = []
+        weights = []
+        for tensor in model.graph.initializer:
+            if tensor.name in {"sequence_axis", "last_axis"}:
+                value = 1 if tensor.name == "sequence_axis" else -1
+                constant = numpy_helper.from_array(np.array([value], np.int64))
+                constants.append(
+                    helper.make_node("Constant", [], [tensor.name], value=constant)
+                )
+            else:
+                weights.append(tensor)
+        del model.graph.initializer[:]
+        model.graph.initializer.extend(weights)
+        nodes = constants + list(model.graph.node)
+        del model.graph.node[:]
+        model.graph.node.extend(nodes)
+        self.assertEqual(stabilize_mean_pooling(model.graph), 1)
+        onnx.checker.check_model(model, full_check=True)
+        (result,) = evaluate(
+            model, np.full((1, 64, 1), 3, np.float16), np.ones((1, 64), np.int64)
+        )
+        np.testing.assert_array_equal(result, [[3]])
+
+    def test_existing_tensor_names_do_not_collide(self):
+        model = mean_classifier()
+        model.graph.initializer.append(
+            numpy_helper.from_array(
+                np.array(1, np.int64), "mean__stable_pool_product_fp32"
+            )
+        )
+        self.assertEqual(stabilize_mean_pooling(model.graph), 1)
+        onnx.checker.check_model(model, full_check=True)
+
+    def test_different_denominator_mask_is_not_a_match(self):
+        model = mean_classifier()
+        model.graph.input.append(
+            helper.make_tensor_value_info(
+                "other_mask", TensorProto.INT64, [1, "sequence"]
+            )
+        )
+        output_node(model.graph, "count").input[0] = "other_mask"
+        self.assert_unchanged(model)
+
+    def test_mask_broadcast_over_sequence_is_not_a_mean(self):
+        model = mean_classifier()
+        mask = next(
+            value for value in model.graph.input if value.name == "attention_mask"
+        )
+        mask.type.tensor_type.shape.dim[1].dim_value = 1
+        self.assert_unchanged(model)
+
+    def test_requires_known_intermediate_dtype(self):
+        model = mean_classifier()
+        kept = [info for info in model.graph.value_info if info.name != "masked"]
+        del model.graph.value_info[:]
+        model.graph.value_info.extend(kept)
+        self.assert_unchanged(model)
+
+    def test_dynamic_reduction_axes_are_not_a_match(self):
+        model = mean_classifier()
+        model.graph.input.append(
+            helper.make_tensor_value_info("runtime_axes", TensorProto.INT64, [1])
+        )
+        output_node(model.graph, "sum").input[1] = "runtime_axes"
+        self.assert_unchanged(model)
+
+    def test_custom_reduction_is_not_a_match(self):
+        model = mean_classifier()
+        output_node(model.graph, "sum").domain = "vendor"
+        self.assert_unchanged(model)
+
+    def test_other_reduction_axis_is_not_a_match(self):
+        model = mean_classifier()
+        output_node(model.graph, "sum").input[1] = "last_axis"
+        self.assert_unchanged(model)
+
+    def test_requires_sequence_classifier_head(self):
+        model = mean_classifier()
+        output_node(model.graph, "logits").op_type = "MatMul"
+        self.assert_unchanged(model)
+
+    def test_cls_pooling_is_unchanged(self):
+        model = mean_classifier()
+        nodes = [node for node in model.graph.node if "mean" not in node.output]
+        nodes.insert(
+            -1,
+            helper.make_node("Gather", ["hidden", "sequence_axis"], ["mean"], axis=1),
+        )
+        del model.graph.node[:]
+        model.graph.node.extend(nodes)
+        self.assert_unchanged(model)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/onnx-binding/ort-ck-flash-attn/tests/test_fa_vs_sdpa.hip
+++ b/onnx-binding/ort-ck-flash-attn/tests/test_fa_vs_sdpa.hip
@@ -16,6 +16,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <numeric>
+#include <limits>
 #include <vector>
 
 #include "ck_flash_attn.h"
@@ -45,7 +46,8 @@ static std::vector<float> reference_sdpa_f32(
     const std::vector<half_t>& k_f16,
     const std::vector<half_t>& v_f16,
     const std::vector<half_t>& bias_f16,
-    int batch, int nhead, int seqlen_q, int seqlen_k, int hdim, float scale)
+    int batch, int nhead, int seqlen_q, int seqlen_k, int hdim, float scale,
+    int window_left, int window_right, bool broadcast_bias)
 {
     // Upcast inputs to FP32
     auto upcast = [](const std::vector<half_t>& src) {
@@ -71,9 +73,9 @@ static std::vector<float> reference_sdpa_f32(
             size_t qo_base = ((size_t)b * nhead + h) * seqlen_q * hdim;
             size_t k_base  = ((size_t)b * nhead + h) * seqlen_k * hdim;
             size_t v_base  = ((size_t)b * nhead + h) * seqlen_k * hdim;
-            size_t bias_base = has_bias
-                ? ((size_t)b * nhead + h) * seqlen_q * seqlen_k
-                : 0;
+            size_t bias_base = has_bias ? (broadcast_bias
+                ? (size_t)b * seqlen_k
+                : ((size_t)b * nhead + h) * seqlen_q * seqlen_k) : 0;
 
             // For each query position
             for (int sq = 0; sq < seqlen_q; sq++) {
@@ -87,12 +89,16 @@ static std::vector<float> reference_sdpa_f32(
                     }
                     scores[sk] = dot * scale;
                     if (has_bias) {
-                        scores[sk] += bias[bias_base + sq * seqlen_k + sk];
+                        scores[sk] += bias[bias_base + (broadcast_bias ? 0 : sq * seqlen_k) + sk];
                     }
+                    if ((window_left >= 0 && sk < sq - window_left) ||
+                        (window_right >= 0 && sk > sq + window_right))
+                        scores[sk] = -std::numeric_limits<float>::infinity();
                 }
 
                 // Softmax (numerically stable)
                 float max_s = *std::max_element(scores.begin(), scores.end());
+                if (!std::isfinite(max_s)) continue; // fully masked row has zero output
                 float sum_exp = 0.0f;
                 for (int sk = 0; sk < seqlen_k; sk++) {
                     scores[sk] = expf(scores[sk] - max_s);
@@ -167,6 +173,11 @@ struct TestConfig {
     bool use_bias;
     float max_abs_tol;
     float min_cosine_tol;
+    int window_left = -1;
+    int window_right = -1;
+    bool broadcast_bias = false;
+    int pad_tokens = 0;
+    bool left_padding = false;
 };
 
 static bool run_test(const TestConfig& cfg) {
@@ -174,7 +185,8 @@ static bool run_test(const TestConfig& cfg) {
     const size_t n_qo = (size_t)cfg.batch * cfg.nhead * cfg.seqlen_q * cfg.hdim;
     const size_t n_kv = (size_t)cfg.batch * cfg.nhead * cfg.seqlen_k * cfg.hdim;
     const size_t n_bias = cfg.use_bias
-        ? (size_t)cfg.batch * cfg.nhead * cfg.seqlen_q * cfg.seqlen_k
+        ? (cfg.broadcast_bias ? (size_t)cfg.batch * cfg.seqlen_k
+           : (size_t)cfg.batch * cfg.nhead * cfg.seqlen_q * cfg.seqlen_k)
         : 0;
 
     // Generate random FP16 inputs in [-0.5, 0.5]
@@ -195,8 +207,19 @@ static bool run_test(const TestConfig& cfg) {
         h_bias.resize(n_bias);
         srand(999);
         for (size_t i = 0; i < n_bias; i++) {
-            // Simulate a padding mask: ~10% of positions masked with -1e4
-            float val = (rand() % 10 == 0) ? -1e4f : 0.0f;
+            float val;
+            if (cfg.broadcast_bias) {
+                // One key-padding row per batch, broadcast across heads and Q.
+                // Vary lengths by batch so a bad batch stride cannot pass.
+                int batch_index = i / cfg.seqlen_k;
+                int key = i % cfg.seqlen_k;
+                int padding = cfg.pad_tokens + batch_index;
+                bool masked = cfg.left_padding ? key < padding
+                    : key >= cfg.seqlen_k - padding;
+                val = masked ? -65504.0f : 0.0f;
+            } else {
+                val = (rand() % 10 == 0) ? -1e4f : 0.0f;
+            }
             h_bias[i] = to_f16(val);
         }
     }
@@ -204,7 +227,8 @@ static bool run_test(const TestConfig& cfg) {
     // ── Reference SDPA (CPU, FP32) ──
     std::vector<float> ref_out = reference_sdpa_f32(
         h_q, h_k, h_v, h_bias,
-        cfg.batch, cfg.nhead, cfg.seqlen_q, cfg.seqlen_k, cfg.hdim, scale);
+        cfg.batch, cfg.nhead, cfg.seqlen_q, cfg.seqlen_k, cfg.hdim, scale,
+        cfg.window_left, cfg.window_right, cfg.broadcast_bias);
 
     // ── CK Flash Attention (GPU, FP16) ──
     void *d_q, *d_k, *d_v, *d_o;
@@ -226,10 +250,12 @@ static bool run_test(const TestConfig& cfg) {
     hipStream_t stream;
     HIP_CHECK(hipStreamCreate(&stream));
 
-    int32_t nhead_bias = cfg.use_bias ? cfg.nhead : 0;
+    int32_t nhead_bias = cfg.use_bias ? (cfg.broadcast_bias ? 1 : cfg.nhead) : 0;
+    int32_t mask_type = (cfg.window_left >= 0 || cfg.window_right >= 0) ? 1 : 0;
     int rc = ck_flash_attn_fwd(
         stream, d_q, d_k, d_v, d_bias, d_o,
-        cfg.batch, cfg.nhead, cfg.seqlen_q, cfg.seqlen_k, cfg.hdim, nhead_bias, scale);
+        cfg.batch, cfg.nhead, cfg.seqlen_q, cfg.seqlen_k, cfg.hdim, nhead_bias, scale,
+        cfg.window_left, cfg.window_right, mask_type, cfg.broadcast_bias ? 1 : 0);
     HIP_CHECK(hipStreamSynchronize(stream));
 
     if (rc != 0) {
@@ -256,11 +282,11 @@ static bool run_test(const TestConfig& cfg) {
              && (m.cosine_sim >= cfg.min_cosine_tol)
              && (rc == 0);
 
-    printf("  %s  B=%d H=%d Sq=%4d Sk=%4d D=%d bias=%d  "
+    printf("  %s  B=%d H=%d Sq=%4d Sk=%4d D=%d bias=%d wl=%d wr=%d broadcast=%d  "
            "max_ae=%.4e mean_ae=%.4e rmse=%.4e cos=%.8f\n",
            pass ? "PASS" : "FAIL",
            cfg.batch, cfg.nhead, cfg.seqlen_q, cfg.seqlen_k,
-           cfg.hdim, cfg.use_bias,
+           cfg.hdim, cfg.use_bias, cfg.window_left, cfg.window_right, cfg.broadcast_bias,
            m.max_abs_err, m.mean_abs_err, m.rmse, m.cosine_sim);
 
     if (!pass) {
@@ -323,6 +349,17 @@ int main() {
         // Cross-attention style (Sq != Sk)
         {1, 12,  64, 128, 64, false, 0.05f, 0.9995f},
         {1, 12, 128,  64, 64, false, 0.05f, 0.9995f},
+
+        // Inclusive ModernBERT window: |q-k| <= 64. Non-tile-aligned sizes
+        // exercise both window endpoints and the kernel's sequence padding.
+        {1,  1,  129, 129, 64, false, 0.05f, 0.9995f, 64, 64},
+        {2, 12,  257, 257, 64, false, 0.05f, 0.9990f, 64, 64},
+
+        // The rewriter's actual [B,1,1,S] padding bias: global/local attention,
+        // multiple heads/batches, and both left and right padding.
+        {2, 12, 129, 129, 64, true, 0.05f, 0.9990f, -1, -1, true, 17},
+        {2, 12, 257, 257, 64, true, 0.05f, 0.9990f, 64, 64, true, 17},
+        {2, 12, 257, 257, 64, true, 0.05f, 0.9990f, 64, 64, true, 17, true},
     };
 
     int n_pass = 0, n_fail = 0;

--- a/onnx-binding/src/model_architectures/classification/mmbert_classifier.rs
+++ b/onnx-binding/src/model_architectures/classification/mmbert_classifier.rs
@@ -18,17 +18,53 @@ use ort::value::Tensor;
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
-use tokenizers::{Tokenizer, TruncationDirection, TruncationParams, TruncationStrategy};
+use tokenizers::{
+    PostProcessor, Tokenizer, TruncationDirection, TruncationParams, TruncationStrategy,
+};
 
-/// Maximum sequence length for classification inference.
-///
-/// ModernBERT-32k has global attention layers (every 3 layers = 7–8 out of 22)
-/// that scale quadratically with sequence length. At ~4000 tokens the global-attention
-/// layers require roughly 6–8 GB of activation memory per batch item, reliably
-/// triggering an OOM kill with no container logs. Classification tasks (intent,
-/// jailbreak, PII) only need the first few hundred tokens to produce a reliable
-/// signal, so we cap at 512 — matching the `max_length` field in tokenizer_config.json.
+/// Conservative default for existing callers. Longer contexts are an explicit
+/// deployment choice: global attention retains quadratic compute, and memory
+/// use depends on the selected ONNX graph and execution provider.
 const MAX_CLASSIFICATION_SEQ_LEN: usize = 512;
+
+fn classifier_context_length(capacity: usize, requested: Option<usize>) -> UnifiedResult<usize> {
+    let limit = requested.unwrap_or(MAX_CLASSIFICATION_SEQ_LEN.min(capacity));
+    if capacity == 0 || limit == 0 || limit > capacity {
+        return Err(errors::config_error(
+            "max_sequence_length",
+            &format!("requested {limit} tokens; model capacity is {capacity}"),
+        ));
+    }
+    Ok(limit)
+}
+
+fn configure_classifier_tokenizer(tokenizer: &mut Tokenizer, limit: usize) -> UnifiedResult<()> {
+    let special_tokens = tokenizer
+        .get_post_processor()
+        .map_or(0, |processor| processor.added_tokens(false));
+    // tokenizers subtracts this count before validating truncation parameters.
+    // Reject undersized budgets before that usize subtraction can underflow.
+    if limit < special_tokens {
+        return Err(errors::config_error(
+            "max_sequence_length",
+            &format!(
+                "requested {limit} tokens; tokenizer requires {special_tokens} special tokens"
+            ),
+        ));
+    }
+    // Batch padding is performed below, using the model's pad token and each
+    // encoding's mask. Artifact-level fixed padding must not expand this budget.
+    tokenizer.with_padding(None);
+    tokenizer
+        .with_truncation(Some(TruncationParams {
+            max_length: limit,
+            strategy: TruncationStrategy::LongestFirst,
+            direction: TruncationDirection::Right,
+            stride: 0,
+        }))
+        .map_err(|e| errors::tokenization_error(&e.to_string()))?;
+    Ok(())
+}
 
 // ============================================================================
 // Classification Types
@@ -143,7 +179,8 @@ impl MmBertClassifierConfig {
             num_attention_heads: config_json["num_attention_heads"].as_u64().unwrap_or(12) as usize,
             max_position_embeddings: config_json["max_position_embeddings"]
                 .as_u64()
-                .unwrap_or(32768) as usize,
+                .unwrap_or(MAX_CLASSIFICATION_SEQ_LEN as u64)
+                as usize,
             num_labels,
             id2label,
             label2id,
@@ -195,6 +232,7 @@ pub struct MmBertSequenceClassifier {
     tokenizer: Arc<Tokenizer>,
     config: MmBertClassifierConfig,
     model_path: String,
+    max_sequence_length: usize,
 }
 
 impl MmBertSequenceClassifier {
@@ -203,10 +241,31 @@ impl MmBertSequenceClassifier {
         model_path: P,
         provider: ClassifierExecutionProvider,
     ) -> UnifiedResult<Self> {
+        Self::load_with_context(model_path, provider, None)
+    }
+
+    /// Load with an explicit input budget, including special tokens. The graph
+    /// must support this length; callers must validate its memory and latency on
+    /// their execution provider before choosing a larger deployment budget.
+    pub fn load_with_max_sequence_length<P: AsRef<Path>>(
+        model_path: P,
+        provider: ClassifierExecutionProvider,
+        max_sequence_length: usize,
+    ) -> UnifiedResult<Self> {
+        Self::load_with_context(model_path, provider, Some(max_sequence_length))
+    }
+
+    fn load_with_context<P: AsRef<Path>>(
+        model_path: P,
+        provider: ClassifierExecutionProvider,
+        requested: Option<usize>,
+    ) -> UnifiedResult<Self> {
         let model_path_str = model_path.as_ref().display().to_string();
 
         // Load configuration
         let config = MmBertClassifierConfig::from_pretrained(&model_path)?;
+        let max_sequence_length =
+            classifier_context_length(config.max_position_embeddings, requested)?;
 
         // Load tokenizer
         let tokenizer_path = model_path.as_ref().join("tokenizer.json");
@@ -219,18 +278,7 @@ impl MmBertSequenceClassifier {
         let mut tokenizer = Tokenizer::from_file(&tokenizer_path)
             .map_err(|e| errors::tokenization_error(&e.to_string()))?;
 
-        // Apply truncation at load time so encode_batch never produces sequences
-        // longer than MAX_CLASSIFICATION_SEQ_LEN. The tokenizer.json loaded above
-        // has no truncation set (tokenizer_config.json max_length=512 is Python-side
-        // metadata that the Rust tokenizers crate does not apply automatically).
-        tokenizer
-            .with_truncation(Some(TruncationParams {
-                max_length: MAX_CLASSIFICATION_SEQ_LEN,
-                strategy: TruncationStrategy::LongestFirst,
-                direction: TruncationDirection::Right,
-                stride: 0,
-            }))
-            .map_err(|e| errors::tokenization_error(&e.to_string()))?;
+        configure_classifier_tokenizer(&mut tokenizer, max_sequence_length)?;
 
         // Find ONNX model candidates and initialize with fallback.
         let onnx_candidates = Self::find_onnx_models(&model_path, provider)?;
@@ -246,6 +294,7 @@ impl MmBertSequenceClassifier {
             tokenizer: Arc::new(tokenizer),
             config,
             model_path: model_path_str,
+            max_sequence_length,
         })
     }
 
@@ -486,10 +535,7 @@ impl MmBertSequenceClassifier {
                                 return Ok(session);
                             }
                             Err(e) => {
-                                println!(
-                                    "WARNING: CUDA EP failed: {}, falling back to CPU",
-                                    e
-                                );
+                                println!("WARNING: CUDA EP failed: {}, falling back to CPU", e);
                             }
                         }
                     }
@@ -590,14 +636,11 @@ impl MmBertSequenceClassifier {
             .encode_batch(texts.to_vec(), true)
             .map_err(|e| errors::tokenization_error(&e.to_string()))?;
 
-        // Find max sequence length; apply both the model's architectural limit and
-        // the classification safety cap. The tokenizer already enforces
-        // MAX_CLASSIFICATION_SEQ_LEN via truncation, but this second guard ensures
-        // correctness even if the tokenizer is replaced or called without truncation.
+        // The tokenizer includes special tokens within the validated budget.
         let max_len = encodings.iter().map(|e| e.len()).max().unwrap_or(0);
         let max_len = max_len
             .min(self.config.max_position_embeddings)
-            .min(MAX_CLASSIFICATION_SEQ_LEN);
+            .min(self.max_sequence_length);
 
         // Prepare input tensors
         let batch_size = texts.len();
@@ -635,6 +678,7 @@ impl MmBertSequenceClassifier {
 
         // Extract logits (inline to avoid borrow issues)
         let logits = extract_logits_from_outputs(&outputs)?;
+        validate_classifier_logits(&logits, batch_size, self.config.num_labels)?;
 
         // Convert to results
         let results = logits_to_classification_results(&logits, &self.config);
@@ -645,6 +689,11 @@ impl MmBertSequenceClassifier {
     /// Get model configuration
     pub fn config(&self) -> &MmBertClassifierConfig {
         &self.config
+    }
+
+    /// Effective input budget, including special tokens.
+    pub fn max_sequence_length(&self) -> usize {
+        self.max_sequence_length
     }
 
     /// Get model info string
@@ -661,6 +710,29 @@ impl MmBertSequenceClassifier {
 // ============================================================================
 // Helper Functions (standalone to avoid borrow issues)
 // ============================================================================
+
+fn validate_classifier_logits(
+    logits: &Array2<f32>,
+    rows: usize,
+    labels: usize,
+) -> UnifiedResult<()> {
+    if logits.dim() != (rows, labels) || rows == 0 || labels == 0 {
+        return Err(errors::inference_error(
+            "validate_logits",
+            &format!(
+                "expected logits shape ({rows}, {labels}), got {:?}; check the exported model task",
+                logits.dim()
+            ),
+        ));
+    }
+    if logits.iter().any(|value| !value.is_finite()) {
+        return Err(errors::inference_error(
+            "validate_logits",
+            "model produced non-finite logits; check graph precision and input context length",
+        ));
+    }
+    Ok(())
+}
 
 /// Extract logits from model output
 fn extract_logits_from_outputs(outputs: &SessionOutputs<'_>) -> UnifiedResult<Array2<f32>> {
@@ -901,6 +973,7 @@ pub struct MmBertTokenClassifier {
     tokenizer: Arc<Tokenizer>,
     config: MmBertClassifierConfig,
     model_path: String,
+    max_sequence_length: usize,
 }
 
 impl MmBertTokenClassifier {
@@ -909,9 +982,28 @@ impl MmBertTokenClassifier {
         model_path: P,
         provider: ClassifierExecutionProvider,
     ) -> UnifiedResult<Self> {
+        Self::load_with_context(model_path, provider, None)
+    }
+
+    /// Load a token classifier with a validated, explicit input budget.
+    pub fn load_with_max_sequence_length<P: AsRef<Path>>(
+        model_path: P,
+        provider: ClassifierExecutionProvider,
+        max_sequence_length: usize,
+    ) -> UnifiedResult<Self> {
+        Self::load_with_context(model_path, provider, Some(max_sequence_length))
+    }
+
+    fn load_with_context<P: AsRef<Path>>(
+        model_path: P,
+        provider: ClassifierExecutionProvider,
+        requested: Option<usize>,
+    ) -> UnifiedResult<Self> {
         let model_path_str = model_path.as_ref().display().to_string();
 
         let config = MmBertClassifierConfig::from_pretrained(&model_path)?;
+        let max_sequence_length =
+            classifier_context_length(config.max_position_embeddings, requested)?;
 
         let tokenizer_path = model_path.as_ref().join("tokenizer.json");
         if !tokenizer_path.exists() {
@@ -923,14 +1015,7 @@ impl MmBertTokenClassifier {
         let mut tokenizer = Tokenizer::from_file(&tokenizer_path)
             .map_err(|e| errors::tokenization_error(&e.to_string()))?;
 
-        tokenizer
-            .with_truncation(Some(TruncationParams {
-                max_length: MAX_CLASSIFICATION_SEQ_LEN,
-                strategy: TruncationStrategy::LongestFirst,
-                direction: TruncationDirection::Right,
-                stride: 0,
-            }))
-            .map_err(|e| errors::tokenization_error(&e.to_string()))?;
+        configure_classifier_tokenizer(&mut tokenizer, max_sequence_length)?;
 
         let onnx_candidates = MmBertSequenceClassifier::find_onnx_models(&model_path, provider)?;
         let (session, onnx_path) = MmBertSequenceClassifier::create_session_with_fallback(
@@ -948,6 +1033,7 @@ impl MmBertTokenClassifier {
             tokenizer: Arc::new(tokenizer),
             config,
             model_path: model_path_str,
+            max_sequence_length,
         })
     }
 
@@ -962,7 +1048,7 @@ impl MmBertTokenClassifier {
         let seq_len = encoding
             .len()
             .min(self.config.max_position_embeddings)
-            .min(MAX_CLASSIFICATION_SEQ_LEN);
+            .min(self.max_sequence_length);
 
         // Prepare inputs
         let mut input_ids = vec![self.config.pad_token_id as i64; seq_len];
@@ -995,6 +1081,9 @@ impl MmBertTokenClassifier {
 
         // Extract token logits [1, seq_len, num_labels]
         let token_logits = extract_token_logits_from_outputs(&outputs)?;
+        // A sequence-classification export can have the same label count but
+        // only one row. It must not silently become an empty/successful PII scan.
+        validate_classifier_logits(&token_logits, seq_len, self.config.num_labels)?;
 
         // Convert to entities using BIO scheme
         let entities = bio_decode_entities(text, &encoding, &token_logits, &self.config)?;
@@ -1009,6 +1098,11 @@ impl MmBertTokenClassifier {
             self.model_path, self.config.num_labels
         )
     }
+
+    /// Effective input budget, including special tokens.
+    pub fn max_sequence_length(&self) -> usize {
+        self.max_sequence_length
+    }
 }
 
 /// Decode BIO tags to entities (standalone function)
@@ -1019,7 +1113,27 @@ fn bio_decode_entities(
     config: &MmBertClassifierConfig,
 ) -> UnifiedResult<Vec<DetectedEntity>> {
     let mut entities = Vec::new();
-    let mut current_entity: Option<(String, usize, usize, f32)> = None;
+    // Keep the confidence sum and token count so every token has equal weight.
+    let mut current_entity: Option<(String, usize, usize, f32, usize)> = None;
+    let finish_entity =
+        |(entity_type, start, end, confidence_sum, count): (String, usize, usize, f32, usize)| {
+            text.get(start..end).and_then(|entity_text| {
+                let trimmed = entity_text.trim();
+                if trimmed.is_empty() {
+                    return None;
+                }
+                // Token offsets may include surrounding whitespace. Keep the
+                // public value and its UTF-8 byte offsets on the same span.
+                let start = start + entity_text.len() - entity_text.trim_start().len();
+                Some(DetectedEntity {
+                    text: trimmed.to_string(),
+                    entity_type,
+                    start,
+                    end: start + trimmed.len(),
+                    confidence: confidence_sum / count as f32,
+                })
+            })
+        };
 
     let offsets = encoding.get_offsets();
 
@@ -1050,65 +1164,39 @@ fn bio_decode_entities(
 
         let label = config.get_label(label_id as i32);
 
-        // Parse BIO tag
-        if let Some(stripped) = label.strip_prefix("B-") {
-            // Save current entity if any
-            if let Some((entity_type, ent_start, ent_end, ent_conf)) = current_entity.take() {
-                if ent_start < text.len() && ent_end <= text.len() {
-                    entities.push(DetectedEntity {
-                        text: text[ent_start..ent_end].to_string(),
-                        entity_type,
-                        start: ent_start,
-                        end: ent_end,
-                        confidence: ent_conf,
-                    });
-                }
-            }
+        let tag = label
+            .strip_prefix("B-")
+            .map(|entity_type| (entity_type, false))
+            .or_else(|| {
+                label
+                    .strip_prefix("I-")
+                    .map(|entity_type| (entity_type, true))
+            });
 
-            // Start new entity
-            let entity_type = stripped.to_string();
-            current_entity = Some((entity_type, start, end, confidence));
-        } else if let Some(stripped) = label.strip_prefix("I-") {
-            // Continue current entity
-            if let Some((ref entity_type, ent_start, _, ref mut ent_conf)) = current_entity {
-                let expected_type = stripped;
-                if entity_type == expected_type {
-                    current_entity = Some((
-                        entity_type.clone(),
-                        ent_start,
-                        end,
-                        (*ent_conf + confidence) / 2.0,
-                    ));
+        if let Some((entity_type, true)) = tag {
+            if let Some((current_type, _, current_end, confidence_sum, count)) =
+                current_entity.as_mut()
+            {
+                if current_type == entity_type {
+                    *current_end = end;
+                    *confidence_sum += confidence;
+                    *count += 1;
+                    continue;
                 }
             }
-        } else {
-            // O tag - save current entity if any
-            if let Some((entity_type, ent_start, ent_end, ent_conf)) = current_entity.take() {
-                if ent_start < text.len() && ent_end <= text.len() {
-                    entities.push(DetectedEntity {
-                        text: text[ent_start..ent_end].to_string(),
-                        entity_type,
-                        start: ent_start,
-                        end: ent_end,
-                        confidence: ent_conf,
-                    });
-                }
-            }
+        }
+
+        entities.extend(current_entity.take().and_then(&finish_entity));
+        // An orphan I-tag or a changed I-tag type starts a new entity. Trained
+        // classifiers can emit these without a preceding B-tag; dropping them
+        // loses valid PII spans, including entire email addresses.
+        if let Some((entity_type, _)) = tag {
+            current_entity = Some((entity_type.to_string(), start, end, confidence, 1));
         }
     }
 
     // Save final entity if any
-    if let Some((entity_type, ent_start, ent_end, ent_conf)) = current_entity {
-        if ent_start < text.len() && ent_end <= text.len() {
-            entities.push(DetectedEntity {
-                text: text[ent_start..ent_end].to_string(),
-                entity_type,
-                start: ent_start,
-                end: ent_end,
-                confidence: ent_conf,
-            });
-        }
-    }
+    entities.extend(current_entity.and_then(finish_entity));
 
     Ok(entities)
 }
@@ -1120,6 +1208,181 @@ fn bio_decode_entities(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn decode_bio_fixture(
+        text: &str,
+        predictions: &[(usize, usize, &str, f32)],
+    ) -> Vec<DetectedEntity> {
+        let labels = [
+            "O",
+            "B-PERSON",
+            "I-PERSON",
+            "B-EMAIL_ADDRESS",
+            "I-EMAIL_ADDRESS",
+        ];
+        let config = MmBertClassifierConfig {
+            num_labels: labels.len(),
+            id2label: labels
+                .iter()
+                .enumerate()
+                .map(|(i, label)| (i as i32, label.to_string()))
+                .collect(),
+            ..Default::default()
+        };
+        let encoding = tokenizers::Encoding::from_tokens(
+            predictions
+                .iter()
+                .enumerate()
+                .map(|(i, &(start, end, _, _))| tokenizers::Token {
+                    id: i as u32,
+                    value: text[start..end].to_string(),
+                    offsets: (start, end),
+                })
+                .collect(),
+            0,
+        );
+        let mut logits = Array2::zeros((predictions.len(), labels.len()));
+        for (i, &(_, _, label, confidence)) in predictions.iter().enumerate() {
+            let label_id = labels
+                .iter()
+                .position(|candidate| *candidate == label)
+                .unwrap();
+            logits
+                .row_mut(i)
+                .fill(((1.0 - confidence) / (labels.len() - 1) as f32).ln());
+            logits[(i, label_id)] = confidence.ln();
+        }
+        bio_decode_entities(text, &encoding, &logits, &config).unwrap()
+    }
+
+    #[test]
+    fn bio_orphan_email_after_unicode_keeps_utf8_byte_offsets() {
+        let text = "中文🙂 alice.smith@example.com";
+        // The maintained PII checkpoint emits this all-I email pattern. Zero
+        // offsets model BOS/EOS/PAD; their predictions must not create entities.
+        let entities = decode_bio_fixture(
+            text,
+            &[
+                (0, 0, "B-PERSON", 0.99),
+                (0, 6, "O", 0.95),
+                (6, 10, "O", 0.95),
+                (10, 16, "I-EMAIL_ADDRESS", 0.40),
+                (16, 17, "I-EMAIL_ADDRESS", 0.85),
+                (17, 22, "I-EMAIL_ADDRESS", 0.99),
+                (22, 23, "I-EMAIL_ADDRESS", 0.52),
+                (23, 30, "I-EMAIL_ADDRESS", 0.86),
+                (30, 31, "I-EMAIL_ADDRESS", 0.74),
+                (31, 34, "I-EMAIL_ADDRESS", 0.92),
+                (0, 0, "B-PERSON", 0.99),
+                (0, 0, "I-PERSON", 0.99),
+            ],
+        );
+        assert_eq!(entities.len(), 1);
+        let entity = &entities[0];
+        assert_eq!(entity.entity_type, "EMAIL_ADDRESS");
+        assert_eq!(entity.text, "alice.smith@example.com");
+        assert_eq!((entity.start, entity.end), (11, text.len()));
+        assert_eq!(&text[entity.start..entity.end], entity.text);
+        assert!((entity.confidence - 5.28 / 7.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn bio_orphan_i_can_start_at_the_first_text_token() {
+        let entities =
+            decode_bio_fixture("李明", &[(0, 3, "I-PERSON", 0.9), (3, 6, "I-PERSON", 0.8)]);
+        assert_eq!(entities.len(), 1);
+        assert_eq!(entities[0].text, "李明");
+        assert_eq!((entities[0].start, entities[0].end), (0, 6));
+    }
+
+    #[test]
+    fn bio_trims_surrounding_unicode_whitespace_and_adjusts_byte_offsets() {
+        let prefix = "前缀🙂";
+        let leading = "\u{2003}\t";
+        let value = "李 明";
+        let trailing = "\n\u{3000}";
+        let text = format!("{prefix}{leading}{value}{trailing}结束");
+        let raw_end = prefix.len() + leading.len() + value.len() + trailing.len();
+        let entities = decode_bio_fixture(
+            &text,
+            &[
+                (0, prefix.len(), "O", 0.9),
+                (prefix.len(), raw_end, "B-PERSON", 0.8),
+                (raw_end, text.len(), "O", 0.9),
+            ],
+        );
+        assert_eq!(entities.len(), 1);
+        let entity = &entities[0];
+        assert_eq!(entity.text, value);
+        assert_eq!(entity.start, prefix.len() + leading.len());
+        assert_eq!(entity.end, entity.start + value.len());
+        assert_eq!(&text[entity.start..entity.end], value);
+        assert!((entity.confidence - 0.8).abs() < 1e-6);
+    }
+
+    #[test]
+    fn bio_drops_whitespace_only_entities_after_trimming() {
+        let text = "\u{2003}\t \n";
+        let entities = decode_bio_fixture(text, &[(0, text.len(), "I-EMAIL_ADDRESS", 0.9)]);
+        assert!(entities.is_empty());
+    }
+
+    #[test]
+    fn bio_i_type_change_closes_the_old_span_before_starting_another() {
+        let entities = decode_bio_fixture(
+            "Alice a@b.co Bob",
+            &[
+                (0, 5, "B-PERSON", 0.9),
+                (6, 7, "I-EMAIL_ADDRESS", 0.8),
+                (7, 12, "I-EMAIL_ADDRESS", 0.7),
+                (13, 16, "I-PERSON", 0.9),
+            ],
+        );
+        assert_eq!(entities.len(), 3);
+        assert_eq!(entities[0].text, "Alice");
+        assert_eq!(entities[0].entity_type, "PERSON");
+        assert_eq!(entities[1].text, "a@b.co");
+        assert_eq!(entities[1].entity_type, "EMAIL_ADDRESS");
+        assert_eq!(entities[2].text, "Bob");
+        assert_eq!(entities[2].entity_type, "PERSON");
+        assert!((entities[1].confidence - 0.75).abs() < 1e-6);
+    }
+
+    #[test]
+    fn bio_b_and_o_tags_keep_same_type_entities_separate() {
+        let entities = decode_bio_fixture(
+            "Alice Bob and Eve",
+            &[
+                (0, 5, "B-PERSON", 0.9),
+                (6, 9, "B-PERSON", 0.9),
+                (10, 13, "O", 0.9),
+                (14, 17, "I-PERSON", 0.9),
+            ],
+        );
+        assert_eq!(
+            entities
+                .iter()
+                .map(|entity| entity.text.as_str())
+                .collect::<Vec<_>>(),
+            ["Alice", "Bob", "Eve"]
+        );
+    }
+
+    #[test]
+    fn bio_confidence_is_the_arithmetic_mean_of_all_entity_tokens() {
+        let entities = decode_bio_fixture(
+            "Alice Mary Jane Smith",
+            &[
+                (0, 5, "B-PERSON", 0.8),
+                (6, 10, "I-PERSON", 0.6),
+                (11, 15, "I-PERSON", 0.9),
+                (16, 21, "I-PERSON", 0.7),
+            ],
+        );
+        assert_eq!(entities.len(), 1);
+        assert_eq!(entities[0].text, "Alice Mary Jane Smith");
+        assert!((entities[0].confidence - 0.75).abs() < 1e-6);
+    }
 
     fn write_onnx_dir(files: &[&str]) -> tempfile::TempDir {
         let dir = tempfile::tempdir().unwrap();
@@ -1317,225 +1580,114 @@ mod tests {
         assert_eq!(cloned.confidence, entity.confidence);
     }
 
-    // =========================================================================
-    // Long-prompt truncation tests
-    //
-    // These tests verify that the tokenizer enforces MAX_CLASSIFICATION_SEQ_LEN
-    // (512) regardless of raw input length, preventing the quadratic global-
-    // attention OOM that was observed at ~4 000 tokens (GitHub issue #1843).
-    //
-    // The tests load tokenizer.json from the mmBERT-32K model on disk and are
-    // therefore skipped automatically when running in CI (where model files are
-    // not present) by checking the `CI` environment variable.
-    // =========================================================================
-
-    /// Return the path to the mmBERT-32K ONNX tokenizer, relative to the
-    /// `onnx-binding` workspace root.
-    fn mmbert_onnx_tokenizer_path() -> std::path::PathBuf {
-        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .parent()
-            .unwrap()
-            .join("models/mmbert32k-intent-classifier-merged/onnx/tokenizer.json")
-    }
-
-    /// Load the long-prompt fixture JSON bundled in `test_data/`.
-    fn load_long_prompt_fixtures() -> serde_json::Value {
-        let fixture_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("test_data/long_prompt_fixtures.json");
-        let raw = std::fs::read_to_string(&fixture_path)
-            .unwrap_or_else(|_| panic!("fixture not found at {:?}", fixture_path));
-        serde_json::from_str(&raw).expect("invalid fixture JSON")
-    }
-
-    /// Helper: tokenize `text` with the given `Tokenizer` and return the
-    /// token count after the tokenizer's internal truncation has been applied.
-    fn token_count_after_encode(tokenizer: &tokenizers::Tokenizer, text: &str) -> usize {
+    fn test_tokenizer() -> Tokenizer {
+        use tokenizers::models::wordlevel::WordLevel;
+        use tokenizers::pre_tokenizers::whitespace::Whitespace;
+        use tokenizers::processors::bert::BertProcessing;
+        let vocabulary = ["[UNK]", "[PAD]", "[CLS]", "[SEP]", "word", "tail"]
+            .iter()
+            .enumerate()
+            .map(|(i, token)| (token.to_string(), i as u32))
+            .collect();
+        let model = WordLevel::builder()
+            .vocab(vocabulary)
+            .unk_token("[UNK]".into())
+            .build()
+            .unwrap();
+        let mut tokenizer = Tokenizer::new(model);
+        tokenizer.with_pre_tokenizer(Some(Whitespace));
+        tokenizer.with_post_processor(Some(BertProcessing::new(
+            ("[SEP]".into(), 3),
+            ("[CLS]".into(), 2),
+        )));
         tokenizer
-            .encode(text, true)
-            .expect("encode failed")
-            .get_ids()
-            .len()
     }
 
-    /// Confirm the constant value that guards against OOM.
     #[test]
-    fn test_max_classification_seq_len_is_512() {
-        assert_eq!(
-            MAX_CLASSIFICATION_SEQ_LEN, 512,
-            "MAX_CLASSIFICATION_SEQ_LEN must be 512 to prevent quadratic-attention OOM"
-        );
-    }
-
-    /// Verify that MmBertSequenceClassifier::load configures the tokenizer so
-    /// that a ~4 000-token prompt is truncated to ≤ 512 tokens.
-    ///
-    /// Skipped in CI (`CI` env var set) because model files are not present.
-    #[test]
-    fn test_onnx_tokenizer_truncates_long_prompt() {
-        if std::env::var("CI").is_ok() {
-            eprintln!(
-                "skipping test_onnx_tokenizer_truncates_long_prompt: CI environment detected"
+    fn context_budget_is_explicit_and_bounded_by_model_capacity() {
+        assert_eq!(classifier_context_length(32768, None).unwrap(), 512);
+        assert_eq!(classifier_context_length(256, None).unwrap(), 256);
+        for limit in [512, 513, 1025, 8192, 32768] {
+            assert_eq!(
+                classifier_context_length(32768, Some(limit)).unwrap(),
+                limit
             );
-            return;
         }
-
-        let tokenizer_path = mmbert_onnx_tokenizer_path();
-        if !tokenizer_path.exists() {
-            eprintln!(
-                "skipping test_onnx_tokenizer_truncates_long_prompt: tokenizer not found at {:?}",
-                tokenizer_path
-            );
-            return;
-        }
-
-        let fixtures = load_long_prompt_fixtures();
-        let prompts = fixtures["prompts"].as_array().expect("prompts array");
-
-        // Load and configure the tokenizer the same way MmBertSequenceClassifier::load does.
-        let mut tokenizer =
-            tokenizers::Tokenizer::from_file(&tokenizer_path).expect("failed to load tokenizer");
-        tokenizer
-            .with_truncation(Some(tokenizers::TruncationParams {
-                max_length: MAX_CLASSIFICATION_SEQ_LEN,
-                strategy: TruncationStrategy::LongestFirst,
-                direction: TruncationDirection::Right,
-                stride: 0,
-            }))
-            .expect("truncation config failed");
-
-        for prompt in prompts {
-            let id = prompt["id"].as_str().unwrap_or("?");
-            let text = prompt["text"].as_str().expect("text field");
-            let approx_untruncated = prompt["approx_tokens_untruncated"].as_u64().unwrap_or(0);
-
-            let count = token_count_after_encode(&tokenizer, text);
-
-            assert!(
-                count <= MAX_CLASSIFICATION_SEQ_LEN,
-                "prompt '{}' produced {} tokens (approx untruncated: {}); expected ≤ {}",
-                id,
-                count,
-                approx_untruncated,
-                MAX_CLASSIFICATION_SEQ_LEN,
-            );
+        for (capacity, limit) in [(32768, 0), (8192, 32768), (0, 512)] {
+            assert!(classifier_context_length(capacity, Some(limit)).is_err());
         }
     }
 
-    /// Verify that a prompt long enough to OOM the model (≥ 4 000 raw tokens)
-    /// does NOT reach the model with more than MAX_CLASSIFICATION_SEQ_LEN tokens.
-    ///
-    /// This is the direct regression test for GitHub issue #1843.
-    ///
-    /// Skipped in CI.
     #[test]
-    fn test_onnx_4k_prompt_truncated_to_safe_length() {
-        if std::env::var("CI").is_ok() {
-            eprintln!("skipping test_onnx_4k_prompt_truncated_to_safe_length: CI environment");
-            return;
-        }
+    fn context_budget_reserves_actual_postprocessor_special_tokens() {
+        let mut tokenizer = test_tokenizer();
+        let error = configure_classifier_tokenizer(&mut tokenizer, 1).unwrap_err();
+        assert!(error.to_string().contains("requires 2 special tokens"));
+        configure_classifier_tokenizer(&mut tokenizer, 2).unwrap();
+        let encoding = tokenizer.encode("word tail", true).unwrap();
+        assert_eq!(encoding.get_ids(), &[2, 3]);
 
-        let tokenizer_path = mmbert_onnx_tokenizer_path();
-        if !tokenizer_path.exists() {
-            eprintln!(
-                "skipping test_onnx_4k_prompt_truncated_to_safe_length: tokenizer not found at {:?}",
-                tokenizer_path
-            );
-            return;
-        }
-
-        let fixtures = load_long_prompt_fixtures();
-        let long_prompt = fixtures["prompts"]
-            .as_array()
-            .and_then(|p| p.iter().find(|x| x["id"] == "long_4k"))
-            .expect("long_4k fixture missing");
-
-        let text = long_prompt["text"].as_str().expect("text");
-        let approx_raw = long_prompt["approx_tokens_untruncated"]
-            .as_u64()
-            .unwrap_or(0);
-
-        // Confirm the fixture is actually long enough to trigger the OOM without the fix.
-        assert!(
-            approx_raw > 2048,
-            "fixture too short ({} est. tokens); update long_prompt_fixtures.json",
-            approx_raw
-        );
-
-        // Configure tokenizer as the classifier does.
-        let mut tokenizer =
-            tokenizers::Tokenizer::from_file(&tokenizer_path).expect("load tokenizer");
-        tokenizer
-            .with_truncation(Some(tokenizers::TruncationParams {
-                max_length: MAX_CLASSIFICATION_SEQ_LEN,
-                strategy: TruncationStrategy::LongestFirst,
-                direction: TruncationDirection::Right,
-                stride: 0,
-            }))
-            .expect("truncation config");
-
-        let count = token_count_after_encode(&tokenizer, text);
-        assert_eq!(
-            count, MAX_CLASSIFICATION_SEQ_LEN,
-            "4k prompt must produce exactly MAX_CLASSIFICATION_SEQ_LEN={} tokens after truncation, got {}",
-            MAX_CLASSIFICATION_SEQ_LEN, count
-        );
+        let mut tokenizer = test_tokenizer();
+        tokenizer.with_post_processor(None::<tokenizers::processors::bert::BertProcessing>);
+        configure_classifier_tokenizer(&mut tokenizer, 1).unwrap();
+        let encoding = tokenizer.encode("word tail", true).unwrap();
+        assert_eq!(encoding.get_ids(), &[4]);
     }
 
-    /// Verify that a short prompt is NOT over-truncated: a normal user message
-    /// must keep all its tokens.
-    ///
-    /// Skipped in CI.
     #[test]
-    fn test_onnx_short_prompt_not_truncated() {
-        if std::env::var("CI").is_ok() {
-            eprintln!("skipping test_onnx_short_prompt_not_truncated: CI environment");
-            return;
+    fn classification_rejects_wrong_task_shapes_and_nonfinite_logits() {
+        let valid = Array2::zeros((513, 35));
+        validate_classifier_logits(&valid, 513, 35).unwrap();
+        assert!(validate_classifier_logits(&Array2::zeros((1, 35)), 513, 35).is_err());
+        assert!(validate_classifier_logits(&valid, 513, 14).is_err());
+        for invalid in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            let mut logits = Array2::zeros((1, 14));
+            logits[(0, 3)] = invalid;
+            assert!(validate_classifier_logits(&logits, 1, 14).is_err());
         }
+    }
 
-        let tokenizer_path = mmbert_onnx_tokenizer_path();
-        if !tokenizer_path.exists() {
-            eprintln!(
-                "skipping test_onnx_short_prompt_not_truncated: tokenizer not found at {:?}",
-                tokenizer_path
+    #[test]
+    fn explicit_context_keeps_tail_and_special_tokens_through_32k() {
+        for limit in [512, 513, 1025, 8192, 32768] {
+            let mut tokenizer = test_tokenizer();
+            configure_classifier_tokenizer(&mut tokenizer, limit).unwrap();
+            let text = format!("{}tail", "word ".repeat(limit - 3));
+            let encoding = tokenizer.encode(text.as_str(), true).unwrap();
+            assert_eq!(encoding.len(), limit);
+            assert_eq!(
+                encoding.get_ids()[limit - 2],
+                5,
+                "tail must survive at {limit}"
             );
-            return;
+            assert_eq!(
+                encoding.get_ids()[limit - 1],
+                3,
+                "SEP must count toward the limit"
+            );
+            let longer = format!("{}word word", text);
+            let encoding = tokenizer.encode(longer.as_str(), true).unwrap();
+            assert_eq!(encoding.len(), limit);
+            assert_eq!(encoding.get_ids()[limit - 1], 3);
         }
+    }
 
-        let fixtures = load_long_prompt_fixtures();
-        let short = fixtures["prompts"]
-            .as_array()
-            .and_then(|p| p.iter().find(|x| x["id"] == "short_baseline"))
-            .expect("short_baseline fixture missing");
-
-        let text = short["text"].as_str().expect("text");
-
-        // Tokenizer without truncation limit to get the "true" token count.
-        let baseline_tokenizer =
-            tokenizers::Tokenizer::from_file(&tokenizer_path).expect("load tokenizer");
-        let baseline_count = token_count_after_encode(&baseline_tokenizer, text);
-
-        // Tokenizer with the production truncation limit.
-        let mut truncating_tokenizer =
-            tokenizers::Tokenizer::from_file(&tokenizer_path).expect("load tokenizer");
-        truncating_tokenizer
-            .with_truncation(Some(tokenizers::TruncationParams {
-                max_length: MAX_CLASSIFICATION_SEQ_LEN,
-                strategy: TruncationStrategy::LongestFirst,
-                direction: TruncationDirection::Right,
-                stride: 0,
-            }))
-            .expect("truncation config");
-        let truncated_count = token_count_after_encode(&truncating_tokenizer, text);
-
-        assert_eq!(
-            baseline_count, truncated_count,
-            "short prompt ({} tokens) should not be truncated by MAX_CLASSIFICATION_SEQ_LEN={}",
-            baseline_count, MAX_CLASSIFICATION_SEQ_LEN
-        );
-        assert!(
-            truncated_count < MAX_CLASSIFICATION_SEQ_LEN,
-            "short prompt unexpectedly long: {} tokens",
-            truncated_count
-        );
+    #[test]
+    fn artifact_fixed_padding_cannot_expand_the_input_budget() {
+        let mut tokenizer = test_tokenizer();
+        tokenizer.with_padding(Some(tokenizers::PaddingParams {
+            strategy: tokenizers::PaddingStrategy::Fixed(4096),
+            pad_id: 1,
+            ..Default::default()
+        }));
+        configure_classifier_tokenizer(&mut tokenizer, 1025).unwrap();
+        let encodings = tokenizer
+            .encode_batch(vec!["word", "word tail"], true)
+            .unwrap();
+        assert_eq!(encodings[0].len(), 3);
+        assert_eq!(encodings[1].len(), 4);
+        assert!(encodings
+            .iter()
+            .all(|e| e.get_attention_mask().iter().all(|&v| v == 1)));
     }
 }

--- a/tools/make/rust.mk
+++ b/tools/make/rust.mk
@@ -23,6 +23,13 @@ RUST_CI_LIB_TESTS ?= \
 	model_architectures::embedding::multimodal_embedding::tests::test_siglip_vision_encoder_requires_pooling_head \
 	model_architectures::traditional::candle_models::modernbert::tests::test_chunked_attention_matches_dense \
 	model_architectures::traditional::candle_models::modernbert::tests::test_chunked_attention_matches_dense_with_padding \
+	model_architectures::traditional::candle_models::modernbert::tests::test_chunked_attention_crosses_default_context_and_query_blocks \
+	model_architectures::traditional::modernbert_test::test_candle_context_default_and_explicit_limits \
+	model_architectures::traditional::modernbert_test::test_candle_context_budget_reserves_actual_postprocessor_special_tokens \
+	model_architectures::traditional::modernbert_test::test_candle_context_tokenization_preserves_tail_and_model_padding \
+	model_architectures::traditional::modernbert_test::test_candle_context_config_preserves_separate_rope_theta \
+	model_architectures::traditional::modernbert_test::test_candle_context_loaders_reject_invalid_limits_before_weights \
+	model_architectures::traditional::modernbert_test::test_candle_context_classifier_loaders_execute_beyond_default \
 	model_architectures::attention::chunked_sdpa_test::test_chunked_sdpa_single_query_over_many_keys \
 	model_architectures::attention::chunked_sdpa_test::test_chunked_sdpa_matches_dense_with_decode_offset \
 	model_architectures::attention::chunked_sdpa_test::test_chunked_sdpa_offset_prefill_equals_split_prefill \
@@ -121,7 +128,7 @@ ck-rewrite-deps: harness-venv-install ## Install the CK graph rewriter test depe
 
 ck-rewrite-test: ck-rewrite-deps ## Run the CK flash-attention graph rewriter unit tests
 	@$(LOG_TARGET)
-	@cd $(CK_REWRITE_SCRIPTS_DIR) && "$(AGENT_PYTHON)" -m unittest test_rewrite_graph
+	@cd $(CK_REWRITE_SCRIPTS_DIR) && "$(AGENT_PYTHON)" -m unittest test_rewrite_graph test_stable_pooling
 
 # Run every MULTIMODAL_MODEL_PATH-gated test against a local model copy:
 # the candle-binding Go tests (including the network-dependent image-encode


### PR DESCRIPTION
Related #2760

## Purpose

mmBERT classifier loaders currently impose a fixed 512-token budget, and raising it exposes independent correctness problems in the exported attention graph and FP16 mean pooling. This change adds explicit, model-validated Rust token budgets while preserving the existing default. It also makes Candle attention honor padding and local/global RoPE settings, rejects malformed ONNX outputs, and aligns BIO decoding and UTF-8 entity offsets across the two bindings.

The ROCm graph conversion now identifies attention-mask semantics instead of guessing layer order, preserves the 64-token local window, and refuses unrecognized exports. Sequence-classification mean pooling accumulates in FP32 to avoid overflow at long lengths. Reproducible benchmark examples validate the actual input token count before recording results. These APIs prepare the native layer for the separately tracked Router Core integration; this PR does not change the public Go request budget.

## Test Plan

- Run `make check CHANGED_FILES="<the 14 files in this PR>"` and the affected Rust unit-test allowlist.
- Run the CK graph-rewrite and stable-pooling Python tests, then the attention comparison executable against the existing ROCm custom-op library.
- Compare Candle CPU and ONNX ROCm results against pinned native Hugging Face sequence/token classifiers; exercise 512-token boundaries, Unicode offsets, padding, invalid budgets and 8K/16K/32K inputs.
- Build the modified ROCm image and use the standard `vllm-sr serve --platform amd --image-pull-policy never --minimal` flow for health, model discovery and classification diagnostics.

## Test Result

- Changed-file checks passed, including formatting, harness checks and the minimal Go binding suite. Unrelated crate-wide Clippy findings are not claimed fixed.
- ONNX classifier tests: 25 passed. Candle context-budget tests: 6 passed. CK Python tests: 43 passed. Real ROCm attention comparisons: 24 passed.
- Candle CPU matched native FP32 top-1 predictions and entity text/type/offsets for the five tested lengths through 1,025 tokens. CUDA/Metal execution was not tested.
- Corrected ONNX ROCm sequence/token graphs completed native 32K inference with finite outputs on MI300X. Warm graph execution was approximately 160/169 ms at batch one; these timings exclude tokenization and service overhead.
- The deployed diagnostic suite returned 9/9 successful HTTP responses and passed 6/9 strict entity cases. The three remaining email-quality failures reproduce in native FP32 with the same chunked inputs and are tracked as checkpoint-quality work. A successful long-context run is not evidence of long-context task accuracy. No routed LLM-generation E2E claim is made.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category.
- [x] PR links accepted work with one recognized owner.
- [x] Commits are signed off.
- [x] Purpose, checks and remaining limitations reflect this change.

</details>
