### PR TITLE
[Bug] Keep the live verification label readable with an icon-only check button

### DIFF
--- a/dashboard/frontend/src/pages/ConfigPageModelLiveVerification.test.tsx
+++ b/dashboard/frontend/src/pages/ConfigPageModelLiveVerification.test.tsx
@@ -17,6 +17,8 @@ describe('ConfigPageModelLiveVerification', () => {
 
     expect(markup).toContain('Checking')
     expect(markup).toContain('Checking… logical-model with a real inference query')
+    expect(markup).toContain('title="Checking…"')
+    expect(markup).not.toContain('Checking…</button>')
     expect(markup).toContain('disabled=""')
     expect(markup).not.toContain('Live')
     expect(markup).not.toContain('liveVerificationDotSuccess')
@@ -49,6 +51,8 @@ describe('ConfigPageModelLiveVerification', () => {
     expect(markup).toContain('liveVerificationDotSuccess')
     expect(markup).toContain('liveVerificationLabelSuccess')
     expect(markup).toContain('Check again logical-model with a real inference query')
+    expect(markup).toContain('title="Check again"')
+    expect(markup).not.toContain('Check again</button>')
     expect(markup).not.toContain('OK from provider')
     expect(markup).not.toContain('openai · 18 ms')
     expect(markup).not.toContain('catalog verified')
@@ -83,6 +87,9 @@ describe('ConfigPageModelLiveVerification', () => {
     )
 
     expect(markup).toContain('Not checked')
+    expect(markup).toContain('Check logical-model with a real inference query')
+    expect(markup).toContain('title="Check"')
+    expect(markup).not.toContain('Check</button>')
     expect(markup).not.toContain('liveVerificationDotSuccess')
     expect(markup).not.toContain('liveVerificationLabelSuccess')
   })

--- a/dashboard/frontend/src/pages/ConfigPageModelLiveVerification.tsx
+++ b/dashboard/frontend/src/pages/ConfigPageModelLiveVerification.tsx
@@ -73,10 +73,10 @@ export default function ConfigPageModelLiveVerification({
         className={styles.liveVerificationButton}
         disabled={!hasBackend || !allowed || pending}
         onClick={onVerify}
+        title={buttonLabel}
         aria-label={`${buttonLabel} ${model} with a real inference query`}
       >
         <ProductIcon name="refresh" width={13} height={13} />
-        {buttonLabel}
       </button>
     </div>
   )

--- a/dashboard/frontend/src/pages/ConfigPageModelsSection.module.css
+++ b/dashboard/frontend/src/pages/ConfigPageModelsSection.module.css
@@ -88,14 +88,18 @@
 }
 
 .liveVerification {
-  display: flex;
+  display: grid;
   min-width: 145px;
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
-  gap: 0.5rem;
+  column-gap: 0.5rem;
+  row-gap: 0.15rem;
 }
 
 .liveVerificationHeading {
   display: flex;
+  grid-row: 1;
+  grid-column: 1;
   align-items: center;
   min-width: 0;
   gap: 0.42rem;
@@ -172,22 +176,25 @@
 }
 
 .liveVerificationError {
+  grid-column: 1 / -1;
+  min-width: 0;
+  max-width: 100%;
   color: #fecaca;
 }
 
 .liveVerificationButton {
   display: inline-flex;
+  grid-row: 1;
+  grid-column: 2;
+  width: 28px;
+  height: 28px;
   align-items: center;
-  gap: 0.3rem;
-  width: fit-content;
-  min-height: 28px;
-  padding: 0.28rem 0.58rem;
+  justify-content: center;
+  padding: 0;
   border: 1px solid rgba(255, 255, 255, 0.14);
   border-radius: 7px;
   background: rgba(255, 255, 255, 0.045);
   color: rgba(255, 255, 255, 0.78);
-  font-size: 0.68rem;
-  font-weight: 680;
 }
 
 .liveVerificationButton:hover:not(:disabled) {


### PR DESCRIPTION
Related #3741

Follow-up to #3749, requested in review there: make the live verification cell on Build > Models clean and drop the text inside the check button.

## Purpose

The Live column is a fixed 164 px cell holding the status dot, the status label, and a text button reading "Check" or "Check again". The button wrapped to two lines and the label was ellipsized, so a verified row showed "Li…" pressed against the button and read as an overlap. In the failed state the error message pushed the button out of the cell entirely.

This change:

- makes the check button icon-only, keeping the existing descriptive `aria-label` and adding a `title` tooltip with the previous button text, so screen readers and hover still get "Check", "Check again", or "Checking…"
- lays the cell out as a two-column grid: dot and label on the left, button on the right, and the failed-state error message on its own line under the label with an ellipsis

"Not checked", "Live", and "Unavailable" now render in full and the button stays visible in every state. The Live column width in `ConfigPageModelInventoryPanel.tsx` is unchanged.

Files: `dashboard/frontend/src/pages/ConfigPageModelsSection.module.css`, `dashboard/frontend/src/pages/ConfigPageModelLiveVerification.tsx`, `dashboard/frontend/src/pages/ConfigPageModelLiveVerification.test.tsx`.

Tests: the idle, pending, and verified unit tests now assert the button carries the action in `title` and `aria-label` and renders no visible text.

![before and after](https://raw.githubusercontent.com/Vaivaswat2244/semantic-router/assets/3741-live-verification-screenshots/live-verification-followup-before-after.png)

## Test Plan

From `dashboard/frontend`:

```
npx vitest run src/pages/ConfigPageModelLiveVerification.test.tsx
npx eslint src/pages/ConfigPageModelLiveVerification.tsx src/pages/ConfigPageModelLiveVerification.test.tsx
npx prettier --check src/pages/ConfigPageModelLiveVerification.tsx src/pages/ConfigPageModelLiveVerification.test.tsx src/pages/ConfigPageModelsSection.module.css
npm run type-check
npx playwright test e2e/model-live-verification.spec.ts
```

Label widths were also measured in the browser at 1280 px and 1920 px viewports: no label is truncated in the idle, verified, or failed state, and the button stays inside the cell.

## Test Result

- vitest: 5 passed (1 file)
- eslint, prettier, tsc: clean
- Playwright `e2e/model-live-verification.spec.ts`: 1 passed, spec unchanged (it locates the button by `aria-label`, which is kept)

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category, such as `[Feature]`, `[Bug]`, `[Docs]`, `[Test]`, `[Research]`, `[Community]`, or `[CI/Build]`
- [x] The title does not stack prefixes such as `[Router][Docs]`; affected modules belong in labels and the PR body
- [x] The PR links an `accepted` issue with exactly one owner: one `wg/*` label for project work or `owner/maintainers` for repository governance
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>
