### PR TITLE
[Feature] Admit Ai2 / OLMo models to the built-in Model Card catalog

### DIFF
--- a/config/catalog/README.md
+++ b/config/catalog/README.md
@@ -115,11 +115,11 @@ without duplicating its intrinsic identity. Virtual recipes are materialized
 from packaged assets and keep their own evaluation directory.
 
 The built-in physical inventory is curated at the creator-company level. The
-current baseline contains 84 physical cards from 22 mainstream creators and
+current baseline contains 99 physical cards from 23 mainstream creators and
 five separately stored virtual cards. For each creator, prefer roughly the
 latest three generations or representative product lines over accumulating a
 shallow long tail of lesser-known creators. This policy is about Model Cards,
-not serving endpoints: the 60 `ProviderDefinition` resources remain broad so
+not serving endpoints: the 61 `ProviderDefinition` resources remain broad so
 Add Model and handwritten custom models can use a known runtime contract even
 when that provider has no curated built-in model mapping. `ModelCard.publisher`
 is the creator; a `ProviderDefinition` is the runtime API contract for the

--- a/config/catalog/manifest.yaml
+++ b/config/catalog/manifest.yaml
@@ -33,6 +33,11 @@ inventory:
           - ai21/jamba2-mini
           - ai21/jamba-reasoning-3b
           - ai21/jamba-large-1.7
+      - publisher: Ai2 / OLMo
+        representative_models:
+          - ai2/olmo-3-32b-base
+          - ai2/olmo-3-1-32b-think
+          - ai2/olmo-3-1-32b-instruct
       - publisher: Alibaba / Qwen
         representative_models:
           - qwen/qwen3.8-max

--- a/config/catalog/resources/benchmarks.yaml
+++ b/config/catalog/resources/benchmarks.yaml
@@ -789,6 +789,9 @@
   source: https://huggingface.co/datasets/openlifescienceai/medmcqa
   default_profile: medmarks-v1-three-order-average
   profiles:
+    - id: published-standard
+      display_name: Published standard
+      description: Source-published MedMCQA multiple-choice accuracy using the evaluated model's documented setup.
     - id: medmarks-v1-three-order-average
       display_name: Medmarks v1 three-order average
       description: Validation accuracy averaged across the original answer order and the two published Medmarks v1 shuffle seeds.
@@ -806,6 +809,9 @@
   source: https://huggingface.co/datasets/GBaker/MedQA-USMLE-4-options-hf
   default_profile: medmarks-v1-three-order-average
   profiles:
+    - id: published-standard
+      display_name: Published standard
+      description: Source-published MedQA USMLE four-option accuracy using the evaluated model's documented setup.
     - id: medmarks-v1-three-order-average
       display_name: Medmarks v1 three-order average
       description: Test accuracy averaged across the original answer order and the two published Medmarks v1 shuffle seeds.
@@ -876,11 +882,28 @@
   source: https://github.com/suzgunmirac/BIG-Bench-Hard
   default_profile: rmcb-eacl-2026-valid-output-test
   profiles:
+    - id: published-standard
+      display_name: Published standard
+      description: Source-published BIG-Bench Hard accuracy using the model card's documented standard setup.
     - id: rmcb-eacl-2026-valid-output-test
       display_name: RMCB EACL 2026 valid-output test
       description: Accuracy over valid generated outputs in the EACL 2026 RMCB test protocol; filtering counts and dataset revision remain on the evaluation record.
   metrics:
     - id: accuracy
+      unit: proportion
+      direction: higher_is_better
+      range: [0, 1]
+- id: bigcode-project/bigcodebench@1.0.0
+  display_name: BigCodeBench
+  domain: code_generation
+  source: https://github.com/bigcode-project/bigcodebench
+  default_profile: published-standard
+  profiles:
+    - id: published-standard
+      display_name: Published standard
+      description: Source-published BigCodeBench pass@1 with the evaluated model variant retained on the record.
+  metrics:
+    - id: pass_at_1
       unit: proportion
       direction: higher_is_better
       range: [0, 1]

--- a/config/catalog/resources/evaluations/single/ai2.yaml
+++ b/config/catalog/resources/evaluations/single/ai2.yaml
@@ -1,0 +1,444 @@
+- id: ai2/olmo-3-32b-base-model-card-mmlu-pro@1.0.0
+  model: ai2/olmo-3-32b-base
+  benchmark: tiger-ai-lab/mmlu-pro@1.0.0
+  benchmark_profile: published-standard
+  reasoning_effort: unspecified
+  subject:
+    variant: OLMo 3 32B Base
+    source_kind: official_model_card
+    model_revision: c2b61dae89a1ad10e4ad5653d0e46b590902607b
+    dataset_variant: MMLU-Pro MC
+  metrics:
+    accuracy: 0.496
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/allenai/Olmo-3-1125-32B/blob/c2b61dae89a1ad10e4ad5653d0e46b590902607b/README.md
+    redistributable: true
+- id: ai2/olmo-3-32b-base-model-card-bbh@1.0.0
+  model: ai2/olmo-3-32b-base
+  benchmark: maveriq/bigbenchhard@1.0.0
+  benchmark_profile: published-standard
+  reasoning_effort: unspecified
+  subject:
+    variant: OLMo 3 32B Base
+    source_kind: official_model_card
+    model_revision: c2b61dae89a1ad10e4ad5653d0e46b590902607b
+  metrics:
+    accuracy: 0.776
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/allenai/Olmo-3-1125-32B/blob/c2b61dae89a1ad10e4ad5653d0e46b590902607b/README.md
+    redistributable: true
+- id: ai2/olmo-3-32b-base-model-card-bigcodebench@1.0.0
+  model: ai2/olmo-3-32b-base
+  benchmark: bigcode-project/bigcodebench@1.0.0
+  benchmark_profile: published-standard
+  reasoning_effort: unspecified
+  subject:
+    variant: OLMo 3 32B Base
+    source_kind: official_model_card
+    model_revision: c2b61dae89a1ad10e4ad5653d0e46b590902607b
+  metrics:
+    pass_at_1: 0.439
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/allenai/Olmo-3-1125-32B/blob/c2b61dae89a1ad10e4ad5653d0e46b590902607b/README.md
+    redistributable: true
+- id: ai2/olmo-3-32b-base-model-card-medmcqa@1.0.0
+  model: ai2/olmo-3-32b-base
+  benchmark: openlifescienceai/medmcqa@1.0.0
+  benchmark_profile: published-standard
+  reasoning_effort: unspecified
+  subject:
+    variant: OLMo 3 32B Base
+    source_kind: official_model_card
+    model_revision: c2b61dae89a1ad10e4ad5653d0e46b590902607b
+    dataset_variant: MedMCQA MC
+  metrics:
+    accuracy: 0.576
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/allenai/Olmo-3-1125-32B/blob/c2b61dae89a1ad10e4ad5653d0e46b590902607b/README.md
+    redistributable: true
+- id: ai2/olmo-3-32b-base-model-card-medqa@1.0.0
+  model: ai2/olmo-3-32b-base
+  benchmark: gbaker/medqa-usmle@1.0.0
+  benchmark_profile: published-standard
+  reasoning_effort: unspecified
+  subject:
+    variant: OLMo 3 32B Base
+    source_kind: official_model_card
+    model_revision: c2b61dae89a1ad10e4ad5653d0e46b590902607b
+    dataset_variant: MedQA MC
+  metrics:
+    accuracy: 0.538
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/allenai/Olmo-3-1125-32B/blob/c2b61dae89a1ad10e4ad5653d0e46b590902607b/README.md
+    redistributable: true
+- id: ai2/olmo-3-1-32b-think-model-card-math@1.0.0
+  model: ai2/olmo-3-1-32b-think
+  benchmark: hendrycks/math@1.0.0
+  benchmark_profile: published-standard
+  reasoning_effort: enabled
+  subject:
+    variant: OLMo 3.1 32B Think
+    source_kind: official_model_card
+    model_revision: 832c3f543499af8fe68b88359501de9cb7840544
+    sampling_temperature: 0.6
+    sampling_top_p: 0.95
+    maximum_output_tokens: 32768
+  metrics:
+    accuracy: 0.962
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/allenai/Olmo-3.1-32B-Think/blob/832c3f543499af8fe68b88359501de9cb7840544/README.md
+    redistributable: true
+- id: ai2/olmo-3-1-32b-think-model-card-aime-2024@1.0.0
+  model: ai2/olmo-3-1-32b-think
+  benchmark: matharena/aime@2024.0.0
+  benchmark_profile: pass-at-1
+  reasoning_effort: enabled
+  subject:
+    variant: OLMo 3.1 32B Think
+    source_kind: official_model_card
+    model_revision: 832c3f543499af8fe68b88359501de9cb7840544
+    sampling_temperature: 0.6
+    sampling_top_p: 0.95
+    maximum_output_tokens: 32768
+  metrics:
+    pass_at_1: 0.806
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/allenai/Olmo-3.1-32B-Think/blob/832c3f543499af8fe68b88359501de9cb7840544/README.md
+    redistributable: true
+- id: ai2/olmo-3-1-32b-think-model-card-aime-2025@1.0.0
+  model: ai2/olmo-3-1-32b-think
+  benchmark: matharena/aime@2025.0.0
+  benchmark_profile: pass-at-1
+  reasoning_effort: enabled
+  subject:
+    variant: OLMo 3.1 32B Think
+    source_kind: official_model_card
+    model_revision: 832c3f543499af8fe68b88359501de9cb7840544
+    sampling_temperature: 0.6
+    sampling_top_p: 0.95
+    maximum_output_tokens: 32768
+  metrics:
+    pass_at_1: 0.781
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/allenai/Olmo-3.1-32B-Think/blob/832c3f543499af8fe68b88359501de9cb7840544/README.md
+    redistributable: true
+- id: ai2/olmo-3-1-32b-think-model-card-ifeval@1.0.0
+  model: ai2/olmo-3-1-32b-think
+  benchmark: google/ifeval@1.0.0
+  benchmark_profile: published-standard
+  reasoning_effort: enabled
+  subject:
+    variant: OLMo 3.1 32B Think
+    source_kind: official_model_card
+    model_revision: 832c3f543499af8fe68b88359501de9cb7840544
+    sampling_temperature: 0.6
+    sampling_top_p: 0.95
+    maximum_output_tokens: 32768
+  metrics:
+    accuracy: 0.938
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/allenai/Olmo-3.1-32B-Think/blob/832c3f543499af8fe68b88359501de9cb7840544/README.md
+    redistributable: true
+- id: ai2/olmo-3-1-32b-think-model-card-gpqa@1.0.0
+  model: ai2/olmo-3-1-32b-think
+  benchmark: idavidrein/gpqa-diamond@1.0.0
+  benchmark_profile: published-standard
+  reasoning_effort: enabled
+  subject:
+    variant: OLMo 3.1 32B Think
+    source_kind: official_model_card
+    model_revision: 832c3f543499af8fe68b88359501de9cb7840544
+    sampling_temperature: 0.6
+    sampling_top_p: 0.95
+    maximum_output_tokens: 32768
+  metrics:
+    accuracy: 0.575
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/allenai/Olmo-3.1-32B-Think/blob/832c3f543499af8fe68b88359501de9cb7840544/README.md
+    redistributable: true
+- id: ai2/olmo-3-1-32b-instruct-model-card-math@1.0.0
+  model: ai2/olmo-3-1-32b-instruct
+  benchmark: hendrycks/math@1.0.0
+  benchmark_profile: published-standard
+  reasoning_effort: unspecified
+  subject:
+    variant: OLMo 3.1 32B Instruct
+    source_kind: official_model_card
+    model_revision: ac0587e4a7744a551c059d8cd17ba220bc940dae
+  metrics:
+    accuracy: 0.934
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/allenai/Olmo-3.1-32B-Instruct/blob/ac0587e4a7744a551c059d8cd17ba220bc940dae/README.md
+    redistributable: true
+- id: ai2/olmo-3-1-32b-instruct-model-card-aime-2024@1.0.0
+  model: ai2/olmo-3-1-32b-instruct
+  benchmark: matharena/aime@2024.0.0
+  benchmark_profile: pass-at-1
+  reasoning_effort: unspecified
+  subject:
+    variant: OLMo 3.1 32B Instruct
+    source_kind: official_model_card
+    model_revision: ac0587e4a7744a551c059d8cd17ba220bc940dae
+  metrics:
+    pass_at_1: 0.678
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/allenai/Olmo-3.1-32B-Instruct/blob/ac0587e4a7744a551c059d8cd17ba220bc940dae/README.md
+    redistributable: true
+- id: ai2/olmo-3-1-32b-instruct-model-card-aime-2025@1.0.0
+  model: ai2/olmo-3-1-32b-instruct
+  benchmark: matharena/aime@2025.0.0
+  benchmark_profile: pass-at-1
+  reasoning_effort: unspecified
+  subject:
+    variant: OLMo 3.1 32B Instruct
+    source_kind: official_model_card
+    model_revision: ac0587e4a7744a551c059d8cd17ba220bc940dae
+  metrics:
+    pass_at_1: 0.579
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/allenai/Olmo-3.1-32B-Instruct/blob/ac0587e4a7744a551c059d8cd17ba220bc940dae/README.md
+    redistributable: true
+- id: ai2/olmo-3-1-32b-instruct-model-card-ifeval@1.0.0
+  model: ai2/olmo-3-1-32b-instruct
+  benchmark: google/ifeval@1.0.0
+  benchmark_profile: published-standard
+  reasoning_effort: unspecified
+  subject:
+    variant: OLMo 3.1 32B Instruct
+    source_kind: official_model_card
+    model_revision: ac0587e4a7744a551c059d8cd17ba220bc940dae
+  metrics:
+    accuracy: 0.888
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/allenai/Olmo-3.1-32B-Instruct/blob/ac0587e4a7744a551c059d8cd17ba220bc940dae/README.md
+    redistributable: true
+- id: ai2/olmo-3-1-32b-instruct-model-card-gpqa@1.0.0
+  model: ai2/olmo-3-1-32b-instruct
+  benchmark: idavidrein/gpqa-diamond@1.0.0
+  benchmark_profile: published-standard
+  reasoning_effort: unspecified
+  subject:
+    variant: OLMo 3.1 32B Instruct
+    source_kind: official_model_card
+    model_revision: ac0587e4a7744a551c059d8cd17ba220bc940dae
+  metrics:
+    accuracy: 0.486
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/allenai/Olmo-3.1-32B-Instruct/blob/ac0587e4a7744a551c059d8cd17ba220bc940dae/README.md
+    redistributable: true
+- id: independent/olmo-3-1-32b-think-mmlu-pro@1.0.0
+  model: ai2/olmo-3-1-32b-think
+  benchmark: tiger-ai-lab/mmlu-pro@1.0.0
+  benchmark_profile: independent-standard
+  reasoning_effort: enabled
+  subject:
+    source_model: OLMo 3.1 32B Think
+    source_model_slug: olmo-3-1-32b-think
+    model_revision: 832c3f543499af8fe68b88359501de9cb7840544
+    run_kind: independent
+    source_kind: independent_evaluation
+    evaluation_harness: Artificial Analysis
+    dataset_release: v1
+    task_count: 12000
+    task_artifact: https://artificialanalysis.ai/evaluations/mmlu-pro
+    cost_usd: null
+    latency_ms: null
+  metrics:
+    accuracy: 0.763
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/mmlu-pro
+    redistributable: true
+- id: independent/olmo-3-1-32b-think-gpqa-diamond@1.0.0
+  model: ai2/olmo-3-1-32b-think
+  benchmark: idavidrein/gpqa-diamond@1.0.0
+  benchmark_profile: independent-standard
+  reasoning_effort: enabled
+  subject:
+    source_model: OLMo 3.1 32B Think
+    source_model_slug: olmo-3-1-32b-think
+    model_revision: 832c3f543499af8fe68b88359501de9cb7840544
+    run_kind: independent
+    source_kind: independent_evaluation
+    evaluation_harness: Artificial Analysis
+    dataset_release: diamond
+    task_count: 198
+    task_artifact: https://artificialanalysis.ai/evaluations/gpqa-diamond
+    cost_usd: null
+    latency_ms: null
+  metrics:
+    accuracy: 0.590909090909091
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/gpqa-diamond
+    redistributable: true
+- id: independent/olmo-3-1-32b-think-humanitys-last-exam@1.0.0
+  model: ai2/olmo-3-1-32b-think
+  benchmark: cais/humanitys-last-exam@1.0.0
+  benchmark_profile: independent-text-only
+  reasoning_effort: enabled
+  subject:
+    source_model: OLMo 3.1 32B Think
+    source_model_slug: olmo-3-1-32b-think
+    model_revision: 832c3f543499af8fe68b88359501de9cb7840544
+    run_kind: independent
+    source_kind: independent_evaluation
+    evaluation_harness: Artificial Analysis
+    dataset_release: v1
+    task_count: 2500
+    task_artifact: https://artificialanalysis.ai/evaluations/humanitys-last-exam
+    cost_usd: null
+    latency_ms: null
+  metrics:
+    accuracy: 0.0625579240037071
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/humanitys-last-exam
+    redistributable: true
+- id: independent/olmo-3-1-32b-think-livecodebench-v6@1.0.0
+  model: ai2/olmo-3-1-32b-think
+  benchmark: livecodebench/livecodebench@6.0.0
+  benchmark_profile: independent-code-generation
+  reasoning_effort: enabled
+  subject:
+    source_model: OLMo 3.1 32B Think
+    source_model_slug: olmo-3-1-32b-think
+    model_revision: 832c3f543499af8fe68b88359501de9cb7840544
+    run_kind: independent
+    source_kind: independent_evaluation
+    evaluation_harness: Artificial Analysis
+    dataset_release: v6
+    task_count: 1055
+    task_artifact: https://artificialanalysis.ai/evaluations/livecodebench
+    cost_usd: null
+    latency_ms: null
+  metrics:
+    pass_at_1: 0.695238095238095
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/livecodebench
+    redistributable: true
+- id: independent/olmo-3-1-32b-think-scicode@1.0.0
+  model: ai2/olmo-3-1-32b-think
+  benchmark: scicode-bench/scicode@1.0.0
+  benchmark_profile: independent-test-288
+  reasoning_effort: enabled
+  subject:
+    source_model: OLMo 3.1 32B Think
+    source_model_slug: olmo-3-1-32b-think
+    model_revision: 832c3f543499af8fe68b88359501de9cb7840544
+    run_kind: independent
+    source_kind: independent_evaluation
+    evaluation_harness: Artificial Analysis
+    dataset_release: test
+    task_count: 288
+    task_artifact: https://artificialanalysis.ai/evaluations/scicode
+    cost_usd: null
+    latency_ms: null
+  metrics:
+    score: 0.293
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/scicode
+    redistributable: true
+- id: independent/olmo-3-1-32b-think-terminalbench-v2-1@1.0.0
+  model: ai2/olmo-3-1-32b-think
+  benchmark: harbor/terminal-bench@2.1.0
+  benchmark_profile: independent-agent
+  reasoning_effort: enabled
+  subject:
+    source_model: OLMo 3.1 32B Think
+    source_model_slug: olmo-3-1-32b-think
+    model_revision: 832c3f543499af8fe68b88359501de9cb7840544
+    run_kind: independent
+    source_kind: independent_evaluation
+    evaluation_harness: Artificial Analysis
+    dataset_release: v2.1
+    task_count: 89
+    task_artifact: https://github.com/harbor-framework/terminal-bench-2-1
+    cost_usd: null
+    latency_ms: null
+  metrics:
+    resolved: 0.0
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/terminalbench-v2-1
+    redistributable: true

--- a/config/catalog/resources/models/single/ai2.yaml
+++ b/config/catalog/resources/models/single/ai2.yaml
@@ -1,0 +1,112 @@
+- id: ai2/olmo-3-32b-base
+  display_name: OLMo 3 32B Base
+  description: Fully open 32B base language model from Ai2's OLMo 3 family.
+  kind: physical
+  publisher: Ai2 / OLMo
+  presentation:
+    logo: package:ai2
+    monogram: O
+    monochrome: false
+  distribution:
+    type: open_weights
+    source: https://huggingface.co/allenai/Olmo-3-1125-32B
+    license: Apache-2.0
+  family: olmo-3
+  parameter_size: 32B
+  revision: c2b61dae89a1ad10e4ad5653d0e46b590902607b
+  lifecycle: active
+  limits:
+    context_window_size: 65536
+  capabilities:
+  - chat
+  - long_context
+  modalities:
+    input:
+    - text
+    output:
+    - text
+  verification:
+    authority: Ai2
+    status: claimed
+    verified_at: 2026-09-11
+    source: https://huggingface.co/allenai/Olmo-3-1125-32B
+  tags:
+  - open_weights
+  - base_model
+  - long_context
+- id: ai2/olmo-3-1-32b-think
+  display_name: OLMo 3.1 32B Think
+  description: Fully open 32B reasoning model from Ai2's OLMo 3.1 family.
+  kind: physical
+  publisher: Ai2 / OLMo
+  presentation:
+    logo: package:ai2
+    monogram: O
+    monochrome: false
+  distribution:
+    type: open_weights
+    source: https://huggingface.co/allenai/Olmo-3.1-32B-Think
+    license: Apache-2.0
+  family: olmo-3
+  parameter_size: 32B
+  revision: 832c3f543499af8fe68b88359501de9cb7840544
+  knowledge_cutoff: '2024-12-01'
+  lifecycle: active
+  limits:
+    context_window_size: 65536
+    max_output_tokens: 32768
+  capabilities:
+  - chat
+  - reasoning
+  - long_context
+  modalities:
+    input:
+    - text
+    output:
+    - text
+  verification:
+    authority: Ai2
+    status: claimed
+    verified_at: 2026-09-11
+    source: https://huggingface.co/allenai/Olmo-3.1-32B-Think
+  tags:
+  - open_weights
+  - reasoning
+  - long_context
+- id: ai2/olmo-3-1-32b-instruct
+  display_name: OLMo 3.1 32B Instruct
+  description: Fully open 32B instruction-tuned model from Ai2's OLMo 3.1 family.
+  kind: physical
+  publisher: Ai2 / OLMo
+  presentation:
+    logo: package:ai2
+    monogram: O
+    monochrome: false
+  distribution:
+    type: open_weights
+    source: https://huggingface.co/allenai/Olmo-3.1-32B-Instruct
+    license: Apache-2.0
+  family: olmo-3
+  parameter_size: 32B
+  revision: ac0587e4a7744a551c059d8cd17ba220bc940dae
+  knowledge_cutoff: '2024-12-01'
+  lifecycle: active
+  limits:
+    context_window_size: 65536
+  capabilities:
+  - chat
+  - long_context
+  modalities:
+    input:
+    - text
+    output:
+    - text
+  verification:
+    authority: Ai2
+    status: claimed
+    verified_at: 2026-09-11
+    source: https://huggingface.co/allenai/Olmo-3.1-32B-Instruct
+  tags:
+  - open_weights
+  - instruction_tuned
+  - long_context

--- a/config/catalog/resources/providers/vllm.yaml
+++ b/config/catalog/resources/providers/vllm.yaml
@@ -105,6 +105,39 @@ models:
     status: claimed
     verified_at: 2026-09-05
     source: https://huggingface.co/ai21labs/AI21-Jamba-Reasoning-3B
+- catalog: ai2/olmo-3-32b-base
+  relationship: self_hosted
+  id: allenai/Olmo-3-1125-32B
+  protocols:
+  - openai/chat-completions@1
+  - openai/responses@1
+  lifecycle: active
+  verification:
+    status: claimed
+    verified_at: 2026-09-11
+    source: https://huggingface.co/allenai/Olmo-3-1125-32B
+- catalog: ai2/olmo-3-1-32b-think
+  relationship: self_hosted
+  id: allenai/Olmo-3.1-32B-Think
+  protocols:
+  - openai/chat-completions@1
+  - openai/responses@1
+  lifecycle: active
+  verification:
+    status: claimed
+    verified_at: 2026-09-11
+    source: https://huggingface.co/allenai/Olmo-3.1-32B-Think
+- catalog: ai2/olmo-3-1-32b-instruct
+  relationship: self_hosted
+  id: allenai/Olmo-3.1-32B-Instruct
+  protocols:
+  - openai/chat-completions@1
+  - openai/responses@1
+  lifecycle: active
+  verification:
+    status: claimed
+    verified_at: 2026-09-11
+    source: https://huggingface.co/allenai/Olmo-3.1-32B-Instruct
 - catalog: bytedance/seed-oss-36b-instruct
   relationship: self_hosted
   id: ByteDance-Seed/Seed-OSS-36B-Instruct

--- a/config/recipes/built-in/latest/catalog.yaml
+++ b/config/recipes/built-in/latest/catalog.yaml
@@ -2848,6 +2848,39 @@ providers:
       status: claimed
       verified_at: '2026-09-05'
       source: https://huggingface.co/ai21labs/AI21-Jamba-Reasoning-3B
+  - catalog: ai2/olmo-3-32b-base
+    relationship: self_hosted
+    id: allenai/Olmo-3-1125-32B
+    protocols:
+    - openai/chat-completions@1
+    - openai/responses@1
+    lifecycle: active
+    verification:
+      status: claimed
+      verified_at: '2026-09-11'
+      source: https://huggingface.co/allenai/Olmo-3-1125-32B
+  - catalog: ai2/olmo-3-1-32b-think
+    relationship: self_hosted
+    id: allenai/Olmo-3.1-32B-Think
+    protocols:
+    - openai/chat-completions@1
+    - openai/responses@1
+    lifecycle: active
+    verification:
+      status: claimed
+      verified_at: '2026-09-11'
+      source: https://huggingface.co/allenai/Olmo-3.1-32B-Think
+  - catalog: ai2/olmo-3-1-32b-instruct
+    relationship: self_hosted
+    id: allenai/Olmo-3.1-32B-Instruct
+    protocols:
+    - openai/chat-completions@1
+    - openai/responses@1
+    lifecycle: active
+    verification:
+      status: claimed
+      verified_at: '2026-09-11'
+      source: https://huggingface.co/allenai/Olmo-3.1-32B-Instruct
   - catalog: bytedance/seed-oss-36b-instruct
     relationship: self_hosted
     id: ByteDance-Seed/Seed-OSS-36B-Instruct
@@ -4219,6 +4252,118 @@ reasoning_families:
   - enabled
   default_mode: enabled
 models:
+- id: ai2/olmo-3-32b-base
+  display_name: OLMo 3 32B Base
+  description: Fully open 32B base language model from Ai2's OLMo 3 family.
+  kind: physical
+  publisher: Ai2 / OLMo
+  presentation:
+    logo: package:ai2
+    monogram: O
+    monochrome: false
+  distribution:
+    type: open_weights
+    source: https://huggingface.co/allenai/Olmo-3-1125-32B
+    license: Apache-2.0
+  family: olmo-3
+  parameter_size: 32B
+  revision: c2b61dae89a1ad10e4ad5653d0e46b590902607b
+  lifecycle: active
+  limits:
+    context_window_size: 65536
+  capabilities:
+  - chat
+  - long_context
+  modalities:
+    input:
+    - text
+    output:
+    - text
+  verification:
+    authority: Ai2
+    status: claimed
+    verified_at: '2026-09-11'
+    source: https://huggingface.co/allenai/Olmo-3-1125-32B
+  tags:
+  - open_weights
+  - base_model
+  - long_context
+- id: ai2/olmo-3-1-32b-think
+  display_name: OLMo 3.1 32B Think
+  description: Fully open 32B reasoning model from Ai2's OLMo 3.1 family.
+  kind: physical
+  publisher: Ai2 / OLMo
+  presentation:
+    logo: package:ai2
+    monogram: O
+    monochrome: false
+  distribution:
+    type: open_weights
+    source: https://huggingface.co/allenai/Olmo-3.1-32B-Think
+    license: Apache-2.0
+  family: olmo-3
+  parameter_size: 32B
+  revision: 832c3f543499af8fe68b88359501de9cb7840544
+  knowledge_cutoff: '2024-12-01'
+  lifecycle: active
+  limits:
+    context_window_size: 65536
+    max_output_tokens: 32768
+  capabilities:
+  - chat
+  - reasoning
+  - long_context
+  modalities:
+    input:
+    - text
+    output:
+    - text
+  verification:
+    authority: Ai2
+    status: claimed
+    verified_at: '2026-09-11'
+    source: https://huggingface.co/allenai/Olmo-3.1-32B-Think
+  tags:
+  - open_weights
+  - reasoning
+  - long_context
+- id: ai2/olmo-3-1-32b-instruct
+  display_name: OLMo 3.1 32B Instruct
+  description: Fully open 32B instruction-tuned model from Ai2's OLMo 3.1 family.
+  kind: physical
+  publisher: Ai2 / OLMo
+  presentation:
+    logo: package:ai2
+    monogram: O
+    monochrome: false
+  distribution:
+    type: open_weights
+    source: https://huggingface.co/allenai/Olmo-3.1-32B-Instruct
+    license: Apache-2.0
+  family: olmo-3
+  parameter_size: 32B
+  revision: ac0587e4a7744a551c059d8cd17ba220bc940dae
+  knowledge_cutoff: '2024-12-01'
+  lifecycle: active
+  limits:
+    context_window_size: 65536
+  capabilities:
+  - chat
+  - long_context
+  modalities:
+    input:
+    - text
+    output:
+    - text
+  verification:
+    authority: Ai2
+    status: claimed
+    verified_at: '2026-09-11'
+    source: https://huggingface.co/allenai/Olmo-3.1-32B-Instruct
+  tags:
+  - open_weights
+  - instruction_tuned
+  - long_context
 - id: ai21/jamba2-mini
   display_name: Jamba2 Mini
   description: Efficient second-generation AI21 Jamba hybrid model.
@@ -9570,6 +9715,9 @@ benchmarks:
   source: https://huggingface.co/datasets/openlifescienceai/medmcqa
   default_profile: medmarks-v1-three-order-average
   profiles:
+  - id: published-standard
+    display_name: Published standard
+    description: Source-published MedMCQA multiple-choice accuracy using the evaluated model's documented setup.
   - id: medmarks-v1-three-order-average
     display_name: Medmarks v1 three-order average
     description: Validation accuracy averaged across the original answer order and the two published Medmarks v1 shuffle seeds.
@@ -9590,6 +9738,9 @@ benchmarks:
   source: https://huggingface.co/datasets/GBaker/MedQA-USMLE-4-options-hf
   default_profile: medmarks-v1-three-order-average
   profiles:
+  - id: published-standard
+    display_name: Published standard
+    description: Source-published MedQA USMLE four-option accuracy using the evaluated model's documented setup.
   - id: medmarks-v1-three-order-average
     display_name: Medmarks v1 three-order average
     description: Test accuracy averaged across the original answer order and the two published Medmarks v1 shuffle seeds.
@@ -9673,12 +9824,31 @@ benchmarks:
   source: https://github.com/suzgunmirac/BIG-Bench-Hard
   default_profile: rmcb-eacl-2026-valid-output-test
   profiles:
+  - id: published-standard
+    display_name: Published standard
+    description: Source-published BIG-Bench Hard accuracy using the model card's documented standard setup.
   - id: rmcb-eacl-2026-valid-output-test
     display_name: RMCB EACL 2026 valid-output test
     description: Accuracy over valid generated outputs in the EACL 2026 RMCB test protocol; filtering counts and dataset revision
       remain on the evaluation record.
   metrics:
   - id: accuracy
+    unit: proportion
+    direction: higher_is_better
+    range:
+    - 0
+    - 1
+- id: bigcode-project/bigcodebench@1.0.0
+  display_name: BigCodeBench
+  domain: code_generation
+  source: https://github.com/bigcode-project/bigcodebench
+  default_profile: published-standard
+  profiles:
+  - id: published-standard
+    display_name: Published standard
+    description: Source-published BigCodeBench pass@1 with the evaluated model variant retained on the record.
+  metrics:
+  - id: pass_at_1
     unit: proportion
     direction: higher_is_better
     range:
@@ -9812,6 +9982,450 @@ benchmarks:
     - 0
     - 1
 evaluations:
+- id: ai2/olmo-3-32b-base-model-card-mmlu-pro@1.0.0
+  model: ai2/olmo-3-32b-base
+  benchmark: tiger-ai-lab/mmlu-pro@1.0.0
+  benchmark_profile: published-standard
+  reasoning_effort: unspecified
+  subject:
+    variant: OLMo 3 32B Base
+    source_kind: official_model_card
+    model_revision: c2b61dae89a1ad10e4ad5653d0e46b590902607b
+    dataset_variant: MMLU-Pro MC
+  metrics:
+    accuracy: 0.496
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/allenai/Olmo-3-1125-32B/blob/c2b61dae89a1ad10e4ad5653d0e46b590902607b/README.md
+    redistributable: true
+- id: ai2/olmo-3-32b-base-model-card-bbh@1.0.0
+  model: ai2/olmo-3-32b-base
+  benchmark: maveriq/bigbenchhard@1.0.0
+  benchmark_profile: published-standard
+  reasoning_effort: unspecified
+  subject:
+    variant: OLMo 3 32B Base
+    source_kind: official_model_card
+    model_revision: c2b61dae89a1ad10e4ad5653d0e46b590902607b
+  metrics:
+    accuracy: 0.776
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/allenai/Olmo-3-1125-32B/blob/c2b61dae89a1ad10e4ad5653d0e46b590902607b/README.md
+    redistributable: true
+- id: ai2/olmo-3-32b-base-model-card-bigcodebench@1.0.0
+  model: ai2/olmo-3-32b-base
+  benchmark: bigcode-project/bigcodebench@1.0.0
+  benchmark_profile: published-standard
+  reasoning_effort: unspecified
+  subject:
+    variant: OLMo 3 32B Base
+    source_kind: official_model_card
+    model_revision: c2b61dae89a1ad10e4ad5653d0e46b590902607b
+  metrics:
+    pass_at_1: 0.439
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/allenai/Olmo-3-1125-32B/blob/c2b61dae89a1ad10e4ad5653d0e46b590902607b/README.md
+    redistributable: true
+- id: ai2/olmo-3-32b-base-model-card-medmcqa@1.0.0
+  model: ai2/olmo-3-32b-base
+  benchmark: openlifescienceai/medmcqa@1.0.0
+  benchmark_profile: published-standard
+  reasoning_effort: unspecified
+  subject:
+    variant: OLMo 3 32B Base
+    source_kind: official_model_card
+    model_revision: c2b61dae89a1ad10e4ad5653d0e46b590902607b
+    dataset_variant: MedMCQA MC
+  metrics:
+    accuracy: 0.576
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/allenai/Olmo-3-1125-32B/blob/c2b61dae89a1ad10e4ad5653d0e46b590902607b/README.md
+    redistributable: true
+- id: ai2/olmo-3-32b-base-model-card-medqa@1.0.0
+  model: ai2/olmo-3-32b-base
+  benchmark: gbaker/medqa-usmle@1.0.0
+  benchmark_profile: published-standard
+  reasoning_effort: unspecified
+  subject:
+    variant: OLMo 3 32B Base
+    source_kind: official_model_card
+    model_revision: c2b61dae89a1ad10e4ad5653d0e46b590902607b
+    dataset_variant: MedQA MC
+  metrics:
+    accuracy: 0.538
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/allenai/Olmo-3-1125-32B/blob/c2b61dae89a1ad10e4ad5653d0e46b590902607b/README.md
+    redistributable: true
+- id: ai2/olmo-3-1-32b-think-model-card-math@1.0.0
+  model: ai2/olmo-3-1-32b-think
+  benchmark: hendrycks/math@1.0.0
+  benchmark_profile: published-standard
+  reasoning_effort: enabled
+  subject:
+    variant: OLMo 3.1 32B Think
+    source_kind: official_model_card
+    model_revision: 832c3f543499af8fe68b88359501de9cb7840544
+    sampling_temperature: 0.6
+    sampling_top_p: 0.95
+    maximum_output_tokens: 32768
+  metrics:
+    accuracy: 0.962
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/allenai/Olmo-3.1-32B-Think/blob/832c3f543499af8fe68b88359501de9cb7840544/README.md
+    redistributable: true
+- id: ai2/olmo-3-1-32b-think-model-card-aime-2024@1.0.0
+  model: ai2/olmo-3-1-32b-think
+  benchmark: matharena/aime@2024.0.0
+  benchmark_profile: pass-at-1
+  reasoning_effort: enabled
+  subject:
+    variant: OLMo 3.1 32B Think
+    source_kind: official_model_card
+    model_revision: 832c3f543499af8fe68b88359501de9cb7840544
+    sampling_temperature: 0.6
+    sampling_top_p: 0.95
+    maximum_output_tokens: 32768
+  metrics:
+    pass_at_1: 0.806
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/allenai/Olmo-3.1-32B-Think/blob/832c3f543499af8fe68b88359501de9cb7840544/README.md
+    redistributable: true
+- id: ai2/olmo-3-1-32b-think-model-card-aime-2025@1.0.0
+  model: ai2/olmo-3-1-32b-think
+  benchmark: matharena/aime@2025.0.0
+  benchmark_profile: pass-at-1
+  reasoning_effort: enabled
+  subject:
+    variant: OLMo 3.1 32B Think
+    source_kind: official_model_card
+    model_revision: 832c3f543499af8fe68b88359501de9cb7840544
+    sampling_temperature: 0.6
+    sampling_top_p: 0.95
+    maximum_output_tokens: 32768
+  metrics:
+    pass_at_1: 0.781
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/allenai/Olmo-3.1-32B-Think/blob/832c3f543499af8fe68b88359501de9cb7840544/README.md
+    redistributable: true
+- id: ai2/olmo-3-1-32b-think-model-card-ifeval@1.0.0
+  model: ai2/olmo-3-1-32b-think
+  benchmark: google/ifeval@1.0.0
+  benchmark_profile: published-standard
+  reasoning_effort: enabled
+  subject:
+    variant: OLMo 3.1 32B Think
+    source_kind: official_model_card
+    model_revision: 832c3f543499af8fe68b88359501de9cb7840544
+    sampling_temperature: 0.6
+    sampling_top_p: 0.95
+    maximum_output_tokens: 32768
+  metrics:
+    accuracy: 0.938
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/allenai/Olmo-3.1-32B-Think/blob/832c3f543499af8fe68b88359501de9cb7840544/README.md
+    redistributable: true
+- id: ai2/olmo-3-1-32b-think-model-card-gpqa@1.0.0
+  model: ai2/olmo-3-1-32b-think
+  benchmark: idavidrein/gpqa-diamond@1.0.0
+  benchmark_profile: published-standard
+  reasoning_effort: enabled
+  subject:
+    variant: OLMo 3.1 32B Think
+    source_kind: official_model_card
+    model_revision: 832c3f543499af8fe68b88359501de9cb7840544
+    sampling_temperature: 0.6
+    sampling_top_p: 0.95
+    maximum_output_tokens: 32768
+  metrics:
+    accuracy: 0.575
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/allenai/Olmo-3.1-32B-Think/blob/832c3f543499af8fe68b88359501de9cb7840544/README.md
+    redistributable: true
+- id: ai2/olmo-3-1-32b-instruct-model-card-math@1.0.0
+  model: ai2/olmo-3-1-32b-instruct
+  benchmark: hendrycks/math@1.0.0
+  benchmark_profile: published-standard
+  reasoning_effort: unspecified
+  subject:
+    variant: OLMo 3.1 32B Instruct
+    source_kind: official_model_card
+    model_revision: ac0587e4a7744a551c059d8cd17ba220bc940dae
+  metrics:
+    accuracy: 0.934
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/allenai/Olmo-3.1-32B-Instruct/blob/ac0587e4a7744a551c059d8cd17ba220bc940dae/README.md
+    redistributable: true
+- id: ai2/olmo-3-1-32b-instruct-model-card-aime-2024@1.0.0
+  model: ai2/olmo-3-1-32b-instruct
+  benchmark: matharena/aime@2024.0.0
+  benchmark_profile: pass-at-1
+  reasoning_effort: unspecified
+  subject:
+    variant: OLMo 3.1 32B Instruct
+    source_kind: official_model_card
+    model_revision: ac0587e4a7744a551c059d8cd17ba220bc940dae
+  metrics:
+    pass_at_1: 0.678
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/allenai/Olmo-3.1-32B-Instruct/blob/ac0587e4a7744a551c059d8cd17ba220bc940dae/README.md
+    redistributable: true
+- id: ai2/olmo-3-1-32b-instruct-model-card-aime-2025@1.0.0
+  model: ai2/olmo-3-1-32b-instruct
+  benchmark: matharena/aime@2025.0.0
+  benchmark_profile: pass-at-1
+  reasoning_effort: unspecified
+  subject:
+    variant: OLMo 3.1 32B Instruct
+    source_kind: official_model_card
+    model_revision: ac0587e4a7744a551c059d8cd17ba220bc940dae
+  metrics:
+    pass_at_1: 0.579
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/allenai/Olmo-3.1-32B-Instruct/blob/ac0587e4a7744a551c059d8cd17ba220bc940dae/README.md
+    redistributable: true
+- id: ai2/olmo-3-1-32b-instruct-model-card-ifeval@1.0.0
+  model: ai2/olmo-3-1-32b-instruct
+  benchmark: google/ifeval@1.0.0
+  benchmark_profile: published-standard
+  reasoning_effort: unspecified
+  subject:
+    variant: OLMo 3.1 32B Instruct
+    source_kind: official_model_card
+    model_revision: ac0587e4a7744a551c059d8cd17ba220bc940dae
+  metrics:
+    accuracy: 0.888
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/allenai/Olmo-3.1-32B-Instruct/blob/ac0587e4a7744a551c059d8cd17ba220bc940dae/README.md
+    redistributable: true
+- id: ai2/olmo-3-1-32b-instruct-model-card-gpqa@1.0.0
+  model: ai2/olmo-3-1-32b-instruct
+  benchmark: idavidrein/gpqa-diamond@1.0.0
+  benchmark_profile: published-standard
+  reasoning_effort: unspecified
+  subject:
+    variant: OLMo 3.1 32B Instruct
+    source_kind: official_model_card
+    model_revision: ac0587e4a7744a551c059d8cd17ba220bc940dae
+  metrics:
+    accuracy: 0.486
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/allenai/Olmo-3.1-32B-Instruct/blob/ac0587e4a7744a551c059d8cd17ba220bc940dae/README.md
+    redistributable: true
+- id: independent/olmo-3-1-32b-think-mmlu-pro@1.0.0
+  model: ai2/olmo-3-1-32b-think
+  benchmark: tiger-ai-lab/mmlu-pro@1.0.0
+  benchmark_profile: independent-standard
+  reasoning_effort: enabled
+  subject:
+    source_model: OLMo 3.1 32B Think
+    source_model_slug: olmo-3-1-32b-think
+    model_revision: 832c3f543499af8fe68b88359501de9cb7840544
+    run_kind: independent
+    source_kind: independent_evaluation
+    evaluation_harness: Artificial Analysis
+    dataset_release: v1
+    task_count: 12000
+    task_artifact: https://artificialanalysis.ai/evaluations/mmlu-pro
+    cost_usd: null
+    latency_ms: null
+  metrics:
+    accuracy: 0.763
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/mmlu-pro
+    redistributable: true
+- id: independent/olmo-3-1-32b-think-gpqa-diamond@1.0.0
+  model: ai2/olmo-3-1-32b-think
+  benchmark: idavidrein/gpqa-diamond@1.0.0
+  benchmark_profile: independent-standard
+  reasoning_effort: enabled
+  subject:
+    source_model: OLMo 3.1 32B Think
+    source_model_slug: olmo-3-1-32b-think
+    model_revision: 832c3f543499af8fe68b88359501de9cb7840544
+    run_kind: independent
+    source_kind: independent_evaluation
+    evaluation_harness: Artificial Analysis
+    dataset_release: diamond
+    task_count: 198
+    task_artifact: https://artificialanalysis.ai/evaluations/gpqa-diamond
+    cost_usd: null
+    latency_ms: null
+  metrics:
+    accuracy: 0.590909090909091
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/gpqa-diamond
+    redistributable: true
+- id: independent/olmo-3-1-32b-think-humanitys-last-exam@1.0.0
+  model: ai2/olmo-3-1-32b-think
+  benchmark: cais/humanitys-last-exam@1.0.0
+  benchmark_profile: independent-text-only
+  reasoning_effort: enabled
+  subject:
+    source_model: OLMo 3.1 32B Think
+    source_model_slug: olmo-3-1-32b-think
+    model_revision: 832c3f543499af8fe68b88359501de9cb7840544
+    run_kind: independent
+    source_kind: independent_evaluation
+    evaluation_harness: Artificial Analysis
+    dataset_release: v1
+    task_count: 2500
+    task_artifact: https://artificialanalysis.ai/evaluations/humanitys-last-exam
+    cost_usd: null
+    latency_ms: null
+  metrics:
+    accuracy: 0.0625579240037071
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/humanitys-last-exam
+    redistributable: true
+- id: independent/olmo-3-1-32b-think-livecodebench-v6@1.0.0
+  model: ai2/olmo-3-1-32b-think
+  benchmark: livecodebench/livecodebench@6.0.0
+  benchmark_profile: independent-code-generation
+  reasoning_effort: enabled
+  subject:
+    source_model: OLMo 3.1 32B Think
+    source_model_slug: olmo-3-1-32b-think
+    model_revision: 832c3f543499af8fe68b88359501de9cb7840544
+    run_kind: independent
+    source_kind: independent_evaluation
+    evaluation_harness: Artificial Analysis
+    dataset_release: v6
+    task_count: 1055
+    task_artifact: https://artificialanalysis.ai/evaluations/livecodebench
+    cost_usd: null
+    latency_ms: null
+  metrics:
+    pass_at_1: 0.695238095238095
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/livecodebench
+    redistributable: true
+- id: independent/olmo-3-1-32b-think-scicode@1.0.0
+  model: ai2/olmo-3-1-32b-think
+  benchmark: scicode-bench/scicode@1.0.0
+  benchmark_profile: independent-test-288
+  reasoning_effort: enabled
+  subject:
+    source_model: OLMo 3.1 32B Think
+    source_model_slug: olmo-3-1-32b-think
+    model_revision: 832c3f543499af8fe68b88359501de9cb7840544
+    run_kind: independent
+    source_kind: independent_evaluation
+    evaluation_harness: Artificial Analysis
+    dataset_release: test
+    task_count: 288
+    task_artifact: https://artificialanalysis.ai/evaluations/scicode
+    cost_usd: null
+    latency_ms: null
+  metrics:
+    score: 0.293
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/scicode
+    redistributable: true
+- id: independent/olmo-3-1-32b-think-terminalbench-v2-1@1.0.0
+  model: ai2/olmo-3-1-32b-think
+  benchmark: harbor/terminal-bench@2.1.0
+  benchmark_profile: independent-agent
+  reasoning_effort: enabled
+  subject:
+    source_model: OLMo 3.1 32B Think
+    source_model_slug: olmo-3-1-32b-think
+    model_revision: 832c3f543499af8fe68b88359501de9cb7840544
+    run_kind: independent
+    source_kind: independent_evaluation
+    evaluation_harness: Artificial Analysis
+    dataset_release: v2.1
+    task_count: 89
+    task_artifact: https://github.com/harbor-framework/terminal-bench-2-1
+    cost_usd: null
+    latency_ms: null
+  metrics:
+    resolved: 0.0
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: third_party
+    verification: imported
+    source: https://artificialanalysis.ai/evaluations/terminalbench-v2-1
+    redistributable: true
 - id: independent/ai21-jamba2-mini-careqa-medmarks-v1@1.0.0
   model: ai21/jamba2-mini
   benchmark: hpai-bsc/careqa@1.0.0
@@ -37701,6 +38315,176 @@ indices:
     normalization:
       type: identity
 index_results:
+- model: ai2/olmo-3-32b-base
+  reasoning_effort: unspecified
+  index: vllm-sr/general@1.0.0
+  status: available
+  score: 49.6
+  coverage: 1.0
+  components:
+  - weight: 1.0
+    status: available
+    value: 0.496
+    normalized: 0.496
+    benchmark: tiger-ai-lab/mmlu-pro@1.0.0
+    metric: accuracy
+    benchmark_profiles:
+    - independent-standard
+    - published-standard
+    evaluation: ai2/olmo-3-32b-base-model-card-mmlu-pro@1.0.0
+    benchmark_profile: published-standard
+  provenance:
+  - ai2/olmo-3-32b-base-model-card-mmlu-pro@1.0.0
+  domains:
+    general_reasoning: 49.6
+- model: ai2/olmo-3-1-32b-think
+  reasoning_effort: enabled
+  index: vllm-sr/general@1.0.0
+  status: available
+  score: 76.3
+  coverage: 1.0
+  components:
+  - weight: 1.0
+    status: available
+    value: 0.763
+    normalized: 0.763
+    benchmark: tiger-ai-lab/mmlu-pro@1.0.0
+    metric: accuracy
+    benchmark_profiles:
+    - independent-standard
+    - published-standard
+    evaluation: independent/olmo-3-1-32b-think-mmlu-pro@1.0.0
+    benchmark_profile: independent-standard
+  provenance:
+  - independent/olmo-3-1-32b-think-mmlu-pro@1.0.0
+  domains:
+    general_reasoning: 76.3
+- model: ai2/olmo-3-1-32b-think
+  reasoning_effort: enabled
+  index: vllm-sr/reasoning@1.0.0
+  status: available
+  score: 32.67335074563991
+  coverage: 1.0
+  components:
+  - weight: 0.5
+    status: available
+    value: 0.590909090909091
+    normalized: 0.590909090909091
+    benchmark: idavidrein/gpqa-diamond@1.0.0
+    metric: accuracy
+    benchmark_profiles:
+    - independent-standard
+    - published-standard
+    evaluation: independent/olmo-3-1-32b-think-gpqa-diamond@1.0.0
+    benchmark_profile: independent-standard
+  - weight: 0.5
+    status: available
+    value: 0.0625579240037071
+    normalized: 0.0625579240037071
+    benchmark: cais/humanitys-last-exam@1.0.0
+    metric: accuracy
+    benchmark_profiles:
+    - independent-text-only
+    - text-only
+    evaluation: independent/olmo-3-1-32b-think-humanitys-last-exam@1.0.0
+    benchmark_profile: independent-text-only
+  provenance:
+  - independent/olmo-3-1-32b-think-gpqa-diamond@1.0.0
+  - independent/olmo-3-1-32b-think-humanitys-last-exam@1.0.0
+  domains:
+    frontier_reasoning: 6.25579240037071
+    scientific_reasoning: 59.09090909090911
+- model: ai2/olmo-3-1-32b-think
+  reasoning_effort: enabled
+  index: vllm-sr/coding@1.0.0
+  status: available
+  score: 49.411904761904744
+  coverage: 1.0
+  components:
+  - weight: 0.5
+    status: available
+    value: 0.695238095238095
+    normalized: 0.695238095238095
+    benchmark: livecodebench/livecodebench@6.0.0
+    metric: pass_at_1
+    benchmark_profiles:
+    - independent-code-generation
+    - published-code-generation
+    evaluation: independent/olmo-3-1-32b-think-livecodebench-v6@1.0.0
+    benchmark_profile: independent-code-generation
+  - weight: 0.5
+    status: available
+    value: 0.293
+    normalized: 0.293
+    benchmark: scicode-bench/scicode@1.0.0
+    metric: score
+    benchmark_profiles:
+    - independent-test-288
+    - published-standard
+    evaluation: independent/olmo-3-1-32b-think-scicode@1.0.0
+    benchmark_profile: independent-test-288
+  provenance:
+  - independent/olmo-3-1-32b-think-livecodebench-v6@1.0.0
+  - independent/olmo-3-1-32b-think-scicode@1.0.0
+  domains:
+    competitive_programming: 69.5238095238095
+    scientific_coding: 29.299999999999997
+- model: ai2/olmo-3-1-32b-think
+  reasoning_effort: enabled
+  index: vllm-sr/agentic@1.0.0
+  status: available
+  score: 0.0
+  coverage: 1.0
+  components:
+  - weight: 1.0
+    status: available
+    value: 0.0
+    normalized: 0.0
+    benchmark: harbor/terminal-bench@2.1.0
+    metric: resolved
+    benchmark_profiles:
+    - independent-agent
+    - published-agent
+    evaluation: independent/olmo-3-1-32b-think-terminalbench-v2-1@1.0.0
+    benchmark_profile: independent-agent
+  provenance:
+  - independent/olmo-3-1-32b-think-terminalbench-v2-1@1.0.0
+  domains:
+    agentic_systems: 0.0
+- model: ai2/olmo-3-1-32b-think
+  reasoning_effort: enabled
+  index: vllm-sr/intelligence@1.0.0
+  status: available
+  score: 38.21172125063691
+  coverage: 1.0
+  components:
+  - weight: 0.2
+    status: available
+    value: 0.763
+    normalized: 0.763
+    index: vllm-sr/general@1.0.0
+  - weight: 0.4
+    status: available
+    value: 0.32673350745639906
+    normalized: 0.32673350745639906
+    index: vllm-sr/reasoning@1.0.0
+  - weight: 0.2
+    status: available
+    value: 0.49411904761904746
+    normalized: 0.49411904761904746
+    index: vllm-sr/coding@1.0.0
+  - weight: 0.2
+    status: available
+    value: 0.0
+    normalized: 0.0
+    index: vllm-sr/agentic@1.0.0
+  provenance:
+  - independent/olmo-3-1-32b-think-gpqa-diamond@1.0.0
+  - independent/olmo-3-1-32b-think-humanitys-last-exam@1.0.0
+  - independent/olmo-3-1-32b-think-livecodebench-v6@1.0.0
+  - independent/olmo-3-1-32b-think-mmlu-pro@1.0.0
+  - independent/olmo-3-1-32b-think-scicode@1.0.0
+  - independent/olmo-3-1-32b-think-terminalbench-v2-1@1.0.0
 - model: ai21/jamba-reasoning-3b
   reasoning_effort: enabled
   index: vllm-sr/reasoning@1.0.0

--- a/dashboard/backend/handlers/model_catalog_test.go
+++ b/dashboard/backend/handlers/model_catalog_test.go
@@ -451,7 +451,7 @@ func TestGeneratedPublicModelCatalogSatisfiesDashboardContract(t *testing.T) {
 	if unmarshalErr := json.Unmarshal(normalized, &document); unmarshalErr != nil {
 		t.Fatalf("decode normalized public catalog: %v", unmarshalErr)
 	}
-	if len(document.Models) != 101 || len(document.Providers) != 61 || len(document.Evaluations) != 1510 {
+	if len(document.Models) != 104 || len(document.Providers) != 61 || len(document.Evaluations) != 1531 {
 		t.Fatalf(
 			"unexpected generated inventory: models=%d providers=%d evaluations=%d; "+
 				"regenerate the catalog, or update these counts if the change is intended",

--- a/src/semantic-router/pkg/catalog/zz_generated_catalog.go
+++ b/src/semantic-router/pkg/catalog/zz_generated_catalog.go
@@ -2,7 +2,7 @@
 
 package catalog
 
-const builtInCatalogDigest = "sha256:59aa26f1e4bb0fa52987c265a626962efb8b610e804d9d92e946e1daccb0506f"
+const builtInCatalogDigest = "sha256:bdec7c235b72556939ae8260e3f187f1464147a5d4de588a50f970575598003e"
 
 const builtInCatalogJSON = `{
   "benchmarks": [
@@ -1465,6 +1465,11 @@ const builtInCatalogJSON = `{
       ],
       "profiles": [
         {
+          "description": "Source-published MedMCQA multiple-choice accuracy using the evaluated model's documented setup.",
+          "display_name": "Published standard",
+          "id": "published-standard"
+        },
+        {
           "description": "Validation accuracy averaged across the original answer order and the two published Medmarks v1 shuffle seeds.",
           "display_name": "Medmarks v1 three-order average",
           "id": "medmarks-v1-three-order-average"
@@ -1494,6 +1499,11 @@ const builtInCatalogJSON = `{
         }
       ],
       "profiles": [
+        {
+          "description": "Source-published MedQA USMLE four-option accuracy using the evaluated model's documented setup.",
+          "display_name": "Published standard",
+          "id": "published-standard"
+        },
         {
           "description": "Test accuracy averaged across the original answer order and the two published Medmarks v1 shuffle seeds.",
           "display_name": "Medmarks v1 three-order average",
@@ -1620,12 +1630,42 @@ const builtInCatalogJSON = `{
       ],
       "profiles": [
         {
+          "description": "Source-published BIG-Bench Hard accuracy using the model card's documented standard setup.",
+          "display_name": "Published standard",
+          "id": "published-standard"
+        },
+        {
           "description": "Accuracy over valid generated outputs in the EACL 2026 RMCB test protocol; filtering counts and dataset revision remain on the evaluation record.",
           "display_name": "RMCB EACL 2026 valid-output test",
           "id": "rmcb-eacl-2026-valid-output-test"
         }
       ],
       "source": "https://github.com/suzgunmirac/BIG-Bench-Hard"
+    },
+    {
+      "default_profile": "published-standard",
+      "display_name": "BigCodeBench",
+      "domain": "code_generation",
+      "id": "bigcode-project/bigcodebench@1.0.0",
+      "metrics": [
+        {
+          "direction": "higher_is_better",
+          "id": "pass_at_1",
+          "range": [
+            0,
+            1
+          ],
+          "unit": "proportion"
+        }
+      ],
+      "profiles": [
+        {
+          "description": "Source-published BigCodeBench pass@1 with the evaluated model variant retained on the record.",
+          "display_name": "Published standard",
+          "id": "published-standard"
+        }
+      ],
+      "source": "https://github.com/bigcode-project/bigcodebench"
     },
     {
       "default_profile": "published-standard",
@@ -1839,6 +1879,555 @@ const builtInCatalogJSON = `{
     }
   ],
   "evaluations": [
+    {
+      "benchmark": "tiger-ai-lab/mmlu-pro@1.0.0",
+      "benchmark_profile": "published-standard",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/allenai/Olmo-3-1125-32B/blob/c2b61dae89a1ad10e4ad5653d0e46b590902607b/README.md",
+        "verification": "claimed"
+      },
+      "id": "ai2/olmo-3-32b-base-model-card-mmlu-pro@1.0.0",
+      "metrics": {
+        "accuracy": 0.496
+      },
+      "model": "ai2/olmo-3-32b-base",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "dataset_variant": "MMLU-Pro MC",
+        "model_revision": "c2b61dae89a1ad10e4ad5653d0e46b590902607b",
+        "source_kind": "official_model_card",
+        "variant": "OLMo 3 32B Base"
+      }
+    },
+    {
+      "benchmark": "maveriq/bigbenchhard@1.0.0",
+      "benchmark_profile": "published-standard",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/allenai/Olmo-3-1125-32B/blob/c2b61dae89a1ad10e4ad5653d0e46b590902607b/README.md",
+        "verification": "claimed"
+      },
+      "id": "ai2/olmo-3-32b-base-model-card-bbh@1.0.0",
+      "metrics": {
+        "accuracy": 0.776
+      },
+      "model": "ai2/olmo-3-32b-base",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "model_revision": "c2b61dae89a1ad10e4ad5653d0e46b590902607b",
+        "source_kind": "official_model_card",
+        "variant": "OLMo 3 32B Base"
+      }
+    },
+    {
+      "benchmark": "bigcode-project/bigcodebench@1.0.0",
+      "benchmark_profile": "published-standard",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/allenai/Olmo-3-1125-32B/blob/c2b61dae89a1ad10e4ad5653d0e46b590902607b/README.md",
+        "verification": "claimed"
+      },
+      "id": "ai2/olmo-3-32b-base-model-card-bigcodebench@1.0.0",
+      "metrics": {
+        "pass_at_1": 0.439
+      },
+      "model": "ai2/olmo-3-32b-base",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "model_revision": "c2b61dae89a1ad10e4ad5653d0e46b590902607b",
+        "source_kind": "official_model_card",
+        "variant": "OLMo 3 32B Base"
+      }
+    },
+    {
+      "benchmark": "openlifescienceai/medmcqa@1.0.0",
+      "benchmark_profile": "published-standard",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/allenai/Olmo-3-1125-32B/blob/c2b61dae89a1ad10e4ad5653d0e46b590902607b/README.md",
+        "verification": "claimed"
+      },
+      "id": "ai2/olmo-3-32b-base-model-card-medmcqa@1.0.0",
+      "metrics": {
+        "accuracy": 0.576
+      },
+      "model": "ai2/olmo-3-32b-base",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "dataset_variant": "MedMCQA MC",
+        "model_revision": "c2b61dae89a1ad10e4ad5653d0e46b590902607b",
+        "source_kind": "official_model_card",
+        "variant": "OLMo 3 32B Base"
+      }
+    },
+    {
+      "benchmark": "gbaker/medqa-usmle@1.0.0",
+      "benchmark_profile": "published-standard",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/allenai/Olmo-3-1125-32B/blob/c2b61dae89a1ad10e4ad5653d0e46b590902607b/README.md",
+        "verification": "claimed"
+      },
+      "id": "ai2/olmo-3-32b-base-model-card-medqa@1.0.0",
+      "metrics": {
+        "accuracy": 0.538
+      },
+      "model": "ai2/olmo-3-32b-base",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "dataset_variant": "MedQA MC",
+        "model_revision": "c2b61dae89a1ad10e4ad5653d0e46b590902607b",
+        "source_kind": "official_model_card",
+        "variant": "OLMo 3 32B Base"
+      }
+    },
+    {
+      "benchmark": "hendrycks/math@1.0.0",
+      "benchmark_profile": "published-standard",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/allenai/Olmo-3.1-32B-Think/blob/832c3f543499af8fe68b88359501de9cb7840544/README.md",
+        "verification": "claimed"
+      },
+      "id": "ai2/olmo-3-1-32b-think-model-card-math@1.0.0",
+      "metrics": {
+        "accuracy": 0.962
+      },
+      "model": "ai2/olmo-3-1-32b-think",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "maximum_output_tokens": 32768,
+        "model_revision": "832c3f543499af8fe68b88359501de9cb7840544",
+        "sampling_temperature": 0.6,
+        "sampling_top_p": 0.95,
+        "source_kind": "official_model_card",
+        "variant": "OLMo 3.1 32B Think"
+      }
+    },
+    {
+      "benchmark": "matharena/aime@2024.0.0",
+      "benchmark_profile": "pass-at-1",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/allenai/Olmo-3.1-32B-Think/blob/832c3f543499af8fe68b88359501de9cb7840544/README.md",
+        "verification": "claimed"
+      },
+      "id": "ai2/olmo-3-1-32b-think-model-card-aime-2024@1.0.0",
+      "metrics": {
+        "pass_at_1": 0.806
+      },
+      "model": "ai2/olmo-3-1-32b-think",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "maximum_output_tokens": 32768,
+        "model_revision": "832c3f543499af8fe68b88359501de9cb7840544",
+        "sampling_temperature": 0.6,
+        "sampling_top_p": 0.95,
+        "source_kind": "official_model_card",
+        "variant": "OLMo 3.1 32B Think"
+      }
+    },
+    {
+      "benchmark": "matharena/aime@2025.0.0",
+      "benchmark_profile": "pass-at-1",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/allenai/Olmo-3.1-32B-Think/blob/832c3f543499af8fe68b88359501de9cb7840544/README.md",
+        "verification": "claimed"
+      },
+      "id": "ai2/olmo-3-1-32b-think-model-card-aime-2025@1.0.0",
+      "metrics": {
+        "pass_at_1": 0.781
+      },
+      "model": "ai2/olmo-3-1-32b-think",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "maximum_output_tokens": 32768,
+        "model_revision": "832c3f543499af8fe68b88359501de9cb7840544",
+        "sampling_temperature": 0.6,
+        "sampling_top_p": 0.95,
+        "source_kind": "official_model_card",
+        "variant": "OLMo 3.1 32B Think"
+      }
+    },
+    {
+      "benchmark": "google/ifeval@1.0.0",
+      "benchmark_profile": "published-standard",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/allenai/Olmo-3.1-32B-Think/blob/832c3f543499af8fe68b88359501de9cb7840544/README.md",
+        "verification": "claimed"
+      },
+      "id": "ai2/olmo-3-1-32b-think-model-card-ifeval@1.0.0",
+      "metrics": {
+        "accuracy": 0.938
+      },
+      "model": "ai2/olmo-3-1-32b-think",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "maximum_output_tokens": 32768,
+        "model_revision": "832c3f543499af8fe68b88359501de9cb7840544",
+        "sampling_temperature": 0.6,
+        "sampling_top_p": 0.95,
+        "source_kind": "official_model_card",
+        "variant": "OLMo 3.1 32B Think"
+      }
+    },
+    {
+      "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+      "benchmark_profile": "published-standard",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/allenai/Olmo-3.1-32B-Think/blob/832c3f543499af8fe68b88359501de9cb7840544/README.md",
+        "verification": "claimed"
+      },
+      "id": "ai2/olmo-3-1-32b-think-model-card-gpqa@1.0.0",
+      "metrics": {
+        "accuracy": 0.575
+      },
+      "model": "ai2/olmo-3-1-32b-think",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "maximum_output_tokens": 32768,
+        "model_revision": "832c3f543499af8fe68b88359501de9cb7840544",
+        "sampling_temperature": 0.6,
+        "sampling_top_p": 0.95,
+        "source_kind": "official_model_card",
+        "variant": "OLMo 3.1 32B Think"
+      }
+    },
+    {
+      "benchmark": "hendrycks/math@1.0.0",
+      "benchmark_profile": "published-standard",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/allenai/Olmo-3.1-32B-Instruct/blob/ac0587e4a7744a551c059d8cd17ba220bc940dae/README.md",
+        "verification": "claimed"
+      },
+      "id": "ai2/olmo-3-1-32b-instruct-model-card-math@1.0.0",
+      "metrics": {
+        "accuracy": 0.934
+      },
+      "model": "ai2/olmo-3-1-32b-instruct",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "model_revision": "ac0587e4a7744a551c059d8cd17ba220bc940dae",
+        "source_kind": "official_model_card",
+        "variant": "OLMo 3.1 32B Instruct"
+      }
+    },
+    {
+      "benchmark": "matharena/aime@2024.0.0",
+      "benchmark_profile": "pass-at-1",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/allenai/Olmo-3.1-32B-Instruct/blob/ac0587e4a7744a551c059d8cd17ba220bc940dae/README.md",
+        "verification": "claimed"
+      },
+      "id": "ai2/olmo-3-1-32b-instruct-model-card-aime-2024@1.0.0",
+      "metrics": {
+        "pass_at_1": 0.678
+      },
+      "model": "ai2/olmo-3-1-32b-instruct",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "model_revision": "ac0587e4a7744a551c059d8cd17ba220bc940dae",
+        "source_kind": "official_model_card",
+        "variant": "OLMo 3.1 32B Instruct"
+      }
+    },
+    {
+      "benchmark": "matharena/aime@2025.0.0",
+      "benchmark_profile": "pass-at-1",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/allenai/Olmo-3.1-32B-Instruct/blob/ac0587e4a7744a551c059d8cd17ba220bc940dae/README.md",
+        "verification": "claimed"
+      },
+      "id": "ai2/olmo-3-1-32b-instruct-model-card-aime-2025@1.0.0",
+      "metrics": {
+        "pass_at_1": 0.579
+      },
+      "model": "ai2/olmo-3-1-32b-instruct",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "model_revision": "ac0587e4a7744a551c059d8cd17ba220bc940dae",
+        "source_kind": "official_model_card",
+        "variant": "OLMo 3.1 32B Instruct"
+      }
+    },
+    {
+      "benchmark": "google/ifeval@1.0.0",
+      "benchmark_profile": "published-standard",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/allenai/Olmo-3.1-32B-Instruct/blob/ac0587e4a7744a551c059d8cd17ba220bc940dae/README.md",
+        "verification": "claimed"
+      },
+      "id": "ai2/olmo-3-1-32b-instruct-model-card-ifeval@1.0.0",
+      "metrics": {
+        "accuracy": 0.888
+      },
+      "model": "ai2/olmo-3-1-32b-instruct",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "model_revision": "ac0587e4a7744a551c059d8cd17ba220bc940dae",
+        "source_kind": "official_model_card",
+        "variant": "OLMo 3.1 32B Instruct"
+      }
+    },
+    {
+      "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+      "benchmark_profile": "published-standard",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/allenai/Olmo-3.1-32B-Instruct/blob/ac0587e4a7744a551c059d8cd17ba220bc940dae/README.md",
+        "verification": "claimed"
+      },
+      "id": "ai2/olmo-3-1-32b-instruct-model-card-gpqa@1.0.0",
+      "metrics": {
+        "accuracy": 0.486
+      },
+      "model": "ai2/olmo-3-1-32b-instruct",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "model_revision": "ac0587e4a7744a551c059d8cd17ba220bc940dae",
+        "source_kind": "official_model_card",
+        "variant": "OLMo 3.1 32B Instruct"
+      }
+    },
+    {
+      "benchmark": "tiger-ai-lab/mmlu-pro@1.0.0",
+      "benchmark_profile": "independent-standard",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/mmlu-pro",
+        "verification": "imported"
+      },
+      "id": "independent/olmo-3-1-32b-think-mmlu-pro@1.0.0",
+      "metrics": {
+        "accuracy": 0.763
+      },
+      "model": "ai2/olmo-3-1-32b-think",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "cost_usd": null,
+        "dataset_release": "v1",
+        "evaluation_harness": "Artificial Analysis",
+        "latency_ms": null,
+        "model_revision": "832c3f543499af8fe68b88359501de9cb7840544",
+        "run_kind": "independent",
+        "source_kind": "independent_evaluation",
+        "source_model": "OLMo 3.1 32B Think",
+        "source_model_slug": "olmo-3-1-32b-think",
+        "task_artifact": "https://artificialanalysis.ai/evaluations/mmlu-pro",
+        "task_count": 12000
+      }
+    },
+    {
+      "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+      "benchmark_profile": "independent-standard",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/gpqa-diamond",
+        "verification": "imported"
+      },
+      "id": "independent/olmo-3-1-32b-think-gpqa-diamond@1.0.0",
+      "metrics": {
+        "accuracy": 0.590909090909091
+      },
+      "model": "ai2/olmo-3-1-32b-think",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "cost_usd": null,
+        "dataset_release": "diamond",
+        "evaluation_harness": "Artificial Analysis",
+        "latency_ms": null,
+        "model_revision": "832c3f543499af8fe68b88359501de9cb7840544",
+        "run_kind": "independent",
+        "source_kind": "independent_evaluation",
+        "source_model": "OLMo 3.1 32B Think",
+        "source_model_slug": "olmo-3-1-32b-think",
+        "task_artifact": "https://artificialanalysis.ai/evaluations/gpqa-diamond",
+        "task_count": 198
+      }
+    },
+    {
+      "benchmark": "cais/humanitys-last-exam@1.0.0",
+      "benchmark_profile": "independent-text-only",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/humanitys-last-exam",
+        "verification": "imported"
+      },
+      "id": "independent/olmo-3-1-32b-think-humanitys-last-exam@1.0.0",
+      "metrics": {
+        "accuracy": 0.0625579240037071
+      },
+      "model": "ai2/olmo-3-1-32b-think",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "cost_usd": null,
+        "dataset_release": "v1",
+        "evaluation_harness": "Artificial Analysis",
+        "latency_ms": null,
+        "model_revision": "832c3f543499af8fe68b88359501de9cb7840544",
+        "run_kind": "independent",
+        "source_kind": "independent_evaluation",
+        "source_model": "OLMo 3.1 32B Think",
+        "source_model_slug": "olmo-3-1-32b-think",
+        "task_artifact": "https://artificialanalysis.ai/evaluations/humanitys-last-exam",
+        "task_count": 2500
+      }
+    },
+    {
+      "benchmark": "livecodebench/livecodebench@6.0.0",
+      "benchmark_profile": "independent-code-generation",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/livecodebench",
+        "verification": "imported"
+      },
+      "id": "independent/olmo-3-1-32b-think-livecodebench-v6@1.0.0",
+      "metrics": {
+        "pass_at_1": 0.695238095238095
+      },
+      "model": "ai2/olmo-3-1-32b-think",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "cost_usd": null,
+        "dataset_release": "v6",
+        "evaluation_harness": "Artificial Analysis",
+        "latency_ms": null,
+        "model_revision": "832c3f543499af8fe68b88359501de9cb7840544",
+        "run_kind": "independent",
+        "source_kind": "independent_evaluation",
+        "source_model": "OLMo 3.1 32B Think",
+        "source_model_slug": "olmo-3-1-32b-think",
+        "task_artifact": "https://artificialanalysis.ai/evaluations/livecodebench",
+        "task_count": 1055
+      }
+    },
+    {
+      "benchmark": "scicode-bench/scicode@1.0.0",
+      "benchmark_profile": "independent-test-288",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/scicode",
+        "verification": "imported"
+      },
+      "id": "independent/olmo-3-1-32b-think-scicode@1.0.0",
+      "metrics": {
+        "score": 0.293
+      },
+      "model": "ai2/olmo-3-1-32b-think",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "cost_usd": null,
+        "dataset_release": "test",
+        "evaluation_harness": "Artificial Analysis",
+        "latency_ms": null,
+        "model_revision": "832c3f543499af8fe68b88359501de9cb7840544",
+        "run_kind": "independent",
+        "source_kind": "independent_evaluation",
+        "source_model": "OLMo 3.1 32B Think",
+        "source_model_slug": "olmo-3-1-32b-think",
+        "task_artifact": "https://artificialanalysis.ai/evaluations/scicode",
+        "task_count": 288
+      }
+    },
+    {
+      "benchmark": "harbor/terminal-bench@2.1.0",
+      "benchmark_profile": "independent-agent",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/terminalbench-v2-1",
+        "verification": "imported"
+      },
+      "id": "independent/olmo-3-1-32b-think-terminalbench-v2-1@1.0.0",
+      "metrics": {
+        "resolved": 0.0
+      },
+      "model": "ai2/olmo-3-1-32b-think",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "cost_usd": null,
+        "dataset_release": "v2.1",
+        "evaluation_harness": "Artificial Analysis",
+        "latency_ms": null,
+        "model_revision": "832c3f543499af8fe68b88359501de9cb7840544",
+        "run_kind": "independent",
+        "source_kind": "independent_evaluation",
+        "source_model": "OLMo 3.1 32B Think",
+        "source_model_slug": "olmo-3-1-32b-think",
+        "task_artifact": "https://github.com/harbor-framework/terminal-bench-2-1",
+        "task_count": 89
+      }
+    },
     {
       "benchmark": "hpai-bsc/careqa@1.0.0",
       "benchmark_profile": "medmarks-v1-three-order-average",
@@ -37150,6 +37739,994 @@ const builtInCatalogJSON = `{
     }
   ],
   "index_results": [
+    {
+      "components": [
+        {
+          "benchmark": "tiger-ai-lab/mmlu-pro@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/general@1.0.0",
+      "model": "ai2/olmo-3-32b-base",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "cais/humanitys-last-exam@1.0.0",
+          "benchmark_profiles": [
+            "independent-text-only",
+            "text-only"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/reasoning@1.0.0",
+      "model": "ai2/olmo-3-32b-base",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "livecodebench/livecodebench@6.0.0",
+          "benchmark_profiles": [
+            "independent-code-generation",
+            "published-code-generation"
+          ],
+          "metric": "pass_at_1",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "scicode-bench/scicode@1.0.0",
+          "benchmark_profiles": [
+            "independent-test-288",
+            "published-standard"
+          ],
+          "metric": "score",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/coding@1.0.0",
+      "model": "ai2/olmo-3-32b-base",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "harbor/terminal-bench@2.1.0",
+          "benchmark_profiles": [
+            "independent-agent",
+            "published-agent"
+          ],
+          "metric": "resolved",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/agentic@1.0.0",
+      "model": "ai2/olmo-3-32b-base",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "index": "vllm-sr/general@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/reasoning@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.4
+        },
+        {
+          "index": "vllm-sr/coding@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/agentic@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/intelligence@1.0.0",
+      "model": "ai2/olmo-3-32b-base",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "tiger-ai-lab/mmlu-pro@1.0.0",
+          "benchmark_profile": "published-standard",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "evaluation": "ai2/olmo-3-32b-base-model-card-mmlu-pro@1.0.0",
+          "metric": "accuracy",
+          "normalized": 0.496,
+          "status": "available",
+          "value": 0.496,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 1.0,
+      "domains": {
+        "general_reasoning": 49.6
+      },
+      "index": "vllm-sr/general@1.0.0",
+      "model": "ai2/olmo-3-32b-base",
+      "provenance": [
+        "ai2/olmo-3-32b-base-model-card-mmlu-pro@1.0.0"
+      ],
+      "reasoning_effort": "unspecified",
+      "score": 49.6,
+      "status": "available"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "cais/humanitys-last-exam@1.0.0",
+          "benchmark_profiles": [
+            "independent-text-only",
+            "text-only"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/reasoning@1.0.0",
+      "model": "ai2/olmo-3-32b-base",
+      "provenance": [],
+      "reasoning_effort": "unspecified",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "livecodebench/livecodebench@6.0.0",
+          "benchmark_profiles": [
+            "independent-code-generation",
+            "published-code-generation"
+          ],
+          "metric": "pass_at_1",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "scicode-bench/scicode@1.0.0",
+          "benchmark_profiles": [
+            "independent-test-288",
+            "published-standard"
+          ],
+          "metric": "score",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/coding@1.0.0",
+      "model": "ai2/olmo-3-32b-base",
+      "provenance": [],
+      "reasoning_effort": "unspecified",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "harbor/terminal-bench@2.1.0",
+          "benchmark_profiles": [
+            "independent-agent",
+            "published-agent"
+          ],
+          "metric": "resolved",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/agentic@1.0.0",
+      "model": "ai2/olmo-3-32b-base",
+      "provenance": [],
+      "reasoning_effort": "unspecified",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "index": "vllm-sr/general@1.0.0",
+          "normalized": 0.496,
+          "status": "available",
+          "value": 0.496,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/reasoning@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.4
+        },
+        {
+          "index": "vllm-sr/coding@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/agentic@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        }
+      ],
+      "coverage": 0.2,
+      "index": "vllm-sr/intelligence@1.0.0",
+      "model": "ai2/olmo-3-32b-base",
+      "provenance": [
+        "ai2/olmo-3-32b-base-model-card-mmlu-pro@1.0.0"
+      ],
+      "reasoning_effort": "unspecified",
+      "score": null,
+      "status": "partial"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "tiger-ai-lab/mmlu-pro@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/general@1.0.0",
+      "model": "ai2/olmo-3-1-32b-think",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "cais/humanitys-last-exam@1.0.0",
+          "benchmark_profiles": [
+            "independent-text-only",
+            "text-only"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/reasoning@1.0.0",
+      "model": "ai2/olmo-3-1-32b-think",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "livecodebench/livecodebench@6.0.0",
+          "benchmark_profiles": [
+            "independent-code-generation",
+            "published-code-generation"
+          ],
+          "metric": "pass_at_1",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "scicode-bench/scicode@1.0.0",
+          "benchmark_profiles": [
+            "independent-test-288",
+            "published-standard"
+          ],
+          "metric": "score",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/coding@1.0.0",
+      "model": "ai2/olmo-3-1-32b-think",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "harbor/terminal-bench@2.1.0",
+          "benchmark_profiles": [
+            "independent-agent",
+            "published-agent"
+          ],
+          "metric": "resolved",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/agentic@1.0.0",
+      "model": "ai2/olmo-3-1-32b-think",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "index": "vllm-sr/general@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/reasoning@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.4
+        },
+        {
+          "index": "vllm-sr/coding@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/agentic@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/intelligence@1.0.0",
+      "model": "ai2/olmo-3-1-32b-think",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "tiger-ai-lab/mmlu-pro@1.0.0",
+          "benchmark_profile": "independent-standard",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "evaluation": "independent/olmo-3-1-32b-think-mmlu-pro@1.0.0",
+          "metric": "accuracy",
+          "normalized": 0.763,
+          "status": "available",
+          "value": 0.763,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 1.0,
+      "domains": {
+        "general_reasoning": 76.3
+      },
+      "index": "vllm-sr/general@1.0.0",
+      "model": "ai2/olmo-3-1-32b-think",
+      "provenance": [
+        "independent/olmo-3-1-32b-think-mmlu-pro@1.0.0"
+      ],
+      "reasoning_effort": "enabled",
+      "score": 76.3,
+      "status": "available"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+          "benchmark_profile": "independent-standard",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "evaluation": "independent/olmo-3-1-32b-think-gpqa-diamond@1.0.0",
+          "metric": "accuracy",
+          "normalized": 0.590909090909091,
+          "status": "available",
+          "value": 0.590909090909091,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "cais/humanitys-last-exam@1.0.0",
+          "benchmark_profile": "independent-text-only",
+          "benchmark_profiles": [
+            "independent-text-only",
+            "text-only"
+          ],
+          "evaluation": "independent/olmo-3-1-32b-think-humanitys-last-exam@1.0.0",
+          "metric": "accuracy",
+          "normalized": 0.0625579240037071,
+          "status": "available",
+          "value": 0.0625579240037071,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 1.0,
+      "domains": {
+        "frontier_reasoning": 6.25579240037071,
+        "scientific_reasoning": 59.09090909090911
+      },
+      "index": "vllm-sr/reasoning@1.0.0",
+      "model": "ai2/olmo-3-1-32b-think",
+      "provenance": [
+        "independent/olmo-3-1-32b-think-gpqa-diamond@1.0.0",
+        "independent/olmo-3-1-32b-think-humanitys-last-exam@1.0.0"
+      ],
+      "reasoning_effort": "enabled",
+      "score": 32.67335074563991,
+      "status": "available"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "livecodebench/livecodebench@6.0.0",
+          "benchmark_profile": "independent-code-generation",
+          "benchmark_profiles": [
+            "independent-code-generation",
+            "published-code-generation"
+          ],
+          "evaluation": "independent/olmo-3-1-32b-think-livecodebench-v6@1.0.0",
+          "metric": "pass_at_1",
+          "normalized": 0.695238095238095,
+          "status": "available",
+          "value": 0.695238095238095,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "scicode-bench/scicode@1.0.0",
+          "benchmark_profile": "independent-test-288",
+          "benchmark_profiles": [
+            "independent-test-288",
+            "published-standard"
+          ],
+          "evaluation": "independent/olmo-3-1-32b-think-scicode@1.0.0",
+          "metric": "score",
+          "normalized": 0.293,
+          "status": "available",
+          "value": 0.293,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 1.0,
+      "domains": {
+        "competitive_programming": 69.5238095238095,
+        "scientific_coding": 29.299999999999997
+      },
+      "index": "vllm-sr/coding@1.0.0",
+      "model": "ai2/olmo-3-1-32b-think",
+      "provenance": [
+        "independent/olmo-3-1-32b-think-livecodebench-v6@1.0.0",
+        "independent/olmo-3-1-32b-think-scicode@1.0.0"
+      ],
+      "reasoning_effort": "enabled",
+      "score": 49.411904761904744,
+      "status": "available"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "harbor/terminal-bench@2.1.0",
+          "benchmark_profile": "independent-agent",
+          "benchmark_profiles": [
+            "independent-agent",
+            "published-agent"
+          ],
+          "evaluation": "independent/olmo-3-1-32b-think-terminalbench-v2-1@1.0.0",
+          "metric": "resolved",
+          "normalized": 0.0,
+          "status": "available",
+          "value": 0.0,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 1.0,
+      "domains": {
+        "agentic_systems": 0.0
+      },
+      "index": "vllm-sr/agentic@1.0.0",
+      "model": "ai2/olmo-3-1-32b-think",
+      "provenance": [
+        "independent/olmo-3-1-32b-think-terminalbench-v2-1@1.0.0"
+      ],
+      "reasoning_effort": "enabled",
+      "score": 0.0,
+      "status": "available"
+    },
+    {
+      "components": [
+        {
+          "index": "vllm-sr/general@1.0.0",
+          "normalized": 0.763,
+          "status": "available",
+          "value": 0.763,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/reasoning@1.0.0",
+          "normalized": 0.32673350745639906,
+          "status": "available",
+          "value": 0.32673350745639906,
+          "weight": 0.4
+        },
+        {
+          "index": "vllm-sr/coding@1.0.0",
+          "normalized": 0.49411904761904746,
+          "status": "available",
+          "value": 0.49411904761904746,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/agentic@1.0.0",
+          "normalized": 0.0,
+          "status": "available",
+          "value": 0.0,
+          "weight": 0.2
+        }
+      ],
+      "coverage": 1.0,
+      "index": "vllm-sr/intelligence@1.0.0",
+      "model": "ai2/olmo-3-1-32b-think",
+      "provenance": [
+        "independent/olmo-3-1-32b-think-gpqa-diamond@1.0.0",
+        "independent/olmo-3-1-32b-think-humanitys-last-exam@1.0.0",
+        "independent/olmo-3-1-32b-think-livecodebench-v6@1.0.0",
+        "independent/olmo-3-1-32b-think-mmlu-pro@1.0.0",
+        "independent/olmo-3-1-32b-think-scicode@1.0.0",
+        "independent/olmo-3-1-32b-think-terminalbench-v2-1@1.0.0"
+      ],
+      "reasoning_effort": "enabled",
+      "score": 38.21172125063691,
+      "status": "available"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "tiger-ai-lab/mmlu-pro@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/general@1.0.0",
+      "model": "ai2/olmo-3-1-32b-instruct",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "cais/humanitys-last-exam@1.0.0",
+          "benchmark_profiles": [
+            "independent-text-only",
+            "text-only"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/reasoning@1.0.0",
+      "model": "ai2/olmo-3-1-32b-instruct",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "livecodebench/livecodebench@6.0.0",
+          "benchmark_profiles": [
+            "independent-code-generation",
+            "published-code-generation"
+          ],
+          "metric": "pass_at_1",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "scicode-bench/scicode@1.0.0",
+          "benchmark_profiles": [
+            "independent-test-288",
+            "published-standard"
+          ],
+          "metric": "score",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/coding@1.0.0",
+      "model": "ai2/olmo-3-1-32b-instruct",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "harbor/terminal-bench@2.1.0",
+          "benchmark_profiles": [
+            "independent-agent",
+            "published-agent"
+          ],
+          "metric": "resolved",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/agentic@1.0.0",
+      "model": "ai2/olmo-3-1-32b-instruct",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "index": "vllm-sr/general@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/reasoning@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.4
+        },
+        {
+          "index": "vllm-sr/coding@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/agentic@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/intelligence@1.0.0",
+      "model": "ai2/olmo-3-1-32b-instruct",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "tiger-ai-lab/mmlu-pro@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/general@1.0.0",
+      "model": "ai2/olmo-3-1-32b-instruct",
+      "provenance": [],
+      "reasoning_effort": "unspecified",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+          "benchmark_profile": "published-standard",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "evaluation": "ai2/olmo-3-1-32b-instruct-model-card-gpqa@1.0.0",
+          "metric": "accuracy",
+          "normalized": 0.486,
+          "status": "available",
+          "value": 0.486,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "cais/humanitys-last-exam@1.0.0",
+          "benchmark_profiles": [
+            "independent-text-only",
+            "text-only"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.5,
+      "index": "vllm-sr/reasoning@1.0.0",
+      "model": "ai2/olmo-3-1-32b-instruct",
+      "provenance": [
+        "ai2/olmo-3-1-32b-instruct-model-card-gpqa@1.0.0"
+      ],
+      "reasoning_effort": "unspecified",
+      "score": null,
+      "status": "partial"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "livecodebench/livecodebench@6.0.0",
+          "benchmark_profiles": [
+            "independent-code-generation",
+            "published-code-generation"
+          ],
+          "metric": "pass_at_1",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "scicode-bench/scicode@1.0.0",
+          "benchmark_profiles": [
+            "independent-test-288",
+            "published-standard"
+          ],
+          "metric": "score",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/coding@1.0.0",
+      "model": "ai2/olmo-3-1-32b-instruct",
+      "provenance": [],
+      "reasoning_effort": "unspecified",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "harbor/terminal-bench@2.1.0",
+          "benchmark_profiles": [
+            "independent-agent",
+            "published-agent"
+          ],
+          "metric": "resolved",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/agentic@1.0.0",
+      "model": "ai2/olmo-3-1-32b-instruct",
+      "provenance": [],
+      "reasoning_effort": "unspecified",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "index": "vllm-sr/general@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/reasoning@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.4
+        },
+        {
+          "index": "vllm-sr/coding@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/agentic@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/intelligence@1.0.0",
+      "model": "ai2/olmo-3-1-32b-instruct",
+      "provenance": [
+        "ai2/olmo-3-1-32b-instruct-model-card-gpqa@1.0.0"
+      ],
+      "reasoning_effort": "unspecified",
+      "score": null,
+      "status": "missing"
+    },
     {
       "components": [
         {
@@ -86212,6 +87789,151 @@ const builtInCatalogJSON = `{
     {
       "capabilities": [
         "chat",
+        "long_context"
+      ],
+      "description": "Fully open 32B base language model from Ai2's OLMo 3 family.",
+      "display_name": "OLMo 3 32B Base",
+      "distribution": {
+        "license": "Apache-2.0",
+        "source": "https://huggingface.co/allenai/Olmo-3-1125-32B",
+        "type": "open_weights"
+      },
+      "family": "olmo-3",
+      "id": "ai2/olmo-3-32b-base",
+      "kind": "physical",
+      "lifecycle": "active",
+      "limits": {
+        "context_window_size": 65536
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "parameter_size": "32B",
+      "presentation": {
+        "logo": "package:ai2",
+        "monochrome": false,
+        "monogram": "O"
+      },
+      "publisher": "Ai2 / OLMo",
+      "revision": "c2b61dae89a1ad10e4ad5653d0e46b590902607b",
+      "tags": [
+        "open_weights",
+        "base_model",
+        "long_context"
+      ],
+      "verification": {
+        "authority": "Ai2",
+        "source": "https://huggingface.co/allenai/Olmo-3-1125-32B",
+        "status": "claimed",
+        "verified_at": "2026-09-11"
+      }
+    },
+    {
+      "capabilities": [
+        "chat",
+        "reasoning",
+        "long_context"
+      ],
+      "description": "Fully open 32B reasoning model from Ai2's OLMo 3.1 family.",
+      "display_name": "OLMo 3.1 32B Think",
+      "distribution": {
+        "license": "Apache-2.0",
+        "source": "https://huggingface.co/allenai/Olmo-3.1-32B-Think",
+        "type": "open_weights"
+      },
+      "family": "olmo-3",
+      "id": "ai2/olmo-3-1-32b-think",
+      "kind": "physical",
+      "knowledge_cutoff": "2024-12-01",
+      "lifecycle": "active",
+      "limits": {
+        "context_window_size": 65536,
+        "max_output_tokens": 32768
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "parameter_size": "32B",
+      "presentation": {
+        "logo": "package:ai2",
+        "monochrome": false,
+        "monogram": "O"
+      },
+      "publisher": "Ai2 / OLMo",
+      "revision": "832c3f543499af8fe68b88359501de9cb7840544",
+      "tags": [
+        "open_weights",
+        "reasoning",
+        "long_context"
+      ],
+      "verification": {
+        "authority": "Ai2",
+        "source": "https://huggingface.co/allenai/Olmo-3.1-32B-Think",
+        "status": "claimed",
+        "verified_at": "2026-09-11"
+      }
+    },
+    {
+      "capabilities": [
+        "chat",
+        "long_context"
+      ],
+      "description": "Fully open 32B instruction-tuned model from Ai2's OLMo 3.1 family.",
+      "display_name": "OLMo 3.1 32B Instruct",
+      "distribution": {
+        "license": "Apache-2.0",
+        "source": "https://huggingface.co/allenai/Olmo-3.1-32B-Instruct",
+        "type": "open_weights"
+      },
+      "family": "olmo-3",
+      "id": "ai2/olmo-3-1-32b-instruct",
+      "kind": "physical",
+      "knowledge_cutoff": "2024-12-01",
+      "lifecycle": "active",
+      "limits": {
+        "context_window_size": 65536
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "parameter_size": "32B",
+      "presentation": {
+        "logo": "package:ai2",
+        "monochrome": false,
+        "monogram": "O"
+      },
+      "publisher": "Ai2 / OLMo",
+      "revision": "ac0587e4a7744a551c059d8cd17ba220bc940dae",
+      "tags": [
+        "open_weights",
+        "instruction_tuned",
+        "long_context"
+      ],
+      "verification": {
+        "authority": "Ai2",
+        "source": "https://huggingface.co/allenai/Olmo-3.1-32B-Instruct",
+        "status": "claimed",
+        "verified_at": "2026-09-11"
+      }
+    },
+    {
+      "capabilities": [
+        "chat",
         "tools",
         "structured_output",
         "long_context"
@@ -95561,6 +97283,51 @@ const builtInCatalogJSON = `{
             "source": "https://huggingface.co/ai21labs/AI21-Jamba-Reasoning-3B",
             "status": "claimed",
             "verified_at": "2026-09-05"
+          }
+        },
+        {
+          "catalog": "ai2/olmo-3-32b-base",
+          "id": "allenai/Olmo-3-1125-32B",
+          "lifecycle": "active",
+          "protocols": [
+            "openai/chat-completions@1",
+            "openai/responses@1"
+          ],
+          "relationship": "self_hosted",
+          "verification": {
+            "source": "https://huggingface.co/allenai/Olmo-3-1125-32B",
+            "status": "claimed",
+            "verified_at": "2026-09-11"
+          }
+        },
+        {
+          "catalog": "ai2/olmo-3-1-32b-think",
+          "id": "allenai/Olmo-3.1-32B-Think",
+          "lifecycle": "active",
+          "protocols": [
+            "openai/chat-completions@1",
+            "openai/responses@1"
+          ],
+          "relationship": "self_hosted",
+          "verification": {
+            "source": "https://huggingface.co/allenai/Olmo-3.1-32B-Think",
+            "status": "claimed",
+            "verified_at": "2026-09-11"
+          }
+        },
+        {
+          "catalog": "ai2/olmo-3-1-32b-instruct",
+          "id": "allenai/Olmo-3.1-32B-Instruct",
+          "lifecycle": "active",
+          "protocols": [
+            "openai/chat-completions@1",
+            "openai/responses@1"
+          ],
+          "relationship": "self_hosted",
+          "verification": {
+            "source": "https://huggingface.co/allenai/Olmo-3.1-32B-Instruct",
+            "status": "claimed",
+            "verified_at": "2026-09-11"
           }
         },
         {

--- a/tools/catalog/tests/test_generate_model_catalog.py
+++ b/tools/catalog/tests/test_generate_model_catalog.py
@@ -290,6 +290,31 @@ class ModelCatalogCompilerTests(unittest.TestCase):
             "the official Astra model page does not publish a default effort",
         )
 
+        public_snapshot = json.loads(
+            catalog.render_outputs()[catalog.WEBSITE_OUTPUT]
+        )
+        anchor_profiles = {
+            result["index"]: result
+            for result in public_snapshot["index_results"]
+            if result["model"] == "ai2/olmo-3-1-32b-think"
+            and result["reasoning_effort"] == "enabled"
+        }
+        self.assertEqual(
+            anchor_profiles["vllm-sr/agentic@1.0.0"]["status"],
+            "available",
+        )
+        self.assertEqual(
+            anchor_profiles["vllm-sr/agentic@1.0.0"]["score"],
+            0.0,
+        )
+        self.assertEqual(
+            anchor_profiles["vllm-sr/intelligence@1.0.0"]["status"],
+            "available",
+        )
+        self.assertIsNotNone(
+            anchor_profiles["vllm-sr/intelligence@1.0.0"]["score"]
+        )
+
         providers = {provider["id"]: provider for provider in resources["providers"]}
         binding = next(
             item
@@ -523,6 +548,128 @@ class ModelCatalogCompilerTests(unittest.TestCase):
         self.assertEqual(
             evaluations["independent/ernie-4.5-300b-a47b-critpt@1.0.0"]["metrics"],
             {"score": 0},
+        )
+
+    def test_ai2_olmo_creator_has_exact_evidence_buckets_and_real_bindings(
+        self,
+    ) -> None:
+        manifest, resources, _ = catalog.load_and_validate()
+        olmo_models = [
+            "ai2/olmo-3-32b-base",
+            "ai2/olmo-3-1-32b-think",
+            "ai2/olmo-3-1-32b-instruct",
+        ]
+        olmo_model_set = set(olmo_models)
+        creators = {
+            creator["publisher"]: creator["representative_models"]
+            for creator in manifest["inventory"]["physical"]["creators"]
+        }
+        self.assertEqual(creators["Ai2 / OLMo"], olmo_models)
+
+        models = {model["id"]: model for model in resources["models"]}
+        self.assertEqual(
+            {models[model_id]["publisher"] for model_id in olmo_models},
+            {"Ai2 / OLMo"},
+        )
+        self.assertEqual(
+            {model_id: models[model_id]["revision"] for model_id in olmo_models},
+            {
+                "ai2/olmo-3-32b-base": "c2b61dae89a1ad10e4ad5653d0e46b590902607b",
+                "ai2/olmo-3-1-32b-think": "832c3f543499af8fe68b88359501de9cb7840544",
+                "ai2/olmo-3-1-32b-instruct": "ac0587e4a7744a551c059d8cd17ba220bc940dae",
+            },
+        )
+
+        buckets = _evaluation_benchmarks_by_bucket(resources, olmo_model_set)
+        self.assertGreaterEqual(
+            len(buckets[("ai2/olmo-3-32b-base", "unspecified", "vendor_claimed")]),
+            5,
+        )
+        self.assertGreaterEqual(
+            len(
+                buckets[
+                    ("ai2/olmo-3-1-32b-think", "enabled", "vendor_claimed")
+                ]
+            ),
+            5,
+        )
+        self.assertGreaterEqual(
+            len(
+                buckets[
+                    ("ai2/olmo-3-1-32b-instruct", "unspecified", "vendor_claimed")
+                ]
+            ),
+            5,
+        )
+
+        anchor_benchmarks = {
+            "tiger-ai-lab/mmlu-pro@1.0.0",
+            "idavidrein/gpqa-diamond@1.0.0",
+            "cais/humanitys-last-exam@1.0.0",
+            "livecodebench/livecodebench@6.0.0",
+            "scicode-bench/scicode@1.0.0",
+            "harbor/terminal-bench@2.1.0",
+        }
+        self.assertEqual(
+            buckets[("ai2/olmo-3-1-32b-think", "enabled", "third_party")],
+            anchor_benchmarks,
+        )
+        anchor_evaluations = [
+            evaluation
+            for evaluation in resources["evaluations"]
+            if evaluation["model"] == "ai2/olmo-3-1-32b-think"
+            and evaluation["evidence"]["provenance"] == "third_party"
+        ]
+        self.assertEqual(len(anchor_evaluations), 6)
+        self.assertTrue(
+            all(
+                evaluation["subject"]["model_revision"]
+                == "832c3f543499af8fe68b88359501de9cb7840544"
+                and evaluation["subject"]["task_count"] > 0
+                and evaluation["subject"]["task_artifact"].startswith("https://")
+                and evaluation["subject"]["cost_usd"] is None
+                and evaluation["subject"]["latency_ms"] is None
+                for evaluation in anchor_evaluations
+            )
+        )
+        terminal_evaluation = next(
+            evaluation
+            for evaluation in anchor_evaluations
+            if evaluation["benchmark"] == "harbor/terminal-bench@2.1.0"
+        )
+        self.assertEqual(terminal_evaluation["benchmark_profile"], "independent-agent")
+        self.assertEqual(terminal_evaluation["subject"]["dataset_release"], "v2.1")
+        self.assertEqual(terminal_evaluation["subject"]["task_count"], 89)
+        self.assertEqual(terminal_evaluation["metrics"], {"resolved": 0.0})
+
+        providers = {provider["id"]: provider for provider in resources["providers"]}
+        vllm_bindings = {
+            binding["catalog"]: binding
+            for binding in providers["vllm"]["models"]
+            if binding["catalog"] in olmo_model_set
+        }
+        self.assertEqual(
+            {model_id: vllm_bindings[model_id]["id"] for model_id in olmo_models},
+            {
+                "ai2/olmo-3-32b-base": "allenai/Olmo-3-1125-32B",
+                "ai2/olmo-3-1-32b-think": "allenai/Olmo-3.1-32B-Think",
+                "ai2/olmo-3-1-32b-instruct": "allenai/Olmo-3.1-32B-Instruct",
+            },
+        )
+        self.assertTrue(
+            all(
+                binding["relationship"] == "self_hosted"
+                for binding in vllm_bindings.values()
+            )
+        )
+        self.assertTrue(
+            all(
+                evaluation["subject"].get("model_revision")
+                == "832c3f543499af8fe68b88359501de9cb7840544"
+                for evaluation in resources["evaluations"]
+                if evaluation["model"] == "ai2/olmo-3-1-32b-think"
+                and evaluation["evidence"]["provenance"] == "third_party"
+            )
         )
 
     def test_stepfun_creator_has_exact_efforts_and_real_bindings(self) -> None:

--- a/website/static/model-catalog/catalog.json
+++ b/website/static/model-catalog/catalog.json
@@ -1459,6 +1459,11 @@
       ],
       "profiles": [
         {
+          "description": "Source-published MedMCQA multiple-choice accuracy using the evaluated model's documented setup.",
+          "display_name": "Published standard",
+          "id": "published-standard"
+        },
+        {
           "description": "Validation accuracy averaged across the original answer order and the two published Medmarks v1 shuffle seeds.",
           "display_name": "Medmarks v1 three-order average",
           "id": "medmarks-v1-three-order-average"
@@ -1488,6 +1493,11 @@
         }
       ],
       "profiles": [
+        {
+          "description": "Source-published MedQA USMLE four-option accuracy using the evaluated model's documented setup.",
+          "display_name": "Published standard",
+          "id": "published-standard"
+        },
         {
           "description": "Test accuracy averaged across the original answer order and the two published Medmarks v1 shuffle seeds.",
           "display_name": "Medmarks v1 three-order average",
@@ -1614,12 +1624,42 @@
       ],
       "profiles": [
         {
+          "description": "Source-published BIG-Bench Hard accuracy using the model card's documented standard setup.",
+          "display_name": "Published standard",
+          "id": "published-standard"
+        },
+        {
           "description": "Accuracy over valid generated outputs in the EACL 2026 RMCB test protocol; filtering counts and dataset revision remain on the evaluation record.",
           "display_name": "RMCB EACL 2026 valid-output test",
           "id": "rmcb-eacl-2026-valid-output-test"
         }
       ],
       "source": "https://github.com/suzgunmirac/BIG-Bench-Hard"
+    },
+    {
+      "default_profile": "published-standard",
+      "display_name": "BigCodeBench",
+      "domain": "code_generation",
+      "id": "bigcode-project/bigcodebench@1.0.0",
+      "metrics": [
+        {
+          "direction": "higher_is_better",
+          "id": "pass_at_1",
+          "range": [
+            0,
+            1
+          ],
+          "unit": "proportion"
+        }
+      ],
+      "profiles": [
+        {
+          "description": "Source-published BigCodeBench pass@1 with the evaluated model variant retained on the record.",
+          "display_name": "Published standard",
+          "id": "published-standard"
+        }
+      ],
+      "source": "https://github.com/bigcode-project/bigcodebench"
     },
     {
       "default_profile": "published-standard",
@@ -1833,6 +1873,555 @@
     }
   ],
   "evaluations": [
+    {
+      "benchmark": "tiger-ai-lab/mmlu-pro@1.0.0",
+      "benchmark_profile": "published-standard",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/allenai/Olmo-3-1125-32B/blob/c2b61dae89a1ad10e4ad5653d0e46b590902607b/README.md",
+        "verification": "claimed"
+      },
+      "id": "ai2/olmo-3-32b-base-model-card-mmlu-pro@1.0.0",
+      "metrics": {
+        "accuracy": 0.496
+      },
+      "model": "ai2/olmo-3-32b-base",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "dataset_variant": "MMLU-Pro MC",
+        "model_revision": "c2b61dae89a1ad10e4ad5653d0e46b590902607b",
+        "source_kind": "official_model_card",
+        "variant": "OLMo 3 32B Base"
+      }
+    },
+    {
+      "benchmark": "maveriq/bigbenchhard@1.0.0",
+      "benchmark_profile": "published-standard",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/allenai/Olmo-3-1125-32B/blob/c2b61dae89a1ad10e4ad5653d0e46b590902607b/README.md",
+        "verification": "claimed"
+      },
+      "id": "ai2/olmo-3-32b-base-model-card-bbh@1.0.0",
+      "metrics": {
+        "accuracy": 0.776
+      },
+      "model": "ai2/olmo-3-32b-base",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "model_revision": "c2b61dae89a1ad10e4ad5653d0e46b590902607b",
+        "source_kind": "official_model_card",
+        "variant": "OLMo 3 32B Base"
+      }
+    },
+    {
+      "benchmark": "bigcode-project/bigcodebench@1.0.0",
+      "benchmark_profile": "published-standard",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/allenai/Olmo-3-1125-32B/blob/c2b61dae89a1ad10e4ad5653d0e46b590902607b/README.md",
+        "verification": "claimed"
+      },
+      "id": "ai2/olmo-3-32b-base-model-card-bigcodebench@1.0.0",
+      "metrics": {
+        "pass_at_1": 0.439
+      },
+      "model": "ai2/olmo-3-32b-base",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "model_revision": "c2b61dae89a1ad10e4ad5653d0e46b590902607b",
+        "source_kind": "official_model_card",
+        "variant": "OLMo 3 32B Base"
+      }
+    },
+    {
+      "benchmark": "openlifescienceai/medmcqa@1.0.0",
+      "benchmark_profile": "published-standard",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/allenai/Olmo-3-1125-32B/blob/c2b61dae89a1ad10e4ad5653d0e46b590902607b/README.md",
+        "verification": "claimed"
+      },
+      "id": "ai2/olmo-3-32b-base-model-card-medmcqa@1.0.0",
+      "metrics": {
+        "accuracy": 0.576
+      },
+      "model": "ai2/olmo-3-32b-base",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "dataset_variant": "MedMCQA MC",
+        "model_revision": "c2b61dae89a1ad10e4ad5653d0e46b590902607b",
+        "source_kind": "official_model_card",
+        "variant": "OLMo 3 32B Base"
+      }
+    },
+    {
+      "benchmark": "gbaker/medqa-usmle@1.0.0",
+      "benchmark_profile": "published-standard",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/allenai/Olmo-3-1125-32B/blob/c2b61dae89a1ad10e4ad5653d0e46b590902607b/README.md",
+        "verification": "claimed"
+      },
+      "id": "ai2/olmo-3-32b-base-model-card-medqa@1.0.0",
+      "metrics": {
+        "accuracy": 0.538
+      },
+      "model": "ai2/olmo-3-32b-base",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "dataset_variant": "MedQA MC",
+        "model_revision": "c2b61dae89a1ad10e4ad5653d0e46b590902607b",
+        "source_kind": "official_model_card",
+        "variant": "OLMo 3 32B Base"
+      }
+    },
+    {
+      "benchmark": "hendrycks/math@1.0.0",
+      "benchmark_profile": "published-standard",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/allenai/Olmo-3.1-32B-Think/blob/832c3f543499af8fe68b88359501de9cb7840544/README.md",
+        "verification": "claimed"
+      },
+      "id": "ai2/olmo-3-1-32b-think-model-card-math@1.0.0",
+      "metrics": {
+        "accuracy": 0.962
+      },
+      "model": "ai2/olmo-3-1-32b-think",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "maximum_output_tokens": 32768,
+        "model_revision": "832c3f543499af8fe68b88359501de9cb7840544",
+        "sampling_temperature": 0.6,
+        "sampling_top_p": 0.95,
+        "source_kind": "official_model_card",
+        "variant": "OLMo 3.1 32B Think"
+      }
+    },
+    {
+      "benchmark": "matharena/aime@2024.0.0",
+      "benchmark_profile": "pass-at-1",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/allenai/Olmo-3.1-32B-Think/blob/832c3f543499af8fe68b88359501de9cb7840544/README.md",
+        "verification": "claimed"
+      },
+      "id": "ai2/olmo-3-1-32b-think-model-card-aime-2024@1.0.0",
+      "metrics": {
+        "pass_at_1": 0.806
+      },
+      "model": "ai2/olmo-3-1-32b-think",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "maximum_output_tokens": 32768,
+        "model_revision": "832c3f543499af8fe68b88359501de9cb7840544",
+        "sampling_temperature": 0.6,
+        "sampling_top_p": 0.95,
+        "source_kind": "official_model_card",
+        "variant": "OLMo 3.1 32B Think"
+      }
+    },
+    {
+      "benchmark": "matharena/aime@2025.0.0",
+      "benchmark_profile": "pass-at-1",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/allenai/Olmo-3.1-32B-Think/blob/832c3f543499af8fe68b88359501de9cb7840544/README.md",
+        "verification": "claimed"
+      },
+      "id": "ai2/olmo-3-1-32b-think-model-card-aime-2025@1.0.0",
+      "metrics": {
+        "pass_at_1": 0.781
+      },
+      "model": "ai2/olmo-3-1-32b-think",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "maximum_output_tokens": 32768,
+        "model_revision": "832c3f543499af8fe68b88359501de9cb7840544",
+        "sampling_temperature": 0.6,
+        "sampling_top_p": 0.95,
+        "source_kind": "official_model_card",
+        "variant": "OLMo 3.1 32B Think"
+      }
+    },
+    {
+      "benchmark": "google/ifeval@1.0.0",
+      "benchmark_profile": "published-standard",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/allenai/Olmo-3.1-32B-Think/blob/832c3f543499af8fe68b88359501de9cb7840544/README.md",
+        "verification": "claimed"
+      },
+      "id": "ai2/olmo-3-1-32b-think-model-card-ifeval@1.0.0",
+      "metrics": {
+        "accuracy": 0.938
+      },
+      "model": "ai2/olmo-3-1-32b-think",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "maximum_output_tokens": 32768,
+        "model_revision": "832c3f543499af8fe68b88359501de9cb7840544",
+        "sampling_temperature": 0.6,
+        "sampling_top_p": 0.95,
+        "source_kind": "official_model_card",
+        "variant": "OLMo 3.1 32B Think"
+      }
+    },
+    {
+      "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+      "benchmark_profile": "published-standard",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/allenai/Olmo-3.1-32B-Think/blob/832c3f543499af8fe68b88359501de9cb7840544/README.md",
+        "verification": "claimed"
+      },
+      "id": "ai2/olmo-3-1-32b-think-model-card-gpqa@1.0.0",
+      "metrics": {
+        "accuracy": 0.575
+      },
+      "model": "ai2/olmo-3-1-32b-think",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "maximum_output_tokens": 32768,
+        "model_revision": "832c3f543499af8fe68b88359501de9cb7840544",
+        "sampling_temperature": 0.6,
+        "sampling_top_p": 0.95,
+        "source_kind": "official_model_card",
+        "variant": "OLMo 3.1 32B Think"
+      }
+    },
+    {
+      "benchmark": "hendrycks/math@1.0.0",
+      "benchmark_profile": "published-standard",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/allenai/Olmo-3.1-32B-Instruct/blob/ac0587e4a7744a551c059d8cd17ba220bc940dae/README.md",
+        "verification": "claimed"
+      },
+      "id": "ai2/olmo-3-1-32b-instruct-model-card-math@1.0.0",
+      "metrics": {
+        "accuracy": 0.934
+      },
+      "model": "ai2/olmo-3-1-32b-instruct",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "model_revision": "ac0587e4a7744a551c059d8cd17ba220bc940dae",
+        "source_kind": "official_model_card",
+        "variant": "OLMo 3.1 32B Instruct"
+      }
+    },
+    {
+      "benchmark": "matharena/aime@2024.0.0",
+      "benchmark_profile": "pass-at-1",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/allenai/Olmo-3.1-32B-Instruct/blob/ac0587e4a7744a551c059d8cd17ba220bc940dae/README.md",
+        "verification": "claimed"
+      },
+      "id": "ai2/olmo-3-1-32b-instruct-model-card-aime-2024@1.0.0",
+      "metrics": {
+        "pass_at_1": 0.678
+      },
+      "model": "ai2/olmo-3-1-32b-instruct",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "model_revision": "ac0587e4a7744a551c059d8cd17ba220bc940dae",
+        "source_kind": "official_model_card",
+        "variant": "OLMo 3.1 32B Instruct"
+      }
+    },
+    {
+      "benchmark": "matharena/aime@2025.0.0",
+      "benchmark_profile": "pass-at-1",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/allenai/Olmo-3.1-32B-Instruct/blob/ac0587e4a7744a551c059d8cd17ba220bc940dae/README.md",
+        "verification": "claimed"
+      },
+      "id": "ai2/olmo-3-1-32b-instruct-model-card-aime-2025@1.0.0",
+      "metrics": {
+        "pass_at_1": 0.579
+      },
+      "model": "ai2/olmo-3-1-32b-instruct",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "model_revision": "ac0587e4a7744a551c059d8cd17ba220bc940dae",
+        "source_kind": "official_model_card",
+        "variant": "OLMo 3.1 32B Instruct"
+      }
+    },
+    {
+      "benchmark": "google/ifeval@1.0.0",
+      "benchmark_profile": "published-standard",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/allenai/Olmo-3.1-32B-Instruct/blob/ac0587e4a7744a551c059d8cd17ba220bc940dae/README.md",
+        "verification": "claimed"
+      },
+      "id": "ai2/olmo-3-1-32b-instruct-model-card-ifeval@1.0.0",
+      "metrics": {
+        "accuracy": 0.888
+      },
+      "model": "ai2/olmo-3-1-32b-instruct",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "model_revision": "ac0587e4a7744a551c059d8cd17ba220bc940dae",
+        "source_kind": "official_model_card",
+        "variant": "OLMo 3.1 32B Instruct"
+      }
+    },
+    {
+      "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+      "benchmark_profile": "published-standard",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/allenai/Olmo-3.1-32B-Instruct/blob/ac0587e4a7744a551c059d8cd17ba220bc940dae/README.md",
+        "verification": "claimed"
+      },
+      "id": "ai2/olmo-3-1-32b-instruct-model-card-gpqa@1.0.0",
+      "metrics": {
+        "accuracy": 0.486
+      },
+      "model": "ai2/olmo-3-1-32b-instruct",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "unspecified",
+      "status": "available",
+      "subject": {
+        "model_revision": "ac0587e4a7744a551c059d8cd17ba220bc940dae",
+        "source_kind": "official_model_card",
+        "variant": "OLMo 3.1 32B Instruct"
+      }
+    },
+    {
+      "benchmark": "tiger-ai-lab/mmlu-pro@1.0.0",
+      "benchmark_profile": "independent-standard",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/mmlu-pro",
+        "verification": "imported"
+      },
+      "id": "independent/olmo-3-1-32b-think-mmlu-pro@1.0.0",
+      "metrics": {
+        "accuracy": 0.763
+      },
+      "model": "ai2/olmo-3-1-32b-think",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "cost_usd": null,
+        "dataset_release": "v1",
+        "evaluation_harness": "Artificial Analysis",
+        "latency_ms": null,
+        "model_revision": "832c3f543499af8fe68b88359501de9cb7840544",
+        "run_kind": "independent",
+        "source_kind": "independent_evaluation",
+        "source_model": "OLMo 3.1 32B Think",
+        "source_model_slug": "olmo-3-1-32b-think",
+        "task_artifact": "https://artificialanalysis.ai/evaluations/mmlu-pro",
+        "task_count": 12000
+      }
+    },
+    {
+      "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+      "benchmark_profile": "independent-standard",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/gpqa-diamond",
+        "verification": "imported"
+      },
+      "id": "independent/olmo-3-1-32b-think-gpqa-diamond@1.0.0",
+      "metrics": {
+        "accuracy": 0.590909090909091
+      },
+      "model": "ai2/olmo-3-1-32b-think",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "cost_usd": null,
+        "dataset_release": "diamond",
+        "evaluation_harness": "Artificial Analysis",
+        "latency_ms": null,
+        "model_revision": "832c3f543499af8fe68b88359501de9cb7840544",
+        "run_kind": "independent",
+        "source_kind": "independent_evaluation",
+        "source_model": "OLMo 3.1 32B Think",
+        "source_model_slug": "olmo-3-1-32b-think",
+        "task_artifact": "https://artificialanalysis.ai/evaluations/gpqa-diamond",
+        "task_count": 198
+      }
+    },
+    {
+      "benchmark": "cais/humanitys-last-exam@1.0.0",
+      "benchmark_profile": "independent-text-only",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/humanitys-last-exam",
+        "verification": "imported"
+      },
+      "id": "independent/olmo-3-1-32b-think-humanitys-last-exam@1.0.0",
+      "metrics": {
+        "accuracy": 0.0625579240037071
+      },
+      "model": "ai2/olmo-3-1-32b-think",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "cost_usd": null,
+        "dataset_release": "v1",
+        "evaluation_harness": "Artificial Analysis",
+        "latency_ms": null,
+        "model_revision": "832c3f543499af8fe68b88359501de9cb7840544",
+        "run_kind": "independent",
+        "source_kind": "independent_evaluation",
+        "source_model": "OLMo 3.1 32B Think",
+        "source_model_slug": "olmo-3-1-32b-think",
+        "task_artifact": "https://artificialanalysis.ai/evaluations/humanitys-last-exam",
+        "task_count": 2500
+      }
+    },
+    {
+      "benchmark": "livecodebench/livecodebench@6.0.0",
+      "benchmark_profile": "independent-code-generation",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/livecodebench",
+        "verification": "imported"
+      },
+      "id": "independent/olmo-3-1-32b-think-livecodebench-v6@1.0.0",
+      "metrics": {
+        "pass_at_1": 0.695238095238095
+      },
+      "model": "ai2/olmo-3-1-32b-think",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "cost_usd": null,
+        "dataset_release": "v6",
+        "evaluation_harness": "Artificial Analysis",
+        "latency_ms": null,
+        "model_revision": "832c3f543499af8fe68b88359501de9cb7840544",
+        "run_kind": "independent",
+        "source_kind": "independent_evaluation",
+        "source_model": "OLMo 3.1 32B Think",
+        "source_model_slug": "olmo-3-1-32b-think",
+        "task_artifact": "https://artificialanalysis.ai/evaluations/livecodebench",
+        "task_count": 1055
+      }
+    },
+    {
+      "benchmark": "scicode-bench/scicode@1.0.0",
+      "benchmark_profile": "independent-test-288",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/scicode",
+        "verification": "imported"
+      },
+      "id": "independent/olmo-3-1-32b-think-scicode@1.0.0",
+      "metrics": {
+        "score": 0.293
+      },
+      "model": "ai2/olmo-3-1-32b-think",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "cost_usd": null,
+        "dataset_release": "test",
+        "evaluation_harness": "Artificial Analysis",
+        "latency_ms": null,
+        "model_revision": "832c3f543499af8fe68b88359501de9cb7840544",
+        "run_kind": "independent",
+        "source_kind": "independent_evaluation",
+        "source_model": "OLMo 3.1 32B Think",
+        "source_model_slug": "olmo-3-1-32b-think",
+        "task_artifact": "https://artificialanalysis.ai/evaluations/scicode",
+        "task_count": 288
+      }
+    },
+    {
+      "benchmark": "harbor/terminal-bench@2.1.0",
+      "benchmark_profile": "independent-agent",
+      "evidence": {
+        "provenance": "third_party",
+        "redistributable": true,
+        "source": "https://artificialanalysis.ai/evaluations/terminalbench-v2-1",
+        "verification": "imported"
+      },
+      "id": "independent/olmo-3-1-32b-think-terminalbench-v2-1@1.0.0",
+      "metrics": {
+        "resolved": 0.0
+      },
+      "model": "ai2/olmo-3-1-32b-think",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "cost_usd": null,
+        "dataset_release": "v2.1",
+        "evaluation_harness": "Artificial Analysis",
+        "latency_ms": null,
+        "model_revision": "832c3f543499af8fe68b88359501de9cb7840544",
+        "run_kind": "independent",
+        "source_kind": "independent_evaluation",
+        "source_model": "OLMo 3.1 32B Think",
+        "source_model_slug": "olmo-3-1-32b-think",
+        "task_artifact": "https://github.com/harbor-framework/terminal-bench-2-1",
+        "task_count": 89
+      }
+    },
     {
       "benchmark": "hpai-bsc/careqa@1.0.0",
       "benchmark_profile": "medmarks-v1-three-order-average",
@@ -37144,6 +37733,994 @@
     }
   ],
   "index_results": [
+    {
+      "components": [
+        {
+          "benchmark": "tiger-ai-lab/mmlu-pro@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/general@1.0.0",
+      "model": "ai2/olmo-3-32b-base",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "cais/humanitys-last-exam@1.0.0",
+          "benchmark_profiles": [
+            "independent-text-only",
+            "text-only"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/reasoning@1.0.0",
+      "model": "ai2/olmo-3-32b-base",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "livecodebench/livecodebench@6.0.0",
+          "benchmark_profiles": [
+            "independent-code-generation",
+            "published-code-generation"
+          ],
+          "metric": "pass_at_1",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "scicode-bench/scicode@1.0.0",
+          "benchmark_profiles": [
+            "independent-test-288",
+            "published-standard"
+          ],
+          "metric": "score",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/coding@1.0.0",
+      "model": "ai2/olmo-3-32b-base",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "harbor/terminal-bench@2.1.0",
+          "benchmark_profiles": [
+            "independent-agent",
+            "published-agent"
+          ],
+          "metric": "resolved",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/agentic@1.0.0",
+      "model": "ai2/olmo-3-32b-base",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "index": "vllm-sr/general@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/reasoning@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.4
+        },
+        {
+          "index": "vllm-sr/coding@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/agentic@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/intelligence@1.0.0",
+      "model": "ai2/olmo-3-32b-base",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "tiger-ai-lab/mmlu-pro@1.0.0",
+          "benchmark_profile": "published-standard",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "evaluation": "ai2/olmo-3-32b-base-model-card-mmlu-pro@1.0.0",
+          "metric": "accuracy",
+          "normalized": 0.496,
+          "status": "available",
+          "value": 0.496,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 1.0,
+      "domains": {
+        "general_reasoning": 49.6
+      },
+      "index": "vllm-sr/general@1.0.0",
+      "model": "ai2/olmo-3-32b-base",
+      "provenance": [
+        "ai2/olmo-3-32b-base-model-card-mmlu-pro@1.0.0"
+      ],
+      "reasoning_effort": "unspecified",
+      "score": 49.6,
+      "status": "available"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "cais/humanitys-last-exam@1.0.0",
+          "benchmark_profiles": [
+            "independent-text-only",
+            "text-only"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/reasoning@1.0.0",
+      "model": "ai2/olmo-3-32b-base",
+      "provenance": [],
+      "reasoning_effort": "unspecified",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "livecodebench/livecodebench@6.0.0",
+          "benchmark_profiles": [
+            "independent-code-generation",
+            "published-code-generation"
+          ],
+          "metric": "pass_at_1",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "scicode-bench/scicode@1.0.0",
+          "benchmark_profiles": [
+            "independent-test-288",
+            "published-standard"
+          ],
+          "metric": "score",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/coding@1.0.0",
+      "model": "ai2/olmo-3-32b-base",
+      "provenance": [],
+      "reasoning_effort": "unspecified",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "harbor/terminal-bench@2.1.0",
+          "benchmark_profiles": [
+            "independent-agent",
+            "published-agent"
+          ],
+          "metric": "resolved",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/agentic@1.0.0",
+      "model": "ai2/olmo-3-32b-base",
+      "provenance": [],
+      "reasoning_effort": "unspecified",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "index": "vllm-sr/general@1.0.0",
+          "normalized": 0.496,
+          "status": "available",
+          "value": 0.496,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/reasoning@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.4
+        },
+        {
+          "index": "vllm-sr/coding@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/agentic@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        }
+      ],
+      "coverage": 0.2,
+      "index": "vllm-sr/intelligence@1.0.0",
+      "model": "ai2/olmo-3-32b-base",
+      "provenance": [
+        "ai2/olmo-3-32b-base-model-card-mmlu-pro@1.0.0"
+      ],
+      "reasoning_effort": "unspecified",
+      "score": null,
+      "status": "partial"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "tiger-ai-lab/mmlu-pro@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/general@1.0.0",
+      "model": "ai2/olmo-3-1-32b-think",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "cais/humanitys-last-exam@1.0.0",
+          "benchmark_profiles": [
+            "independent-text-only",
+            "text-only"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/reasoning@1.0.0",
+      "model": "ai2/olmo-3-1-32b-think",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "livecodebench/livecodebench@6.0.0",
+          "benchmark_profiles": [
+            "independent-code-generation",
+            "published-code-generation"
+          ],
+          "metric": "pass_at_1",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "scicode-bench/scicode@1.0.0",
+          "benchmark_profiles": [
+            "independent-test-288",
+            "published-standard"
+          ],
+          "metric": "score",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/coding@1.0.0",
+      "model": "ai2/olmo-3-1-32b-think",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "harbor/terminal-bench@2.1.0",
+          "benchmark_profiles": [
+            "independent-agent",
+            "published-agent"
+          ],
+          "metric": "resolved",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/agentic@1.0.0",
+      "model": "ai2/olmo-3-1-32b-think",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "index": "vllm-sr/general@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/reasoning@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.4
+        },
+        {
+          "index": "vllm-sr/coding@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/agentic@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/intelligence@1.0.0",
+      "model": "ai2/olmo-3-1-32b-think",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "tiger-ai-lab/mmlu-pro@1.0.0",
+          "benchmark_profile": "independent-standard",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "evaluation": "independent/olmo-3-1-32b-think-mmlu-pro@1.0.0",
+          "metric": "accuracy",
+          "normalized": 0.763,
+          "status": "available",
+          "value": 0.763,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 1.0,
+      "domains": {
+        "general_reasoning": 76.3
+      },
+      "index": "vllm-sr/general@1.0.0",
+      "model": "ai2/olmo-3-1-32b-think",
+      "provenance": [
+        "independent/olmo-3-1-32b-think-mmlu-pro@1.0.0"
+      ],
+      "reasoning_effort": "enabled",
+      "score": 76.3,
+      "status": "available"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+          "benchmark_profile": "independent-standard",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "evaluation": "independent/olmo-3-1-32b-think-gpqa-diamond@1.0.0",
+          "metric": "accuracy",
+          "normalized": 0.590909090909091,
+          "status": "available",
+          "value": 0.590909090909091,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "cais/humanitys-last-exam@1.0.0",
+          "benchmark_profile": "independent-text-only",
+          "benchmark_profiles": [
+            "independent-text-only",
+            "text-only"
+          ],
+          "evaluation": "independent/olmo-3-1-32b-think-humanitys-last-exam@1.0.0",
+          "metric": "accuracy",
+          "normalized": 0.0625579240037071,
+          "status": "available",
+          "value": 0.0625579240037071,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 1.0,
+      "domains": {
+        "frontier_reasoning": 6.25579240037071,
+        "scientific_reasoning": 59.09090909090911
+      },
+      "index": "vllm-sr/reasoning@1.0.0",
+      "model": "ai2/olmo-3-1-32b-think",
+      "provenance": [
+        "independent/olmo-3-1-32b-think-gpqa-diamond@1.0.0",
+        "independent/olmo-3-1-32b-think-humanitys-last-exam@1.0.0"
+      ],
+      "reasoning_effort": "enabled",
+      "score": 32.67335074563991,
+      "status": "available"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "livecodebench/livecodebench@6.0.0",
+          "benchmark_profile": "independent-code-generation",
+          "benchmark_profiles": [
+            "independent-code-generation",
+            "published-code-generation"
+          ],
+          "evaluation": "independent/olmo-3-1-32b-think-livecodebench-v6@1.0.0",
+          "metric": "pass_at_1",
+          "normalized": 0.695238095238095,
+          "status": "available",
+          "value": 0.695238095238095,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "scicode-bench/scicode@1.0.0",
+          "benchmark_profile": "independent-test-288",
+          "benchmark_profiles": [
+            "independent-test-288",
+            "published-standard"
+          ],
+          "evaluation": "independent/olmo-3-1-32b-think-scicode@1.0.0",
+          "metric": "score",
+          "normalized": 0.293,
+          "status": "available",
+          "value": 0.293,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 1.0,
+      "domains": {
+        "competitive_programming": 69.5238095238095,
+        "scientific_coding": 29.299999999999997
+      },
+      "index": "vllm-sr/coding@1.0.0",
+      "model": "ai2/olmo-3-1-32b-think",
+      "provenance": [
+        "independent/olmo-3-1-32b-think-livecodebench-v6@1.0.0",
+        "independent/olmo-3-1-32b-think-scicode@1.0.0"
+      ],
+      "reasoning_effort": "enabled",
+      "score": 49.411904761904744,
+      "status": "available"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "harbor/terminal-bench@2.1.0",
+          "benchmark_profile": "independent-agent",
+          "benchmark_profiles": [
+            "independent-agent",
+            "published-agent"
+          ],
+          "evaluation": "independent/olmo-3-1-32b-think-terminalbench-v2-1@1.0.0",
+          "metric": "resolved",
+          "normalized": 0.0,
+          "status": "available",
+          "value": 0.0,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 1.0,
+      "domains": {
+        "agentic_systems": 0.0
+      },
+      "index": "vllm-sr/agentic@1.0.0",
+      "model": "ai2/olmo-3-1-32b-think",
+      "provenance": [
+        "independent/olmo-3-1-32b-think-terminalbench-v2-1@1.0.0"
+      ],
+      "reasoning_effort": "enabled",
+      "score": 0.0,
+      "status": "available"
+    },
+    {
+      "components": [
+        {
+          "index": "vllm-sr/general@1.0.0",
+          "normalized": 0.763,
+          "status": "available",
+          "value": 0.763,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/reasoning@1.0.0",
+          "normalized": 0.32673350745639906,
+          "status": "available",
+          "value": 0.32673350745639906,
+          "weight": 0.4
+        },
+        {
+          "index": "vllm-sr/coding@1.0.0",
+          "normalized": 0.49411904761904746,
+          "status": "available",
+          "value": 0.49411904761904746,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/agentic@1.0.0",
+          "normalized": 0.0,
+          "status": "available",
+          "value": 0.0,
+          "weight": 0.2
+        }
+      ],
+      "coverage": 1.0,
+      "index": "vllm-sr/intelligence@1.0.0",
+      "model": "ai2/olmo-3-1-32b-think",
+      "provenance": [
+        "independent/olmo-3-1-32b-think-gpqa-diamond@1.0.0",
+        "independent/olmo-3-1-32b-think-humanitys-last-exam@1.0.0",
+        "independent/olmo-3-1-32b-think-livecodebench-v6@1.0.0",
+        "independent/olmo-3-1-32b-think-mmlu-pro@1.0.0",
+        "independent/olmo-3-1-32b-think-scicode@1.0.0",
+        "independent/olmo-3-1-32b-think-terminalbench-v2-1@1.0.0"
+      ],
+      "reasoning_effort": "enabled",
+      "score": 38.21172125063691,
+      "status": "available"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "tiger-ai-lab/mmlu-pro@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/general@1.0.0",
+      "model": "ai2/olmo-3-1-32b-instruct",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "cais/humanitys-last-exam@1.0.0",
+          "benchmark_profiles": [
+            "independent-text-only",
+            "text-only"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/reasoning@1.0.0",
+      "model": "ai2/olmo-3-1-32b-instruct",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "livecodebench/livecodebench@6.0.0",
+          "benchmark_profiles": [
+            "independent-code-generation",
+            "published-code-generation"
+          ],
+          "metric": "pass_at_1",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "scicode-bench/scicode@1.0.0",
+          "benchmark_profiles": [
+            "independent-test-288",
+            "published-standard"
+          ],
+          "metric": "score",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/coding@1.0.0",
+      "model": "ai2/olmo-3-1-32b-instruct",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "harbor/terminal-bench@2.1.0",
+          "benchmark_profiles": [
+            "independent-agent",
+            "published-agent"
+          ],
+          "metric": "resolved",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/agentic@1.0.0",
+      "model": "ai2/olmo-3-1-32b-instruct",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "index": "vllm-sr/general@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/reasoning@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.4
+        },
+        {
+          "index": "vllm-sr/coding@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/agentic@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/intelligence@1.0.0",
+      "model": "ai2/olmo-3-1-32b-instruct",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "tiger-ai-lab/mmlu-pro@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/general@1.0.0",
+      "model": "ai2/olmo-3-1-32b-instruct",
+      "provenance": [],
+      "reasoning_effort": "unspecified",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+          "benchmark_profile": "published-standard",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "evaluation": "ai2/olmo-3-1-32b-instruct-model-card-gpqa@1.0.0",
+          "metric": "accuracy",
+          "normalized": 0.486,
+          "status": "available",
+          "value": 0.486,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "cais/humanitys-last-exam@1.0.0",
+          "benchmark_profiles": [
+            "independent-text-only",
+            "text-only"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.5,
+      "index": "vllm-sr/reasoning@1.0.0",
+      "model": "ai2/olmo-3-1-32b-instruct",
+      "provenance": [
+        "ai2/olmo-3-1-32b-instruct-model-card-gpqa@1.0.0"
+      ],
+      "reasoning_effort": "unspecified",
+      "score": null,
+      "status": "partial"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "livecodebench/livecodebench@6.0.0",
+          "benchmark_profiles": [
+            "independent-code-generation",
+            "published-code-generation"
+          ],
+          "metric": "pass_at_1",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "scicode-bench/scicode@1.0.0",
+          "benchmark_profiles": [
+            "independent-test-288",
+            "published-standard"
+          ],
+          "metric": "score",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/coding@1.0.0",
+      "model": "ai2/olmo-3-1-32b-instruct",
+      "provenance": [],
+      "reasoning_effort": "unspecified",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "harbor/terminal-bench@2.1.0",
+          "benchmark_profiles": [
+            "independent-agent",
+            "published-agent"
+          ],
+          "metric": "resolved",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/agentic@1.0.0",
+      "model": "ai2/olmo-3-1-32b-instruct",
+      "provenance": [],
+      "reasoning_effort": "unspecified",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "index": "vllm-sr/general@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/reasoning@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.4
+        },
+        {
+          "index": "vllm-sr/coding@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/agentic@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/intelligence@1.0.0",
+      "model": "ai2/olmo-3-1-32b-instruct",
+      "provenance": [
+        "ai2/olmo-3-1-32b-instruct-model-card-gpqa@1.0.0"
+      ],
+      "reasoning_effort": "unspecified",
+      "score": null,
+      "status": "missing"
+    },
     {
       "components": [
         {
@@ -86206,6 +87783,151 @@
     {
       "capabilities": [
         "chat",
+        "long_context"
+      ],
+      "description": "Fully open 32B base language model from Ai2's OLMo 3 family.",
+      "display_name": "OLMo 3 32B Base",
+      "distribution": {
+        "license": "Apache-2.0",
+        "source": "https://huggingface.co/allenai/Olmo-3-1125-32B",
+        "type": "open_weights"
+      },
+      "family": "olmo-3",
+      "id": "ai2/olmo-3-32b-base",
+      "kind": "physical",
+      "lifecycle": "active",
+      "limits": {
+        "context_window_size": 65536
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "parameter_size": "32B",
+      "presentation": {
+        "logo": "package:ai2",
+        "monochrome": false,
+        "monogram": "O"
+      },
+      "publisher": "Ai2 / OLMo",
+      "revision": "c2b61dae89a1ad10e4ad5653d0e46b590902607b",
+      "tags": [
+        "open_weights",
+        "base_model",
+        "long_context"
+      ],
+      "verification": {
+        "authority": "Ai2",
+        "source": "https://huggingface.co/allenai/Olmo-3-1125-32B",
+        "status": "claimed",
+        "verified_at": "2026-09-11"
+      }
+    },
+    {
+      "capabilities": [
+        "chat",
+        "reasoning",
+        "long_context"
+      ],
+      "description": "Fully open 32B reasoning model from Ai2's OLMo 3.1 family.",
+      "display_name": "OLMo 3.1 32B Think",
+      "distribution": {
+        "license": "Apache-2.0",
+        "source": "https://huggingface.co/allenai/Olmo-3.1-32B-Think",
+        "type": "open_weights"
+      },
+      "family": "olmo-3",
+      "id": "ai2/olmo-3-1-32b-think",
+      "kind": "physical",
+      "knowledge_cutoff": "2024-12-01",
+      "lifecycle": "active",
+      "limits": {
+        "context_window_size": 65536,
+        "max_output_tokens": 32768
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "parameter_size": "32B",
+      "presentation": {
+        "logo": "package:ai2",
+        "monochrome": false,
+        "monogram": "O"
+      },
+      "publisher": "Ai2 / OLMo",
+      "revision": "832c3f543499af8fe68b88359501de9cb7840544",
+      "tags": [
+        "open_weights",
+        "reasoning",
+        "long_context"
+      ],
+      "verification": {
+        "authority": "Ai2",
+        "source": "https://huggingface.co/allenai/Olmo-3.1-32B-Think",
+        "status": "claimed",
+        "verified_at": "2026-09-11"
+      }
+    },
+    {
+      "capabilities": [
+        "chat",
+        "long_context"
+      ],
+      "description": "Fully open 32B instruction-tuned model from Ai2's OLMo 3.1 family.",
+      "display_name": "OLMo 3.1 32B Instruct",
+      "distribution": {
+        "license": "Apache-2.0",
+        "source": "https://huggingface.co/allenai/Olmo-3.1-32B-Instruct",
+        "type": "open_weights"
+      },
+      "family": "olmo-3",
+      "id": "ai2/olmo-3-1-32b-instruct",
+      "kind": "physical",
+      "knowledge_cutoff": "2024-12-01",
+      "lifecycle": "active",
+      "limits": {
+        "context_window_size": 65536
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "parameter_size": "32B",
+      "presentation": {
+        "logo": "package:ai2",
+        "monochrome": false,
+        "monogram": "O"
+      },
+      "publisher": "Ai2 / OLMo",
+      "revision": "ac0587e4a7744a551c059d8cd17ba220bc940dae",
+      "tags": [
+        "open_weights",
+        "instruction_tuned",
+        "long_context"
+      ],
+      "verification": {
+        "authority": "Ai2",
+        "source": "https://huggingface.co/allenai/Olmo-3.1-32B-Instruct",
+        "status": "claimed",
+        "verified_at": "2026-09-11"
+      }
+    },
+    {
+      "capabilities": [
+        "chat",
         "tools",
         "structured_output",
         "long_context"
@@ -95555,6 +97277,51 @@
             "source": "https://huggingface.co/ai21labs/AI21-Jamba-Reasoning-3B",
             "status": "claimed",
             "verified_at": "2026-09-05"
+          }
+        },
+        {
+          "catalog": "ai2/olmo-3-32b-base",
+          "id": "allenai/Olmo-3-1125-32B",
+          "lifecycle": "active",
+          "protocols": [
+            "openai/chat-completions@1",
+            "openai/responses@1"
+          ],
+          "relationship": "self_hosted",
+          "verification": {
+            "source": "https://huggingface.co/allenai/Olmo-3-1125-32B",
+            "status": "claimed",
+            "verified_at": "2026-09-11"
+          }
+        },
+        {
+          "catalog": "ai2/olmo-3-1-32b-think",
+          "id": "allenai/Olmo-3.1-32B-Think",
+          "lifecycle": "active",
+          "protocols": [
+            "openai/chat-completions@1",
+            "openai/responses@1"
+          ],
+          "relationship": "self_hosted",
+          "verification": {
+            "source": "https://huggingface.co/allenai/Olmo-3.1-32B-Think",
+            "status": "claimed",
+            "verified_at": "2026-09-11"
+          }
+        },
+        {
+          "catalog": "ai2/olmo-3-1-32b-instruct",
+          "id": "allenai/Olmo-3.1-32B-Instruct",
+          "lifecycle": "active",
+          "protocols": [
+            "openai/chat-completions@1",
+            "openai/responses@1"
+          ],
+          "relationship": "self_hosted",
+          "verification": {
+            "source": "https://huggingface.co/allenai/Olmo-3.1-32B-Instruct",
+            "status": "claimed",
+            "verified_at": "2026-09-11"
           }
         },
         {


### PR DESCRIPTION
<!-- markdownlint-disable -->

Closes #3605

## Purpose

Admit Ai2 / OLMo as a creator-owned slice of the built-in Model Card catalog
under the Evaluation & Quality Workgroup.

This change:

- Adds three representative open-weight Model Cards:
  - `ai2/olmo-3-32b-base`
  - `ai2/olmo-3-1-32b-think`
  - `ai2/olmo-3-1-32b-instruct`
- Pins each card to its source revision and records its context, capabilities,
  modalities, and lifecycle.
- Adds exact self-hosted vLLM mappings for all three models.
- Adds the catalog resource definitions and 21 source-backed evaluation
  records for the OLMo slice: 15 model-card records and six independent
  records for the OLMo 3.1 32B Think anchor.
- Completes the anchor with an independent Terminal-Bench 2.1 record from
  [Artificial Analysis](https://artificialanalysis.ai/evaluations/terminalbench-v2-1),
  retaining the 89-task dataset artifact and the measured `resolved: 0.0`
  result.
- Regenerates the built-in Router catalog, Go catalog embed, and public
  website/Dashboard catalog projection.
- Adds regression coverage for creator inventory, evidence buckets, pinned
  revisions, provider bindings, and the generated Agentic and Overall
  Intelligence 1.0 profiles.

No existing v1 benchmark or index semantics are changed.

## Test Plan

- `python tools/catalog/generate_model_catalog.py`
- `python tools/catalog/generate_model_catalog.py --check`
- `python -m unittest -v tools.catalog.tests.test_generate_model_catalog`
- `python tools/catalog/audit_model_catalog.py --require-min-evaluations-per-model 5`
- `python tools/ci/sync_evaluation_catalogs.py --check`
- `go test ./pkg/catalog/...` from `src/semantic-router`
- `go test ./pkg/config/... -run TestReferenceConfig -count=1` from `src/semantic-router`
- `go test ./handlers -run TestGeneratedPublicModelCatalogSatisfiesDashboardContract -count=1` from `dashboard/backend`
- `git diff --check HEAD^ HEAD`

## Test Result

- Catalog generation and generated-output check passed.
- Catalog compiler tests passed: 23 tests.
- Catalog audit passed with 99 physical models, 5 virtual models, 61
  providers, and 1,531 available evaluations.
- Evaluation catalog synchronization passed.
- Go catalog and config tests passed.
- The generated OLMo Think `enabled` anchor produces `available` Agentic and
  Overall Intelligence 1.0 profiles; Agentic retains the measured score 0.0.
- `git diff --check HEAD^ HEAD` passed.
- The Dashboard contract command is blocked on Windows because
  `log_spool_reader_unix.go`, which defines `maxRuntimeLogLineBytes` and
  `runtimeLogTruncatedMarker`, is excluded by the Windows build while
  `handlers/logs_test.go` references those symbols. This is outside the
  catalog change; the Linux-targeted source path includes that file.

---

<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category, such as `[Feature]`, `[Bug]`, `[Docs]`, `[Test]`, `[Research]`, `[Community]`, or `[CI/Build]`
- [x] The title does not stack prefixes such as `[Router][Docs]`; affected modules belong in labels and the PR body
- [x] The PR links an `accepted` issue with exactly one owner: one `wg/*` label for project work or `owner/maintainers` for repository governance
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
