### PR TITLE
[Feature] Admit Shanghai AI Laboratory / Intern models to the built-in Model Card catalog

### DIFF
--- a/config/catalog/README.md
+++ b/config/catalog/README.md
@@ -115,11 +115,11 @@ without duplicating its intrinsic identity. Virtual recipes are materialized
 from packaged assets and keep their own evaluation directory.
 
 The built-in physical inventory is curated at the creator-company level. The
-current baseline contains 84 physical cards from 22 mainstream creators and
+current baseline contains 99 physical cards from 23 mainstream creators and
 five separately stored virtual cards. For each creator, prefer roughly the
 latest three generations or representative product lines over accumulating a
 shallow long tail of lesser-known creators. This policy is about Model Cards,
-not serving endpoints: the 60 `ProviderDefinition` resources remain broad so
+not serving endpoints: the 61 `ProviderDefinition` resources remain broad so
 Add Model and handwritten custom models can use a known runtime contract even
 when that provider has no curated built-in model mapping. `ModelCard.publisher`
 is the creator; a `ProviderDefinition` is the runtime API contract for the

--- a/config/catalog/manifest.yaml
+++ b/config/catalog/manifest.yaml
@@ -109,6 +109,11 @@ inventory:
           - openai/gpt-6-astra
           - openai/gpt-5.6-sol
           - openai/gpt-5.5
+      - publisher: Shanghai AI Laboratory / Intern
+        representative_models:
+          - intern/intern-s2-preview-397b
+          - intern/intern-s2-preview-35b
+          - intern/intern-s1
       - publisher: StepFun
         representative_models:
           - stepfun/step-3.7-flash

--- a/config/catalog/resources/evaluations/single/intern.yaml
+++ b/config/catalog/resources/evaluations/single/intern.yaml
@@ -1,0 +1,510 @@
+- id: intern/intern-s2-preview-397b-report-mmlu-pro@1.0.0
+  model: intern/intern-s2-preview-397b
+  benchmark: tiger-ai-lab/mmlu-pro@1.0.0
+  benchmark_profile: published-standard
+  reasoning_effort: enabled
+  subject:
+    source_model: Intern-S2-Preview-397B
+    source_model_slug: intern-s2-preview-397b
+    source_kind: official_technical_report
+    model_revision: f4ed28782e23ad9fb4e4895b9069dcd889f5e2a1
+    evaluation_harness: OpenCompass
+    dataset_variant: MMLU-Pro
+    sampling_temperature: 0.8
+    sampling_top_p: 0.95
+    sampling_top_k: 50
+    sampling_min_p: 0.0
+    maximum_inference_tokens: 262144
+    task_count: 12000
+    task_artifact: https://github.com/TIGER-AI-Lab/MMLU-Pro
+    cost_usd: null
+    latency_ms: null
+  metrics:
+    accuracy: 0.8975
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://arxiv.org/html/2608.13505v1
+    redistributable: true
+- id: intern/intern-s2-preview-397b-report-hmmt@1.0.0
+  model: intern/intern-s2-preview-397b
+  benchmark: matharena/hmmt-feb@2026.0.0
+  benchmark_profile: pass-at-1
+  reasoning_effort: enabled
+  subject:
+    source_model: Intern-S2-Preview-397B
+    source_model_slug: intern-s2-preview-397b
+    source_kind: official_technical_report
+    model_revision: f4ed28782e23ad9fb4e4895b9069dcd889f5e2a1
+    evaluation_harness: OpenCompass
+    dataset_variant: February 2026 Harvard-MIT Mathematics Tournament
+    sampling_temperature: 0.8
+    sampling_top_p: 0.95
+    sampling_top_k: 50
+    sampling_min_p: 0.0
+    maximum_inference_tokens: 262144
+    task_count: 33
+    task_artifact: https://github.com/eth-sri/matharena
+    cost_usd: null
+    latency_ms: null
+  metrics:
+    pass_at_1: 0.9157
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://arxiv.org/html/2608.13505v1
+    redistributable: true
+- id: intern/intern-s2-preview-397b-report-mmmu-pro@1.0.0
+  model: intern/intern-s2-preview-397b
+  benchmark: mmmu-benchmark/mmmu-pro@1.0.0
+  benchmark_profile: standard-10
+  reasoning_effort: enabled
+  subject:
+    source_model: Intern-S2-Preview-397B
+    source_model_slug: intern-s2-preview-397b
+    source_kind: official_technical_report
+    model_revision: f4ed28782e23ad9fb4e4895b9069dcd889f5e2a1
+    evaluation_harness: VLMEvalKit
+    dataset_variant: MMMU-Pro
+    sampling_temperature: 0.8
+    sampling_top_p: 0.95
+    sampling_top_k: 50
+    sampling_min_p: 0.0
+    maximum_inference_tokens: 65536
+    task_artifact: https://github.com/MMMU-Benchmark/MMMU
+    cost_usd: null
+    latency_ms: null
+  metrics:
+    accuracy: 0.8046
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://arxiv.org/html/2608.13505v1
+    redistributable: true
+- id: intern/intern-s2-preview-397b-report-terminal-bench@1.0.0
+  model: intern/intern-s2-preview-397b
+  benchmark: harbor/terminal-bench@2.1.0
+  benchmark_profile: published-agent
+  reasoning_effort: enabled
+  subject:
+    source_model: Intern-S2-Preview-397B
+    source_model_slug: intern-s2-preview-397b
+    source_kind: official_technical_report
+    model_revision: f4ed28782e23ad9fb4e4895b9069dcd889f5e2a1
+    agent_harness: Terminus 2
+    sampling_temperature: 0.8
+    sampling_top_p: 0.95
+    sampling_top_k: 50
+    sampling_min_p: 0.0
+    maximum_inference_tokens: 262144
+    task_count: 89
+    task_artifact: https://github.com/harbor-framework/terminal-bench-2-1
+    cost_usd: null
+    latency_ms: null
+  metrics:
+    resolved: 0.6742
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://arxiv.org/html/2608.13505v1
+    redistributable: true
+- id: intern/intern-s2-preview-397b-report-swe-bench-pro@1.0.0
+  model: intern/intern-s2-preview-397b
+  benchmark: swe-bench/pro@1.0.0
+  benchmark_profile: published-agent
+  reasoning_effort: enabled
+  subject:
+    source_model: Intern-S2-Preview-397B
+    source_model_slug: intern-s2-preview-397b
+    source_kind: official_technical_report
+    model_revision: f4ed28782e23ad9fb4e4895b9069dcd889f5e2a1
+    agent_harness: Mini-SWE-Agent
+    evaluation_image: modified official evaluation image
+    sampling_temperature: 0.8
+    sampling_top_p: 0.95
+    sampling_top_k: 50
+    sampling_min_p: 0.0
+    maximum_inference_tokens: 262144
+    task_count: 1865
+    task_artifact: https://scale.com/leaderboard/swe_bench_pro_public
+    cost_usd: null
+    latency_ms: null
+  metrics:
+    resolved: 0.6156
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://arxiv.org/html/2608.13505v1
+    redistributable: true
+- id: intern/intern-s2-preview-397b-report-scicode@1.0.0
+  model: intern/intern-s2-preview-397b
+  benchmark: scicode-bench/scicode@1.0.0
+  benchmark_profile: published-standard
+  reasoning_effort: enabled
+  subject:
+    source_model: Intern-S2-Preview-397B
+    source_model_slug: intern-s2-preview-397b
+    source_kind: official_technical_report
+    model_revision: f4ed28782e23ad9fb4e4895b9069dcd889f5e2a1
+    evaluation_harness: OpenCompass
+    dataset_variant: 80 problems / 338 subproblems
+    sampling_temperature: 0.8
+    sampling_top_p: 0.95
+    sampling_top_k: 50
+    sampling_min_p: 0.0
+    maximum_inference_tokens: 262144
+    task_count: 338
+    task_artifact: https://github.com/scicode-bench/SciCode
+    cost_usd: null
+    latency_ms: null
+  metrics:
+    score: 0.4911
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://arxiv.org/html/2608.13505v1
+    redistributable: true
+- id: intern/intern-s2-preview-397b-anchor-gpqa-diamond@1.0.0
+  model: intern/intern-s2-preview-397b
+  benchmark: idavidrein/gpqa-diamond@1.0.0
+  benchmark_profile: published-standard
+  reasoning_effort: enabled
+  subject:
+    source_model: Intern-S2-Preview-397B
+    source_model_slug: intern-s2-preview-397b
+    source_kind: official_anchor_reproduction
+    model_revision: f4ed28782e23ad9fb4e4895b9069dcd889f5e2a1
+    evaluation_harness: OpenCompass
+    dataset_variant: GPQA Diamond
+    sampling_temperature: 0.8
+    sampling_top_p: 0.95
+    sampling_top_k: 50
+    sampling_min_p: 0.0
+    maximum_inference_tokens: 262144
+    task_count: 198
+    task_artifact: https://github.com/idavidrein/gpqa
+    cost_usd: null
+    latency_ms: null
+  metrics:
+    accuracy: 0.8475
+  status: available
+  observed_at: 2026-09-12
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://arxiv.org/html/2608.13505v1
+    redistributable: true
+- id: intern/intern-s2-preview-397b-anchor-humanitys-last-exam@1.0.0
+  model: intern/intern-s2-preview-397b
+  benchmark: cais/humanitys-last-exam@1.0.0
+  benchmark_profile: text-only
+  reasoning_effort: enabled
+  subject:
+    source_model: Intern-S2-Preview-397B
+    source_model_slug: intern-s2-preview-397b
+    source_kind: official_anchor_reproduction
+    model_revision: f4ed28782e23ad9fb4e4895b9069dcd889f5e2a1
+    evaluation_harness: OpenCompass
+    tool_policy: no_tools
+    dataset_variant: May 2025 text-only subset
+    sampling_temperature: 0.8
+    sampling_top_p: 0.95
+    sampling_top_k: 50
+    sampling_min_p: 0.0
+    maximum_inference_tokens: 262144
+    task_count: 2158
+    task_artifact: https://github.com/centerforaisafety/hle
+    cost_usd: null
+    latency_ms: null
+  metrics:
+    accuracy: 0.2680
+  status: available
+  observed_at: 2026-09-12
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://arxiv.org/html/2608.13505v1
+    redistributable: true
+- id: intern/intern-s2-preview-397b-anchor-livecodebench-v6@1.0.0
+  model: intern/intern-s2-preview-397b
+  benchmark: livecodebench/livecodebench@6.0.0
+  benchmark_profile: published-code-generation
+  reasoning_effort: enabled
+  subject:
+    source_model: Intern-S2-Preview-397B
+    source_model_slug: intern-s2-preview-397b
+    source_kind: official_anchor_reproduction
+    model_revision: f4ed28782e23ad9fb4e4895b9069dcd889f5e2a1
+    evaluation_harness: OpenCompass
+    dataset_release: v6
+    problem_window: 2023-05_to_2025-04
+    sampling_temperature: 0.8
+    sampling_top_p: 0.95
+    sampling_top_k: 50
+    sampling_min_p: 0.0
+    maximum_inference_tokens: 262144
+    task_count: 1055
+    task_artifact: https://github.com/LiveCodeBench/LiveCodeBench
+    cost_usd: null
+    latency_ms: null
+  metrics:
+    pass_at_1: 0.7340
+  status: available
+  observed_at: 2026-09-12
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://arxiv.org/html/2608.13505v1
+    redistributable: true
+- id: intern/intern-s2-preview-35b-eval-mmlu-pro@1.0.0
+  model: intern/intern-s2-preview-35b
+  benchmark: tiger-ai-lab/mmlu-pro@1.0.0
+  benchmark_profile: published-standard
+  reasoning_effort: enabled
+  subject:
+    variant: Intern-S2-Preview 35B
+    source_kind: official_huggingface_eval_result
+    model_revision: 4f57cab513689b089019fce4ad24e26520df183c
+    evaluation_harness: OpenCompass
+    dataset_variant: MMLU-Pro
+    maximum_inference_tokens: 131072
+    sampling_temperature: 0.8
+    sampling_top_p: 0.95
+    sampling_top_k: 50
+    sampling_min_p: 0.0
+  metrics:
+    accuracy: 0.88
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/internlm/Intern-S2-Preview
+    redistributable: true
+- id: intern/intern-s2-preview-35b-eval-hle@1.0.0
+  model: intern/intern-s2-preview-35b
+  benchmark: cais/humanitys-last-exam@1.0.0
+  benchmark_profile: published-unspecified
+  reasoning_effort: enabled
+  subject:
+    variant: Intern-S2-Preview 35B
+    source_kind: official_huggingface_eval_result
+    model_revision: 4f57cab513689b089019fce4ad24e26520df183c
+    evaluation_harness: unspecified
+    tool_policy: unspecified
+    dataset_variant: HLE
+    maximum_inference_tokens: 131072
+    sampling_temperature: 0.8
+    sampling_top_p: 0.95
+    sampling_top_k: 50
+    sampling_min_p: 0.0
+  metrics:
+    accuracy: 0.2194
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/internlm/Intern-S2-Preview
+    redistributable: true
+- id: intern/intern-s2-preview-35b-eval-hmmt@1.0.0
+  model: intern/intern-s2-preview-35b
+  benchmark: matharena/hmmt-feb@2026.0.0
+  benchmark_profile: pass-at-1
+  reasoning_effort: enabled
+  subject:
+    variant: Intern-S2-Preview 35B
+    source_kind: official_huggingface_eval_result
+    model_revision: 4f57cab513689b089019fce4ad24e26520df183c
+    evaluation_harness: OpenCompass
+    dataset_variant: February 2026 Harvard-MIT Mathematics Tournament
+    maximum_inference_tokens: 131072
+    sampling_temperature: 0.8
+    sampling_top_p: 0.95
+    sampling_top_k: 50
+    sampling_min_p: 0.0
+  metrics:
+    pass_at_1: 0.8731
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/internlm/Intern-S2-Preview
+    redistributable: true
+- id: intern/intern-s2-preview-35b-eval-mmmu-pro@1.0.0
+  model: intern/intern-s2-preview-35b
+  benchmark: mmmu-benchmark/mmmu-pro@1.0.0
+  benchmark_profile: standard-10
+  reasoning_effort: enabled
+  subject:
+    variant: Intern-S2-Preview 35B
+    source_kind: official_huggingface_eval_result
+    model_revision: 4f57cab513689b089019fce4ad24e26520df183c
+    evaluation_harness: VLMEvalKit
+    evaluation_label: MMMU Pro Vision
+    dataset_variant: MMMU-Pro
+    maximum_inference_tokens: 65536
+    sampling_temperature: 0.8
+    sampling_top_p: 0.95
+    sampling_top_k: 50
+    sampling_min_p: 0.0
+  metrics:
+    accuracy: 0.7688
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/internlm/Intern-S2-Preview
+    redistributable: true
+- id: intern/intern-s2-preview-35b-eval-swe-bench-verified@1.0.0
+  model: intern/intern-s2-preview-35b
+  benchmark: swe-bench/verified@1.0.0
+  benchmark_profile: published-agent
+  reasoning_effort: enabled
+  subject:
+    variant: Intern-S2-Preview 35B
+    source_kind: official_huggingface_eval_result
+    model_revision: 4f57cab513689b089019fce4ad24e26520df183c
+    evaluation_label: SWE-bench Verified
+  metrics:
+    resolved: 0.64
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/internlm/Intern-S2-Preview
+    redistributable: true
+- id: intern/intern-s1-model-card-mmlu-pro@1.0.0
+  model: intern/intern-s1
+  benchmark: tiger-ai-lab/mmlu-pro@1.0.0
+  benchmark_profile: published-standard
+  reasoning_effort: enabled
+  subject:
+    variant: Intern-S1
+    source_kind: official_model_card
+    model_revision: 4ecad381e28293c4825793f113327cc016cdcbda
+    evaluation_harness: OpenCompass
+    dataset_variant: MMLU-Pro
+    sampling_temperature: 0.7
+    sampling_top_p: 1.0
+    sampling_top_k: 50
+    sampling_min_p: 0.0
+  metrics:
+    accuracy: 0.835
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/internlm/Intern-S1/blob/4ecad381e28293c4825793f113327cc016cdcbda/README.md
+    redistributable: true
+- id: intern/intern-s1-model-card-mmmu@1.0.0
+  model: intern/intern-s1
+  benchmark: mmmu-benchmark/mmmu@1.0.0
+  benchmark_profile: dev-val
+  reasoning_effort: enabled
+  subject:
+    variant: Intern-S1
+    source_kind: official_model_card
+    model_revision: 4ecad381e28293c4825793f113327cc016cdcbda
+    evaluation_harness: VLMEvalKit
+    dataset_variant: MMMU (model card table; split unspecified)
+    sampling_temperature: 0.7
+    sampling_top_p: 1.0
+    sampling_top_k: 50
+    sampling_min_p: 0.0
+  metrics:
+    accuracy: 0.777
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/internlm/Intern-S1/blob/4ecad381e28293c4825793f113327cc016cdcbda/README.md
+    redistributable: true
+- id: intern/intern-s1-model-card-mathvista@1.0.0
+  model: intern/intern-s1
+  benchmark: mathvista/mathvista@1.0.0
+  benchmark_profile: mini
+  reasoning_effort: enabled
+  subject:
+    variant: Intern-S1
+    source_kind: official_model_card
+    model_revision: 4ecad381e28293c4825793f113327cc016cdcbda
+    evaluation_harness: VLMEvalKit
+    dataset_variant: MathVista mini
+    sampling_temperature: 0.7
+    sampling_top_p: 1.0
+    sampling_top_k: 50
+    sampling_min_p: 0.0
+  metrics:
+    accuracy: 0.815
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/internlm/Intern-S1/blob/4ecad381e28293c4825793f113327cc016cdcbda/README.md
+    redistributable: true
+- id: intern/intern-s1-model-card-aime-2025@1.0.0
+  model: intern/intern-s1
+  benchmark: matharena/aime@2025.0.0
+  benchmark_profile: pass-at-1
+  reasoning_effort: enabled
+  subject:
+    variant: Intern-S1
+    source_kind: official_model_card
+    model_revision: 4ecad381e28293c4825793f113327cc016cdcbda
+    evaluation_harness: OpenCompass
+    dataset_variant: AIME2025
+    sampling_temperature: 0.7
+    sampling_top_p: 1.0
+    sampling_top_k: 50
+    sampling_min_p: 0.0
+  metrics:
+    pass_at_1: 0.86
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/internlm/Intern-S1/blob/4ecad381e28293c4825793f113327cc016cdcbda/README.md
+    redistributable: true
+- id: intern/intern-s1-model-card-ifeval@1.0.0
+  model: intern/intern-s1
+  benchmark: google/ifeval@1.0.0
+  benchmark_profile: published-standard
+  reasoning_effort: enabled
+  subject:
+    variant: Intern-S1
+    source_kind: official_model_card
+    model_revision: 4ecad381e28293c4825793f113327cc016cdcbda
+    evaluation_harness: OpenCompass
+    sampling_temperature: 0.7
+    sampling_top_p: 1.0
+    sampling_top_k: 50
+    sampling_min_p: 0.0
+  metrics:
+    accuracy: 0.867
+  status: available
+  observed_at: 2026-09-11
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/internlm/Intern-S1/blob/4ecad381e28293c4825793f113327cc016cdcbda/README.md
+    redistributable: true

--- a/config/catalog/resources/models/single/intern.yaml
+++ b/config/catalog/resources/models/single/intern.yaml
@@ -1,0 +1,133 @@
+- id: intern/intern-s2-preview-397b
+  display_name: Intern-S2-Preview 397B
+  description: Shanghai AI Laboratory's multimodal scientific foundation model for long-horizon reasoning and agentic workflows.
+  kind: physical
+  publisher: Shanghai AI Laboratory / Intern
+  presentation:
+    logo: monogram
+    monogram: I
+    monochrome: false
+  distribution:
+    type: open_weights
+    source: https://huggingface.co/internlm/Intern-S2-Preview-397B
+    license: Apache-2.0
+  family: intern-s2-preview
+  parameter_size: 397B (17B active)
+  revision: f4ed28782e23ad9fb4e4895b9069dcd889f5e2a1
+  released_at: '2026-07-16'
+  lifecycle: active
+  limits:
+    context_window_size: 262144
+  capabilities:
+  - chat
+  - reasoning
+  - tools
+  - vision
+  - long_context
+  modalities:
+    input:
+    - text
+    - image
+    output:
+    - text
+  verification:
+    authority: Shanghai AI Laboratory / Intern
+    status: claimed
+    verified_at: 2026-09-11
+    source: https://huggingface.co/internlm/Intern-S2-Preview-397B
+  tags:
+  - open_weights
+  - multimodal
+  - reasoning
+  - agentic
+  - long_context
+- id: intern/intern-s2-preview-35b
+  display_name: Intern-S2-Preview 35B
+  description: Shanghai AI Laboratory's efficient multimodal scientific foundation model for reasoning and scientific agent workflows.
+  kind: physical
+  publisher: Shanghai AI Laboratory / Intern
+  presentation:
+    logo: monogram
+    monogram: I
+    monochrome: false
+  distribution:
+    type: open_weights
+    source: https://huggingface.co/internlm/Intern-S2-Preview
+    license: Apache-2.0
+  family: intern-s2-preview
+  parameter_size: 35B (3B active)
+  revision: 4f57cab513689b089019fce4ad24e26520df183c
+  released_at: '2026-05-15'
+  lifecycle: active
+  limits:
+    context_window_size: 131072
+  capabilities:
+  - chat
+  - reasoning
+  - tools
+  - vision
+  - long_context
+  modalities:
+    input:
+    - text
+    - image
+    output:
+    - text
+  verification:
+    authority: Shanghai AI Laboratory / Intern
+    status: claimed
+    verified_at: 2026-09-11
+    source: https://huggingface.co/internlm/Intern-S2-Preview
+  tags:
+  - open_weights
+  - multimodal
+  - reasoning
+  - agentic
+  - long_context
+- id: intern/intern-s1
+  display_name: Intern-S1
+  description: Shanghai AI Laboratory's open multimodal reasoning model for scientific understanding and research assistance.
+  kind: physical
+  publisher: Shanghai AI Laboratory / Intern
+  presentation:
+    logo: monogram
+    monogram: I
+    monochrome: false
+  distribution:
+    type: open_weights
+    source: https://huggingface.co/internlm/Intern-S1
+    license: Apache-2.0
+  family: intern-s1
+  parameter_size: 235B (22B active)
+  revision: 4ecad381e28293c4825793f113327cc016cdcbda
+  released_at: '2025-07-24'
+  lifecycle: active
+  limits:
+    context_window_size: 65536
+    max_output_tokens: 32768
+  capabilities:
+  - chat
+  - reasoning
+  - tools
+  - vision
+  - video
+  - long_context
+  modalities:
+    input:
+    - text
+    - image
+    - video
+    output:
+    - text
+  verification:
+    authority: Shanghai AI Laboratory / Intern
+    status: claimed
+    verified_at: 2026-09-11
+    source: https://huggingface.co/internlm/Intern-S1
+  tags:
+  - open_weights
+  - multimodal
+  - reasoning
+  - scientific
+  - agentic
+  - long_context

--- a/config/catalog/resources/providers/vllm.yaml
+++ b/config/catalog/resources/providers/vllm.yaml
@@ -105,6 +105,39 @@ models:
     status: claimed
     verified_at: 2026-09-05
     source: https://huggingface.co/ai21labs/AI21-Jamba-Reasoning-3B
+- catalog: intern/intern-s2-preview-397b
+  relationship: self_hosted
+  id: internlm/Intern-S2-Preview-397B
+  protocols:
+  - openai/chat-completions@1
+  - openai/responses@1
+  lifecycle: active
+  verification:
+    status: claimed
+    verified_at: 2026-09-11
+    source: https://huggingface.co/internlm/Intern-S2-Preview-397B
+- catalog: intern/intern-s2-preview-35b
+  relationship: self_hosted
+  id: internlm/Intern-S2-Preview
+  protocols:
+  - openai/chat-completions@1
+  - openai/responses@1
+  lifecycle: active
+  verification:
+    status: claimed
+    verified_at: 2026-09-11
+    source: https://huggingface.co/internlm/Intern-S2-Preview
+- catalog: intern/intern-s1
+  relationship: self_hosted
+  id: internlm/Intern-S1
+  protocols:
+  - openai/chat-completions@1
+  - openai/responses@1
+  lifecycle: active
+  verification:
+    status: claimed
+    verified_at: 2026-09-11
+    source: https://huggingface.co/internlm/Intern-S1
 - catalog: bytedance/seed-oss-36b-instruct
   relationship: self_hosted
   id: ByteDance-Seed/Seed-OSS-36B-Instruct

--- a/config/recipes/built-in/latest/catalog.yaml
+++ b/config/recipes/built-in/latest/catalog.yaml
@@ -2848,6 +2848,39 @@ providers:
       status: claimed
       verified_at: '2026-09-05'
       source: https://huggingface.co/ai21labs/AI21-Jamba-Reasoning-3B
+  - catalog: intern/intern-s2-preview-397b
+    relationship: self_hosted
+    id: internlm/Intern-S2-Preview-397B
+    protocols:
+    - openai/chat-completions@1
+    - openai/responses@1
+    lifecycle: active
+    verification:
+      status: claimed
+      verified_at: '2026-09-11'
+      source: https://huggingface.co/internlm/Intern-S2-Preview-397B
+  - catalog: intern/intern-s2-preview-35b
+    relationship: self_hosted
+    id: internlm/Intern-S2-Preview
+    protocols:
+    - openai/chat-completions@1
+    - openai/responses@1
+    lifecycle: active
+    verification:
+      status: claimed
+      verified_at: '2026-09-11'
+      source: https://huggingface.co/internlm/Intern-S2-Preview
+  - catalog: intern/intern-s1
+    relationship: self_hosted
+    id: internlm/Intern-S1
+    protocols:
+    - openai/chat-completions@1
+    - openai/responses@1
+    lifecycle: active
+    verification:
+      status: claimed
+      verified_at: '2026-09-11'
+      source: https://huggingface.co/internlm/Intern-S1
   - catalog: bytedance/seed-oss-36b-instruct
     relationship: self_hosted
     id: ByteDance-Seed/Seed-OSS-36B-Instruct
@@ -5601,6 +5634,140 @@ models:
   - multimodal
   - dense
   released_at: '2025-03-12'
+- id: intern/intern-s2-preview-397b
+  display_name: Intern-S2-Preview 397B
+  description: Shanghai AI Laboratory's multimodal scientific foundation model for long-horizon reasoning and agentic workflows.
+  kind: physical
+  publisher: Shanghai AI Laboratory / Intern
+  presentation:
+    logo: monogram
+    monogram: I
+    monochrome: false
+  distribution:
+    type: open_weights
+    source: https://huggingface.co/internlm/Intern-S2-Preview-397B
+    license: Apache-2.0
+  family: intern-s2-preview
+  parameter_size: 397B (17B active)
+  revision: f4ed28782e23ad9fb4e4895b9069dcd889f5e2a1
+  released_at: '2026-07-16'
+  lifecycle: active
+  limits:
+    context_window_size: 262144
+  capabilities:
+  - chat
+  - reasoning
+  - tools
+  - vision
+  - long_context
+  modalities:
+    input:
+    - text
+    - image
+    output:
+    - text
+  verification:
+    authority: Shanghai AI Laboratory / Intern
+    status: claimed
+    verified_at: '2026-09-11'
+    source: https://huggingface.co/internlm/Intern-S2-Preview-397B
+  tags:
+  - open_weights
+  - multimodal
+  - reasoning
+  - agentic
+  - long_context
+- id: intern/intern-s2-preview-35b
+  display_name: Intern-S2-Preview 35B
+  description: Shanghai AI Laboratory's efficient multimodal scientific foundation model for reasoning and scientific agent
+    workflows.
+  kind: physical
+  publisher: Shanghai AI Laboratory / Intern
+  presentation:
+    logo: monogram
+    monogram: I
+    monochrome: false
+  distribution:
+    type: open_weights
+    source: https://huggingface.co/internlm/Intern-S2-Preview
+    license: Apache-2.0
+  family: intern-s2-preview
+  parameter_size: 35B (3B active)
+  revision: 4f57cab513689b089019fce4ad24e26520df183c
+  released_at: '2026-05-15'
+  lifecycle: active
+  limits:
+    context_window_size: 131072
+  capabilities:
+  - chat
+  - reasoning
+  - tools
+  - vision
+  - long_context
+  modalities:
+    input:
+    - text
+    - image
+    output:
+    - text
+  verification:
+    authority: Shanghai AI Laboratory / Intern
+    status: claimed
+    verified_at: '2026-09-11'
+    source: https://huggingface.co/internlm/Intern-S2-Preview
+  tags:
+  - open_weights
+  - multimodal
+  - reasoning
+  - agentic
+  - long_context
+- id: intern/intern-s1
+  display_name: Intern-S1
+  description: Shanghai AI Laboratory's open multimodal reasoning model for scientific understanding and research assistance.
+  kind: physical
+  publisher: Shanghai AI Laboratory / Intern
+  presentation:
+    logo: monogram
+    monogram: I
+    monochrome: false
+  distribution:
+    type: open_weights
+    source: https://huggingface.co/internlm/Intern-S1
+    license: Apache-2.0
+  family: intern-s1
+  parameter_size: 235B (22B active)
+  revision: 4ecad381e28293c4825793f113327cc016cdcbda
+  released_at: '2025-07-24'
+  lifecycle: active
+  limits:
+    context_window_size: 65536
+    max_output_tokens: 32768
+  capabilities:
+  - chat
+  - reasoning
+  - tools
+  - vision
+  - video
+  - long_context
+  modalities:
+    input:
+    - text
+    - image
+    - video
+    output:
+    - text
+  verification:
+    authority: Shanghai AI Laboratory / Intern
+    status: claimed
+    verified_at: '2026-09-11'
+    source: https://huggingface.co/internlm/Intern-S1
+  tags:
+  - open_weights
+  - multimodal
+  - reasoning
+  - scientific
+  - agentic
+  - long_context
 - id: meta/muse-spark-1.3
   display_name: Muse Spark 1.3
   description: Meta's latest Muse Spark model for agentic workflows, coding, and long-running collaborative work.
@@ -18570,6 +18737,516 @@ evaluations:
     provenance: third_party
     verification: imported
     source: https://artificialanalysis.ai/models/gemma-3-12b
+    redistributable: true
+- id: intern/intern-s2-preview-397b-report-mmlu-pro@1.0.0
+  model: intern/intern-s2-preview-397b
+  benchmark: tiger-ai-lab/mmlu-pro@1.0.0
+  benchmark_profile: published-standard
+  reasoning_effort: enabled
+  subject:
+    source_model: Intern-S2-Preview-397B
+    source_model_slug: intern-s2-preview-397b
+    source_kind: official_technical_report
+    model_revision: f4ed28782e23ad9fb4e4895b9069dcd889f5e2a1
+    evaluation_harness: OpenCompass
+    dataset_variant: MMLU-Pro
+    sampling_temperature: 0.8
+    sampling_top_p: 0.95
+    sampling_top_k: 50
+    sampling_min_p: 0.0
+    maximum_inference_tokens: 262144
+    task_count: 12000
+    task_artifact: https://github.com/TIGER-AI-Lab/MMLU-Pro
+    cost_usd: null
+    latency_ms: null
+  metrics:
+    accuracy: 0.8975
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://arxiv.org/html/2608.13505v1
+    redistributable: true
+- id: intern/intern-s2-preview-397b-report-hmmt@1.0.0
+  model: intern/intern-s2-preview-397b
+  benchmark: matharena/hmmt-feb@2026.0.0
+  benchmark_profile: pass-at-1
+  reasoning_effort: enabled
+  subject:
+    source_model: Intern-S2-Preview-397B
+    source_model_slug: intern-s2-preview-397b
+    source_kind: official_technical_report
+    model_revision: f4ed28782e23ad9fb4e4895b9069dcd889f5e2a1
+    evaluation_harness: OpenCompass
+    dataset_variant: February 2026 Harvard-MIT Mathematics Tournament
+    sampling_temperature: 0.8
+    sampling_top_p: 0.95
+    sampling_top_k: 50
+    sampling_min_p: 0.0
+    maximum_inference_tokens: 262144
+    task_count: 33
+    task_artifact: https://github.com/eth-sri/matharena
+    cost_usd: null
+    latency_ms: null
+  metrics:
+    pass_at_1: 0.9157
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://arxiv.org/html/2608.13505v1
+    redistributable: true
+- id: intern/intern-s2-preview-397b-report-mmmu-pro@1.0.0
+  model: intern/intern-s2-preview-397b
+  benchmark: mmmu-benchmark/mmmu-pro@1.0.0
+  benchmark_profile: standard-10
+  reasoning_effort: enabled
+  subject:
+    source_model: Intern-S2-Preview-397B
+    source_model_slug: intern-s2-preview-397b
+    source_kind: official_technical_report
+    model_revision: f4ed28782e23ad9fb4e4895b9069dcd889f5e2a1
+    evaluation_harness: VLMEvalKit
+    dataset_variant: MMMU-Pro
+    sampling_temperature: 0.8
+    sampling_top_p: 0.95
+    sampling_top_k: 50
+    sampling_min_p: 0.0
+    maximum_inference_tokens: 65536
+    task_artifact: https://github.com/MMMU-Benchmark/MMMU
+    cost_usd: null
+    latency_ms: null
+  metrics:
+    accuracy: 0.8046
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://arxiv.org/html/2608.13505v1
+    redistributable: true
+- id: intern/intern-s2-preview-397b-report-terminal-bench@1.0.0
+  model: intern/intern-s2-preview-397b
+  benchmark: harbor/terminal-bench@2.1.0
+  benchmark_profile: published-agent
+  reasoning_effort: enabled
+  subject:
+    source_model: Intern-S2-Preview-397B
+    source_model_slug: intern-s2-preview-397b
+    source_kind: official_technical_report
+    model_revision: f4ed28782e23ad9fb4e4895b9069dcd889f5e2a1
+    agent_harness: Terminus 2
+    sampling_temperature: 0.8
+    sampling_top_p: 0.95
+    sampling_top_k: 50
+    sampling_min_p: 0.0
+    maximum_inference_tokens: 262144
+    task_count: 89
+    task_artifact: https://github.com/harbor-framework/terminal-bench-2-1
+    cost_usd: null
+    latency_ms: null
+  metrics:
+    resolved: 0.6742
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://arxiv.org/html/2608.13505v1
+    redistributable: true
+- id: intern/intern-s2-preview-397b-report-swe-bench-pro@1.0.0
+  model: intern/intern-s2-preview-397b
+  benchmark: swe-bench/pro@1.0.0
+  benchmark_profile: published-agent
+  reasoning_effort: enabled
+  subject:
+    source_model: Intern-S2-Preview-397B
+    source_model_slug: intern-s2-preview-397b
+    source_kind: official_technical_report
+    model_revision: f4ed28782e23ad9fb4e4895b9069dcd889f5e2a1
+    agent_harness: Mini-SWE-Agent
+    evaluation_image: modified official evaluation image
+    sampling_temperature: 0.8
+    sampling_top_p: 0.95
+    sampling_top_k: 50
+    sampling_min_p: 0.0
+    maximum_inference_tokens: 262144
+    task_count: 1865
+    task_artifact: https://scale.com/leaderboard/swe_bench_pro_public
+    cost_usd: null
+    latency_ms: null
+  metrics:
+    resolved: 0.6156
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://arxiv.org/html/2608.13505v1
+    redistributable: true
+- id: intern/intern-s2-preview-397b-report-scicode@1.0.0
+  model: intern/intern-s2-preview-397b
+  benchmark: scicode-bench/scicode@1.0.0
+  benchmark_profile: published-standard
+  reasoning_effort: enabled
+  subject:
+    source_model: Intern-S2-Preview-397B
+    source_model_slug: intern-s2-preview-397b
+    source_kind: official_technical_report
+    model_revision: f4ed28782e23ad9fb4e4895b9069dcd889f5e2a1
+    evaluation_harness: OpenCompass
+    dataset_variant: 80 problems / 338 subproblems
+    sampling_temperature: 0.8
+    sampling_top_p: 0.95
+    sampling_top_k: 50
+    sampling_min_p: 0.0
+    maximum_inference_tokens: 262144
+    task_count: 338
+    task_artifact: https://github.com/scicode-bench/SciCode
+    cost_usd: null
+    latency_ms: null
+  metrics:
+    score: 0.4911
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://arxiv.org/html/2608.13505v1
+    redistributable: true
+- id: intern/intern-s2-preview-397b-anchor-gpqa-diamond@1.0.0
+  model: intern/intern-s2-preview-397b
+  benchmark: idavidrein/gpqa-diamond@1.0.0
+  benchmark_profile: published-standard
+  reasoning_effort: enabled
+  subject:
+    source_model: Intern-S2-Preview-397B
+    source_model_slug: intern-s2-preview-397b
+    source_kind: official_anchor_reproduction
+    model_revision: f4ed28782e23ad9fb4e4895b9069dcd889f5e2a1
+    evaluation_harness: OpenCompass
+    dataset_variant: GPQA Diamond
+    sampling_temperature: 0.8
+    sampling_top_p: 0.95
+    sampling_top_k: 50
+    sampling_min_p: 0.0
+    maximum_inference_tokens: 262144
+    task_count: 198
+    task_artifact: https://github.com/idavidrein/gpqa
+    cost_usd: null
+    latency_ms: null
+  metrics:
+    accuracy: 0.8475
+  status: available
+  observed_at: '2026-09-12'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://arxiv.org/html/2608.13505v1
+    redistributable: true
+- id: intern/intern-s2-preview-397b-anchor-humanitys-last-exam@1.0.0
+  model: intern/intern-s2-preview-397b
+  benchmark: cais/humanitys-last-exam@1.0.0
+  benchmark_profile: text-only
+  reasoning_effort: enabled
+  subject:
+    source_model: Intern-S2-Preview-397B
+    source_model_slug: intern-s2-preview-397b
+    source_kind: official_anchor_reproduction
+    model_revision: f4ed28782e23ad9fb4e4895b9069dcd889f5e2a1
+    evaluation_harness: OpenCompass
+    tool_policy: no_tools
+    dataset_variant: May 2025 text-only subset
+    sampling_temperature: 0.8
+    sampling_top_p: 0.95
+    sampling_top_k: 50
+    sampling_min_p: 0.0
+    maximum_inference_tokens: 262144
+    task_count: 2158
+    task_artifact: https://github.com/centerforaisafety/hle
+    cost_usd: null
+    latency_ms: null
+  metrics:
+    accuracy: 0.268
+  status: available
+  observed_at: '2026-09-12'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://arxiv.org/html/2608.13505v1
+    redistributable: true
+- id: intern/intern-s2-preview-397b-anchor-livecodebench-v6@1.0.0
+  model: intern/intern-s2-preview-397b
+  benchmark: livecodebench/livecodebench@6.0.0
+  benchmark_profile: published-code-generation
+  reasoning_effort: enabled
+  subject:
+    source_model: Intern-S2-Preview-397B
+    source_model_slug: intern-s2-preview-397b
+    source_kind: official_anchor_reproduction
+    model_revision: f4ed28782e23ad9fb4e4895b9069dcd889f5e2a1
+    evaluation_harness: OpenCompass
+    dataset_release: v6
+    problem_window: 2023-05_to_2025-04
+    sampling_temperature: 0.8
+    sampling_top_p: 0.95
+    sampling_top_k: 50
+    sampling_min_p: 0.0
+    maximum_inference_tokens: 262144
+    task_count: 1055
+    task_artifact: https://github.com/LiveCodeBench/LiveCodeBench
+    cost_usd: null
+    latency_ms: null
+  metrics:
+    pass_at_1: 0.734
+  status: available
+  observed_at: '2026-09-12'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://arxiv.org/html/2608.13505v1
+    redistributable: true
+- id: intern/intern-s2-preview-35b-eval-mmlu-pro@1.0.0
+  model: intern/intern-s2-preview-35b
+  benchmark: tiger-ai-lab/mmlu-pro@1.0.0
+  benchmark_profile: published-standard
+  reasoning_effort: enabled
+  subject:
+    variant: Intern-S2-Preview 35B
+    source_kind: official_huggingface_eval_result
+    model_revision: 4f57cab513689b089019fce4ad24e26520df183c
+    evaluation_harness: OpenCompass
+    dataset_variant: MMLU-Pro
+    maximum_inference_tokens: 131072
+    sampling_temperature: 0.8
+    sampling_top_p: 0.95
+    sampling_top_k: 50
+    sampling_min_p: 0.0
+  metrics:
+    accuracy: 0.88
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/internlm/Intern-S2-Preview
+    redistributable: true
+- id: intern/intern-s2-preview-35b-eval-hle@1.0.0
+  model: intern/intern-s2-preview-35b
+  benchmark: cais/humanitys-last-exam@1.0.0
+  benchmark_profile: published-unspecified
+  reasoning_effort: enabled
+  subject:
+    variant: Intern-S2-Preview 35B
+    source_kind: official_huggingface_eval_result
+    model_revision: 4f57cab513689b089019fce4ad24e26520df183c
+    evaluation_harness: unspecified
+    tool_policy: unspecified
+    dataset_variant: HLE
+    maximum_inference_tokens: 131072
+    sampling_temperature: 0.8
+    sampling_top_p: 0.95
+    sampling_top_k: 50
+    sampling_min_p: 0.0
+  metrics:
+    accuracy: 0.2194
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/internlm/Intern-S2-Preview
+    redistributable: true
+- id: intern/intern-s2-preview-35b-eval-hmmt@1.0.0
+  model: intern/intern-s2-preview-35b
+  benchmark: matharena/hmmt-feb@2026.0.0
+  benchmark_profile: pass-at-1
+  reasoning_effort: enabled
+  subject:
+    variant: Intern-S2-Preview 35B
+    source_kind: official_huggingface_eval_result
+    model_revision: 4f57cab513689b089019fce4ad24e26520df183c
+    evaluation_harness: OpenCompass
+    dataset_variant: February 2026 Harvard-MIT Mathematics Tournament
+    maximum_inference_tokens: 131072
+    sampling_temperature: 0.8
+    sampling_top_p: 0.95
+    sampling_top_k: 50
+    sampling_min_p: 0.0
+  metrics:
+    pass_at_1: 0.8731
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/internlm/Intern-S2-Preview
+    redistributable: true
+- id: intern/intern-s2-preview-35b-eval-mmmu-pro@1.0.0
+  model: intern/intern-s2-preview-35b
+  benchmark: mmmu-benchmark/mmmu-pro@1.0.0
+  benchmark_profile: standard-10
+  reasoning_effort: enabled
+  subject:
+    variant: Intern-S2-Preview 35B
+    source_kind: official_huggingface_eval_result
+    model_revision: 4f57cab513689b089019fce4ad24e26520df183c
+    evaluation_harness: VLMEvalKit
+    evaluation_label: MMMU Pro Vision
+    dataset_variant: MMMU-Pro
+    maximum_inference_tokens: 65536
+    sampling_temperature: 0.8
+    sampling_top_p: 0.95
+    sampling_top_k: 50
+    sampling_min_p: 0.0
+  metrics:
+    accuracy: 0.7688
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/internlm/Intern-S2-Preview
+    redistributable: true
+- id: intern/intern-s2-preview-35b-eval-swe-bench-verified@1.0.0
+  model: intern/intern-s2-preview-35b
+  benchmark: swe-bench/verified@1.0.0
+  benchmark_profile: published-agent
+  reasoning_effort: enabled
+  subject:
+    variant: Intern-S2-Preview 35B
+    source_kind: official_huggingface_eval_result
+    model_revision: 4f57cab513689b089019fce4ad24e26520df183c
+    evaluation_label: SWE-bench Verified
+  metrics:
+    resolved: 0.64
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/internlm/Intern-S2-Preview
+    redistributable: true
+- id: intern/intern-s1-model-card-mmlu-pro@1.0.0
+  model: intern/intern-s1
+  benchmark: tiger-ai-lab/mmlu-pro@1.0.0
+  benchmark_profile: published-standard
+  reasoning_effort: enabled
+  subject:
+    variant: Intern-S1
+    source_kind: official_model_card
+    model_revision: 4ecad381e28293c4825793f113327cc016cdcbda
+    evaluation_harness: OpenCompass
+    dataset_variant: MMLU-Pro
+    sampling_temperature: 0.7
+    sampling_top_p: 1.0
+    sampling_top_k: 50
+    sampling_min_p: 0.0
+  metrics:
+    accuracy: 0.835
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/internlm/Intern-S1/blob/4ecad381e28293c4825793f113327cc016cdcbda/README.md
+    redistributable: true
+- id: intern/intern-s1-model-card-mmmu@1.0.0
+  model: intern/intern-s1
+  benchmark: mmmu-benchmark/mmmu@1.0.0
+  benchmark_profile: dev-val
+  reasoning_effort: enabled
+  subject:
+    variant: Intern-S1
+    source_kind: official_model_card
+    model_revision: 4ecad381e28293c4825793f113327cc016cdcbda
+    evaluation_harness: VLMEvalKit
+    dataset_variant: MMMU (model card table; split unspecified)
+    sampling_temperature: 0.7
+    sampling_top_p: 1.0
+    sampling_top_k: 50
+    sampling_min_p: 0.0
+  metrics:
+    accuracy: 0.777
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/internlm/Intern-S1/blob/4ecad381e28293c4825793f113327cc016cdcbda/README.md
+    redistributable: true
+- id: intern/intern-s1-model-card-mathvista@1.0.0
+  model: intern/intern-s1
+  benchmark: mathvista/mathvista@1.0.0
+  benchmark_profile: mini
+  reasoning_effort: enabled
+  subject:
+    variant: Intern-S1
+    source_kind: official_model_card
+    model_revision: 4ecad381e28293c4825793f113327cc016cdcbda
+    evaluation_harness: VLMEvalKit
+    dataset_variant: MathVista mini
+    sampling_temperature: 0.7
+    sampling_top_p: 1.0
+    sampling_top_k: 50
+    sampling_min_p: 0.0
+  metrics:
+    accuracy: 0.815
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/internlm/Intern-S1/blob/4ecad381e28293c4825793f113327cc016cdcbda/README.md
+    redistributable: true
+- id: intern/intern-s1-model-card-aime-2025@1.0.0
+  model: intern/intern-s1
+  benchmark: matharena/aime@2025.0.0
+  benchmark_profile: pass-at-1
+  reasoning_effort: enabled
+  subject:
+    variant: Intern-S1
+    source_kind: official_model_card
+    model_revision: 4ecad381e28293c4825793f113327cc016cdcbda
+    evaluation_harness: OpenCompass
+    dataset_variant: AIME2025
+    sampling_temperature: 0.7
+    sampling_top_p: 1.0
+    sampling_top_k: 50
+    sampling_min_p: 0.0
+  metrics:
+    pass_at_1: 0.86
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/internlm/Intern-S1/blob/4ecad381e28293c4825793f113327cc016cdcbda/README.md
+    redistributable: true
+- id: intern/intern-s1-model-card-ifeval@1.0.0
+  model: intern/intern-s1
+  benchmark: google/ifeval@1.0.0
+  benchmark_profile: published-standard
+  reasoning_effort: enabled
+  subject:
+    variant: Intern-S1
+    source_kind: official_model_card
+    model_revision: 4ecad381e28293c4825793f113327cc016cdcbda
+    evaluation_harness: OpenCompass
+    sampling_temperature: 0.7
+    sampling_top_p: 1.0
+    sampling_top_k: 50
+    sampling_min_p: 0.0
+  metrics:
+    accuracy: 0.867
+  status: available
+  observed_at: '2026-09-11'
+  evidence:
+    provenance: vendor_claimed
+    verification: claimed
+    source: https://huggingface.co/internlm/Intern-S1/blob/4ecad381e28293c4825793f113327cc016cdcbda/README.md
     redistributable: true
 - id: independent/muse-spark-1-3-aa-briefcase@1.0.0
   model: meta/muse-spark-1.3
@@ -40925,6 +41602,198 @@ index_results:
   - independent/gemma-3-12b-terminalbench-v2-1@1.0.0
   domains:
     agentic_systems: 0.0
+- model: intern/intern-s2-preview-397b
+  reasoning_effort: enabled
+  index: vllm-sr/general@1.0.0
+  status: available
+  score: 89.75
+  coverage: 1.0
+  components:
+  - weight: 1.0
+    status: available
+    value: 0.8975
+    normalized: 0.8975
+    benchmark: tiger-ai-lab/mmlu-pro@1.0.0
+    metric: accuracy
+    benchmark_profiles:
+    - independent-standard
+    - published-standard
+    evaluation: intern/intern-s2-preview-397b-report-mmlu-pro@1.0.0
+    benchmark_profile: published-standard
+  provenance:
+  - intern/intern-s2-preview-397b-report-mmlu-pro@1.0.0
+  domains:
+    general_reasoning: 89.75
+- model: intern/intern-s2-preview-397b
+  reasoning_effort: enabled
+  index: vllm-sr/reasoning@1.0.0
+  status: available
+  score: 55.775
+  coverage: 1.0
+  components:
+  - weight: 0.5
+    status: available
+    value: 0.8475
+    normalized: 0.8475
+    benchmark: idavidrein/gpqa-diamond@1.0.0
+    metric: accuracy
+    benchmark_profiles:
+    - independent-standard
+    - published-standard
+    evaluation: intern/intern-s2-preview-397b-anchor-gpqa-diamond@1.0.0
+    benchmark_profile: published-standard
+  - weight: 0.5
+    status: available
+    value: 0.268
+    normalized: 0.268
+    benchmark: cais/humanitys-last-exam@1.0.0
+    metric: accuracy
+    benchmark_profiles:
+    - independent-text-only
+    - text-only
+    evaluation: intern/intern-s2-preview-397b-anchor-humanitys-last-exam@1.0.0
+    benchmark_profile: text-only
+  provenance:
+  - intern/intern-s2-preview-397b-anchor-gpqa-diamond@1.0.0
+  - intern/intern-s2-preview-397b-anchor-humanitys-last-exam@1.0.0
+  domains:
+    frontier_reasoning: 26.8
+    scientific_reasoning: 84.75
+- model: intern/intern-s2-preview-397b
+  reasoning_effort: enabled
+  index: vllm-sr/coding@1.0.0
+  status: available
+  score: 61.254999999999995
+  coverage: 1.0
+  components:
+  - weight: 0.5
+    status: available
+    value: 0.734
+    normalized: 0.734
+    benchmark: livecodebench/livecodebench@6.0.0
+    metric: pass_at_1
+    benchmark_profiles:
+    - independent-code-generation
+    - published-code-generation
+    evaluation: intern/intern-s2-preview-397b-anchor-livecodebench-v6@1.0.0
+    benchmark_profile: published-code-generation
+  - weight: 0.5
+    status: available
+    value: 0.4911
+    normalized: 0.4911
+    benchmark: scicode-bench/scicode@1.0.0
+    metric: score
+    benchmark_profiles:
+    - independent-test-288
+    - published-standard
+    evaluation: intern/intern-s2-preview-397b-report-scicode@1.0.0
+    benchmark_profile: published-standard
+  provenance:
+  - intern/intern-s2-preview-397b-anchor-livecodebench-v6@1.0.0
+  - intern/intern-s2-preview-397b-report-scicode@1.0.0
+  domains:
+    competitive_programming: 73.4
+    scientific_coding: 49.11
+- model: intern/intern-s2-preview-397b
+  reasoning_effort: enabled
+  index: vllm-sr/agentic@1.0.0
+  status: available
+  score: 67.42
+  coverage: 1.0
+  components:
+  - weight: 1.0
+    status: available
+    value: 0.6742
+    normalized: 0.6742
+    benchmark: harbor/terminal-bench@2.1.0
+    metric: resolved
+    benchmark_profiles:
+    - independent-agent
+    - published-agent
+    evaluation: intern/intern-s2-preview-397b-report-terminal-bench@1.0.0
+    benchmark_profile: published-agent
+  provenance:
+  - intern/intern-s2-preview-397b-report-terminal-bench@1.0.0
+  domains:
+    agentic_systems: 67.42
+- model: intern/intern-s2-preview-397b
+  reasoning_effort: enabled
+  index: vllm-sr/intelligence@1.0.0
+  status: available
+  score: 65.995
+  coverage: 1.0
+  components:
+  - weight: 0.2
+    status: available
+    value: 0.8975
+    normalized: 0.8975
+    index: vllm-sr/general@1.0.0
+  - weight: 0.4
+    status: available
+    value: 0.55775
+    normalized: 0.55775
+    index: vllm-sr/reasoning@1.0.0
+  - weight: 0.2
+    status: available
+    value: 0.6125499999999999
+    normalized: 0.6125499999999999
+    index: vllm-sr/coding@1.0.0
+  - weight: 0.2
+    status: available
+    value: 0.6742
+    normalized: 0.6742
+    index: vllm-sr/agentic@1.0.0
+  provenance:
+  - intern/intern-s2-preview-397b-anchor-gpqa-diamond@1.0.0
+  - intern/intern-s2-preview-397b-anchor-humanitys-last-exam@1.0.0
+  - intern/intern-s2-preview-397b-anchor-livecodebench-v6@1.0.0
+  - intern/intern-s2-preview-397b-report-mmlu-pro@1.0.0
+  - intern/intern-s2-preview-397b-report-scicode@1.0.0
+  - intern/intern-s2-preview-397b-report-terminal-bench@1.0.0
+- model: intern/intern-s2-preview-35b
+  reasoning_effort: enabled
+  index: vllm-sr/general@1.0.0
+  status: available
+  score: 88.0
+  coverage: 1.0
+  components:
+  - weight: 1.0
+    status: available
+    value: 0.88
+    normalized: 0.88
+    benchmark: tiger-ai-lab/mmlu-pro@1.0.0
+    metric: accuracy
+    benchmark_profiles:
+    - independent-standard
+    - published-standard
+    evaluation: intern/intern-s2-preview-35b-eval-mmlu-pro@1.0.0
+    benchmark_profile: published-standard
+  provenance:
+  - intern/intern-s2-preview-35b-eval-mmlu-pro@1.0.0
+  domains:
+    general_reasoning: 88.0
+- model: intern/intern-s1
+  reasoning_effort: enabled
+  index: vllm-sr/general@1.0.0
+  status: available
+  score: 83.5
+  coverage: 1.0
+  components:
+  - weight: 1.0
+    status: available
+    value: 0.835
+    normalized: 0.835
+    benchmark: tiger-ai-lab/mmlu-pro@1.0.0
+    metric: accuracy
+    benchmark_profiles:
+    - independent-standard
+    - published-standard
+    evaluation: intern/intern-s1-model-card-mmlu-pro@1.0.0
+    benchmark_profile: published-standard
+  provenance:
+  - intern/intern-s1-model-card-mmlu-pro@1.0.0
+  domains:
+    general_reasoning: 83.5
 - model: meta/muse-spark-1.3
   reasoning_effort: xhigh
   index: vllm-sr/reasoning@1.0.0

--- a/dashboard/backend/handlers/model_catalog_test.go
+++ b/dashboard/backend/handlers/model_catalog_test.go
@@ -451,7 +451,7 @@ func TestGeneratedPublicModelCatalogSatisfiesDashboardContract(t *testing.T) {
 	if unmarshalErr := json.Unmarshal(normalized, &document); unmarshalErr != nil {
 		t.Fatalf("decode normalized public catalog: %v", unmarshalErr)
 	}
-	if len(document.Models) != 101 || len(document.Providers) != 61 || len(document.Evaluations) != 1510 {
+	if len(document.Models) != 104 || len(document.Providers) != 61 || len(document.Evaluations) != 1529 {
 		t.Fatalf(
 			"unexpected generated inventory: models=%d providers=%d evaluations=%d; "+
 				"regenerate the catalog, or update these counts if the change is intended",

--- a/src/semantic-router/pkg/catalog/zz_generated_catalog.go
+++ b/src/semantic-router/pkg/catalog/zz_generated_catalog.go
@@ -2,7 +2,7 @@
 
 package catalog
 
-const builtInCatalogDigest = "sha256:59aa26f1e4bb0fa52987c265a626962efb8b610e804d9d92e946e1daccb0506f"
+const builtInCatalogDigest = "sha256:ca0bcce326e201ebf798ceb56edced86ea52c7e7c1adde7d45e5338c6ae22588"
 
 const builtInCatalogJSON = `{
   "benchmarks": [
@@ -12957,6 +12957,611 @@ const builtInCatalogJSON = `{
         "run_kind": "independent",
         "source_model": "Gemma 3 12B Instruct",
         "source_model_slug": "gemma-3-12b"
+      }
+    },
+    {
+      "benchmark": "tiger-ai-lab/mmlu-pro@1.0.0",
+      "benchmark_profile": "published-standard",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://arxiv.org/html/2608.13505v1",
+        "verification": "claimed"
+      },
+      "id": "intern/intern-s2-preview-397b-report-mmlu-pro@1.0.0",
+      "metrics": {
+        "accuracy": 0.8975
+      },
+      "model": "intern/intern-s2-preview-397b",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "cost_usd": null,
+        "dataset_variant": "MMLU-Pro",
+        "evaluation_harness": "OpenCompass",
+        "latency_ms": null,
+        "maximum_inference_tokens": 262144,
+        "model_revision": "f4ed28782e23ad9fb4e4895b9069dcd889f5e2a1",
+        "sampling_min_p": 0.0,
+        "sampling_temperature": 0.8,
+        "sampling_top_k": 50,
+        "sampling_top_p": 0.95,
+        "source_kind": "official_technical_report",
+        "source_model": "Intern-S2-Preview-397B",
+        "source_model_slug": "intern-s2-preview-397b",
+        "task_artifact": "https://github.com/TIGER-AI-Lab/MMLU-Pro",
+        "task_count": 12000
+      }
+    },
+    {
+      "benchmark": "matharena/hmmt-feb@2026.0.0",
+      "benchmark_profile": "pass-at-1",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://arxiv.org/html/2608.13505v1",
+        "verification": "claimed"
+      },
+      "id": "intern/intern-s2-preview-397b-report-hmmt@1.0.0",
+      "metrics": {
+        "pass_at_1": 0.9157
+      },
+      "model": "intern/intern-s2-preview-397b",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "cost_usd": null,
+        "dataset_variant": "February 2026 Harvard-MIT Mathematics Tournament",
+        "evaluation_harness": "OpenCompass",
+        "latency_ms": null,
+        "maximum_inference_tokens": 262144,
+        "model_revision": "f4ed28782e23ad9fb4e4895b9069dcd889f5e2a1",
+        "sampling_min_p": 0.0,
+        "sampling_temperature": 0.8,
+        "sampling_top_k": 50,
+        "sampling_top_p": 0.95,
+        "source_kind": "official_technical_report",
+        "source_model": "Intern-S2-Preview-397B",
+        "source_model_slug": "intern-s2-preview-397b",
+        "task_artifact": "https://github.com/eth-sri/matharena",
+        "task_count": 33
+      }
+    },
+    {
+      "benchmark": "mmmu-benchmark/mmmu-pro@1.0.0",
+      "benchmark_profile": "standard-10",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://arxiv.org/html/2608.13505v1",
+        "verification": "claimed"
+      },
+      "id": "intern/intern-s2-preview-397b-report-mmmu-pro@1.0.0",
+      "metrics": {
+        "accuracy": 0.8046
+      },
+      "model": "intern/intern-s2-preview-397b",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "cost_usd": null,
+        "dataset_variant": "MMMU-Pro",
+        "evaluation_harness": "VLMEvalKit",
+        "latency_ms": null,
+        "maximum_inference_tokens": 65536,
+        "model_revision": "f4ed28782e23ad9fb4e4895b9069dcd889f5e2a1",
+        "sampling_min_p": 0.0,
+        "sampling_temperature": 0.8,
+        "sampling_top_k": 50,
+        "sampling_top_p": 0.95,
+        "source_kind": "official_technical_report",
+        "source_model": "Intern-S2-Preview-397B",
+        "source_model_slug": "intern-s2-preview-397b",
+        "task_artifact": "https://github.com/MMMU-Benchmark/MMMU"
+      }
+    },
+    {
+      "benchmark": "harbor/terminal-bench@2.1.0",
+      "benchmark_profile": "published-agent",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://arxiv.org/html/2608.13505v1",
+        "verification": "claimed"
+      },
+      "id": "intern/intern-s2-preview-397b-report-terminal-bench@1.0.0",
+      "metrics": {
+        "resolved": 0.6742
+      },
+      "model": "intern/intern-s2-preview-397b",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "agent_harness": "Terminus 2",
+        "cost_usd": null,
+        "latency_ms": null,
+        "maximum_inference_tokens": 262144,
+        "model_revision": "f4ed28782e23ad9fb4e4895b9069dcd889f5e2a1",
+        "sampling_min_p": 0.0,
+        "sampling_temperature": 0.8,
+        "sampling_top_k": 50,
+        "sampling_top_p": 0.95,
+        "source_kind": "official_technical_report",
+        "source_model": "Intern-S2-Preview-397B",
+        "source_model_slug": "intern-s2-preview-397b",
+        "task_artifact": "https://github.com/harbor-framework/terminal-bench-2-1",
+        "task_count": 89
+      }
+    },
+    {
+      "benchmark": "swe-bench/pro@1.0.0",
+      "benchmark_profile": "published-agent",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://arxiv.org/html/2608.13505v1",
+        "verification": "claimed"
+      },
+      "id": "intern/intern-s2-preview-397b-report-swe-bench-pro@1.0.0",
+      "metrics": {
+        "resolved": 0.6156
+      },
+      "model": "intern/intern-s2-preview-397b",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "agent_harness": "Mini-SWE-Agent",
+        "cost_usd": null,
+        "evaluation_image": "modified official evaluation image",
+        "latency_ms": null,
+        "maximum_inference_tokens": 262144,
+        "model_revision": "f4ed28782e23ad9fb4e4895b9069dcd889f5e2a1",
+        "sampling_min_p": 0.0,
+        "sampling_temperature": 0.8,
+        "sampling_top_k": 50,
+        "sampling_top_p": 0.95,
+        "source_kind": "official_technical_report",
+        "source_model": "Intern-S2-Preview-397B",
+        "source_model_slug": "intern-s2-preview-397b",
+        "task_artifact": "https://scale.com/leaderboard/swe_bench_pro_public",
+        "task_count": 1865
+      }
+    },
+    {
+      "benchmark": "scicode-bench/scicode@1.0.0",
+      "benchmark_profile": "published-standard",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://arxiv.org/html/2608.13505v1",
+        "verification": "claimed"
+      },
+      "id": "intern/intern-s2-preview-397b-report-scicode@1.0.0",
+      "metrics": {
+        "score": 0.4911
+      },
+      "model": "intern/intern-s2-preview-397b",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "cost_usd": null,
+        "dataset_variant": "80 problems / 338 subproblems",
+        "evaluation_harness": "OpenCompass",
+        "latency_ms": null,
+        "maximum_inference_tokens": 262144,
+        "model_revision": "f4ed28782e23ad9fb4e4895b9069dcd889f5e2a1",
+        "sampling_min_p": 0.0,
+        "sampling_temperature": 0.8,
+        "sampling_top_k": 50,
+        "sampling_top_p": 0.95,
+        "source_kind": "official_technical_report",
+        "source_model": "Intern-S2-Preview-397B",
+        "source_model_slug": "intern-s2-preview-397b",
+        "task_artifact": "https://github.com/scicode-bench/SciCode",
+        "task_count": 338
+      }
+    },
+    {
+      "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+      "benchmark_profile": "published-standard",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://arxiv.org/html/2608.13505v1",
+        "verification": "claimed"
+      },
+      "id": "intern/intern-s2-preview-397b-anchor-gpqa-diamond@1.0.0",
+      "metrics": {
+        "accuracy": 0.8475
+      },
+      "model": "intern/intern-s2-preview-397b",
+      "observed_at": "2026-09-12",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "cost_usd": null,
+        "dataset_variant": "GPQA Diamond",
+        "evaluation_harness": "OpenCompass",
+        "latency_ms": null,
+        "maximum_inference_tokens": 262144,
+        "model_revision": "f4ed28782e23ad9fb4e4895b9069dcd889f5e2a1",
+        "sampling_min_p": 0.0,
+        "sampling_temperature": 0.8,
+        "sampling_top_k": 50,
+        "sampling_top_p": 0.95,
+        "source_kind": "official_anchor_reproduction",
+        "source_model": "Intern-S2-Preview-397B",
+        "source_model_slug": "intern-s2-preview-397b",
+        "task_artifact": "https://github.com/idavidrein/gpqa",
+        "task_count": 198
+      }
+    },
+    {
+      "benchmark": "cais/humanitys-last-exam@1.0.0",
+      "benchmark_profile": "text-only",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://arxiv.org/html/2608.13505v1",
+        "verification": "claimed"
+      },
+      "id": "intern/intern-s2-preview-397b-anchor-humanitys-last-exam@1.0.0",
+      "metrics": {
+        "accuracy": 0.268
+      },
+      "model": "intern/intern-s2-preview-397b",
+      "observed_at": "2026-09-12",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "cost_usd": null,
+        "dataset_variant": "May 2025 text-only subset",
+        "evaluation_harness": "OpenCompass",
+        "latency_ms": null,
+        "maximum_inference_tokens": 262144,
+        "model_revision": "f4ed28782e23ad9fb4e4895b9069dcd889f5e2a1",
+        "sampling_min_p": 0.0,
+        "sampling_temperature": 0.8,
+        "sampling_top_k": 50,
+        "sampling_top_p": 0.95,
+        "source_kind": "official_anchor_reproduction",
+        "source_model": "Intern-S2-Preview-397B",
+        "source_model_slug": "intern-s2-preview-397b",
+        "task_artifact": "https://github.com/centerforaisafety/hle",
+        "task_count": 2158,
+        "tool_policy": "no_tools"
+      }
+    },
+    {
+      "benchmark": "livecodebench/livecodebench@6.0.0",
+      "benchmark_profile": "published-code-generation",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://arxiv.org/html/2608.13505v1",
+        "verification": "claimed"
+      },
+      "id": "intern/intern-s2-preview-397b-anchor-livecodebench-v6@1.0.0",
+      "metrics": {
+        "pass_at_1": 0.734
+      },
+      "model": "intern/intern-s2-preview-397b",
+      "observed_at": "2026-09-12",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "cost_usd": null,
+        "dataset_release": "v6",
+        "evaluation_harness": "OpenCompass",
+        "latency_ms": null,
+        "maximum_inference_tokens": 262144,
+        "model_revision": "f4ed28782e23ad9fb4e4895b9069dcd889f5e2a1",
+        "problem_window": "2023-05_to_2025-04",
+        "sampling_min_p": 0.0,
+        "sampling_temperature": 0.8,
+        "sampling_top_k": 50,
+        "sampling_top_p": 0.95,
+        "source_kind": "official_anchor_reproduction",
+        "source_model": "Intern-S2-Preview-397B",
+        "source_model_slug": "intern-s2-preview-397b",
+        "task_artifact": "https://github.com/LiveCodeBench/LiveCodeBench",
+        "task_count": 1055
+      }
+    },
+    {
+      "benchmark": "tiger-ai-lab/mmlu-pro@1.0.0",
+      "benchmark_profile": "published-standard",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/internlm/Intern-S2-Preview",
+        "verification": "claimed"
+      },
+      "id": "intern/intern-s2-preview-35b-eval-mmlu-pro@1.0.0",
+      "metrics": {
+        "accuracy": 0.88
+      },
+      "model": "intern/intern-s2-preview-35b",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "dataset_variant": "MMLU-Pro",
+        "evaluation_harness": "OpenCompass",
+        "maximum_inference_tokens": 131072,
+        "model_revision": "4f57cab513689b089019fce4ad24e26520df183c",
+        "sampling_min_p": 0.0,
+        "sampling_temperature": 0.8,
+        "sampling_top_k": 50,
+        "sampling_top_p": 0.95,
+        "source_kind": "official_huggingface_eval_result",
+        "variant": "Intern-S2-Preview 35B"
+      }
+    },
+    {
+      "benchmark": "cais/humanitys-last-exam@1.0.0",
+      "benchmark_profile": "published-unspecified",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/internlm/Intern-S2-Preview",
+        "verification": "claimed"
+      },
+      "id": "intern/intern-s2-preview-35b-eval-hle@1.0.0",
+      "metrics": {
+        "accuracy": 0.2194
+      },
+      "model": "intern/intern-s2-preview-35b",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "dataset_variant": "HLE",
+        "evaluation_harness": "unspecified",
+        "maximum_inference_tokens": 131072,
+        "model_revision": "4f57cab513689b089019fce4ad24e26520df183c",
+        "sampling_min_p": 0.0,
+        "sampling_temperature": 0.8,
+        "sampling_top_k": 50,
+        "sampling_top_p": 0.95,
+        "source_kind": "official_huggingface_eval_result",
+        "tool_policy": "unspecified",
+        "variant": "Intern-S2-Preview 35B"
+      }
+    },
+    {
+      "benchmark": "matharena/hmmt-feb@2026.0.0",
+      "benchmark_profile": "pass-at-1",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/internlm/Intern-S2-Preview",
+        "verification": "claimed"
+      },
+      "id": "intern/intern-s2-preview-35b-eval-hmmt@1.0.0",
+      "metrics": {
+        "pass_at_1": 0.8731
+      },
+      "model": "intern/intern-s2-preview-35b",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "dataset_variant": "February 2026 Harvard-MIT Mathematics Tournament",
+        "evaluation_harness": "OpenCompass",
+        "maximum_inference_tokens": 131072,
+        "model_revision": "4f57cab513689b089019fce4ad24e26520df183c",
+        "sampling_min_p": 0.0,
+        "sampling_temperature": 0.8,
+        "sampling_top_k": 50,
+        "sampling_top_p": 0.95,
+        "source_kind": "official_huggingface_eval_result",
+        "variant": "Intern-S2-Preview 35B"
+      }
+    },
+    {
+      "benchmark": "mmmu-benchmark/mmmu-pro@1.0.0",
+      "benchmark_profile": "standard-10",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/internlm/Intern-S2-Preview",
+        "verification": "claimed"
+      },
+      "id": "intern/intern-s2-preview-35b-eval-mmmu-pro@1.0.0",
+      "metrics": {
+        "accuracy": 0.7688
+      },
+      "model": "intern/intern-s2-preview-35b",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "dataset_variant": "MMMU-Pro",
+        "evaluation_harness": "VLMEvalKit",
+        "evaluation_label": "MMMU Pro Vision",
+        "maximum_inference_tokens": 65536,
+        "model_revision": "4f57cab513689b089019fce4ad24e26520df183c",
+        "sampling_min_p": 0.0,
+        "sampling_temperature": 0.8,
+        "sampling_top_k": 50,
+        "sampling_top_p": 0.95,
+        "source_kind": "official_huggingface_eval_result",
+        "variant": "Intern-S2-Preview 35B"
+      }
+    },
+    {
+      "benchmark": "swe-bench/verified@1.0.0",
+      "benchmark_profile": "published-agent",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/internlm/Intern-S2-Preview",
+        "verification": "claimed"
+      },
+      "id": "intern/intern-s2-preview-35b-eval-swe-bench-verified@1.0.0",
+      "metrics": {
+        "resolved": 0.64
+      },
+      "model": "intern/intern-s2-preview-35b",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "evaluation_label": "SWE-bench Verified",
+        "model_revision": "4f57cab513689b089019fce4ad24e26520df183c",
+        "source_kind": "official_huggingface_eval_result",
+        "variant": "Intern-S2-Preview 35B"
+      }
+    },
+    {
+      "benchmark": "tiger-ai-lab/mmlu-pro@1.0.0",
+      "benchmark_profile": "published-standard",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/internlm/Intern-S1/blob/4ecad381e28293c4825793f113327cc016cdcbda/README.md",
+        "verification": "claimed"
+      },
+      "id": "intern/intern-s1-model-card-mmlu-pro@1.0.0",
+      "metrics": {
+        "accuracy": 0.835
+      },
+      "model": "intern/intern-s1",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "dataset_variant": "MMLU-Pro",
+        "evaluation_harness": "OpenCompass",
+        "model_revision": "4ecad381e28293c4825793f113327cc016cdcbda",
+        "sampling_min_p": 0.0,
+        "sampling_temperature": 0.7,
+        "sampling_top_k": 50,
+        "sampling_top_p": 1.0,
+        "source_kind": "official_model_card",
+        "variant": "Intern-S1"
+      }
+    },
+    {
+      "benchmark": "mmmu-benchmark/mmmu@1.0.0",
+      "benchmark_profile": "dev-val",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/internlm/Intern-S1/blob/4ecad381e28293c4825793f113327cc016cdcbda/README.md",
+        "verification": "claimed"
+      },
+      "id": "intern/intern-s1-model-card-mmmu@1.0.0",
+      "metrics": {
+        "accuracy": 0.777
+      },
+      "model": "intern/intern-s1",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "dataset_variant": "MMMU (model card table; split unspecified)",
+        "evaluation_harness": "VLMEvalKit",
+        "model_revision": "4ecad381e28293c4825793f113327cc016cdcbda",
+        "sampling_min_p": 0.0,
+        "sampling_temperature": 0.7,
+        "sampling_top_k": 50,
+        "sampling_top_p": 1.0,
+        "source_kind": "official_model_card",
+        "variant": "Intern-S1"
+      }
+    },
+    {
+      "benchmark": "mathvista/mathvista@1.0.0",
+      "benchmark_profile": "mini",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/internlm/Intern-S1/blob/4ecad381e28293c4825793f113327cc016cdcbda/README.md",
+        "verification": "claimed"
+      },
+      "id": "intern/intern-s1-model-card-mathvista@1.0.0",
+      "metrics": {
+        "accuracy": 0.815
+      },
+      "model": "intern/intern-s1",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "dataset_variant": "MathVista mini",
+        "evaluation_harness": "VLMEvalKit",
+        "model_revision": "4ecad381e28293c4825793f113327cc016cdcbda",
+        "sampling_min_p": 0.0,
+        "sampling_temperature": 0.7,
+        "sampling_top_k": 50,
+        "sampling_top_p": 1.0,
+        "source_kind": "official_model_card",
+        "variant": "Intern-S1"
+      }
+    },
+    {
+      "benchmark": "matharena/aime@2025.0.0",
+      "benchmark_profile": "pass-at-1",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/internlm/Intern-S1/blob/4ecad381e28293c4825793f113327cc016cdcbda/README.md",
+        "verification": "claimed"
+      },
+      "id": "intern/intern-s1-model-card-aime-2025@1.0.0",
+      "metrics": {
+        "pass_at_1": 0.86
+      },
+      "model": "intern/intern-s1",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "dataset_variant": "AIME2025",
+        "evaluation_harness": "OpenCompass",
+        "model_revision": "4ecad381e28293c4825793f113327cc016cdcbda",
+        "sampling_min_p": 0.0,
+        "sampling_temperature": 0.7,
+        "sampling_top_k": 50,
+        "sampling_top_p": 1.0,
+        "source_kind": "official_model_card",
+        "variant": "Intern-S1"
+      }
+    },
+    {
+      "benchmark": "google/ifeval@1.0.0",
+      "benchmark_profile": "published-standard",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/internlm/Intern-S1/blob/4ecad381e28293c4825793f113327cc016cdcbda/README.md",
+        "verification": "claimed"
+      },
+      "id": "intern/intern-s1-model-card-ifeval@1.0.0",
+      "metrics": {
+        "accuracy": 0.867
+      },
+      "model": "intern/intern-s1",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "evaluation_harness": "OpenCompass",
+        "model_revision": "4ecad381e28293c4825793f113327cc016cdcbda",
+        "sampling_min_p": 0.0,
+        "sampling_temperature": 0.7,
+        "sampling_top_k": 50,
+        "sampling_top_p": 1.0,
+        "source_kind": "official_model_card",
+        "variant": "Intern-S1"
       }
     },
     {
@@ -52578,6 +53183,997 @@ const builtInCatalogJSON = `{
       ],
       "coverage": 0.0,
       "index": "vllm-sr/general@1.0.0",
+      "model": "intern/intern-s2-preview-397b",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "cais/humanitys-last-exam@1.0.0",
+          "benchmark_profiles": [
+            "independent-text-only",
+            "text-only"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/reasoning@1.0.0",
+      "model": "intern/intern-s2-preview-397b",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "livecodebench/livecodebench@6.0.0",
+          "benchmark_profiles": [
+            "independent-code-generation",
+            "published-code-generation"
+          ],
+          "metric": "pass_at_1",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "scicode-bench/scicode@1.0.0",
+          "benchmark_profiles": [
+            "independent-test-288",
+            "published-standard"
+          ],
+          "metric": "score",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/coding@1.0.0",
+      "model": "intern/intern-s2-preview-397b",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "harbor/terminal-bench@2.1.0",
+          "benchmark_profiles": [
+            "independent-agent",
+            "published-agent"
+          ],
+          "metric": "resolved",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/agentic@1.0.0",
+      "model": "intern/intern-s2-preview-397b",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "index": "vllm-sr/general@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/reasoning@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.4
+        },
+        {
+          "index": "vllm-sr/coding@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/agentic@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/intelligence@1.0.0",
+      "model": "intern/intern-s2-preview-397b",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "tiger-ai-lab/mmlu-pro@1.0.0",
+          "benchmark_profile": "published-standard",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "evaluation": "intern/intern-s2-preview-397b-report-mmlu-pro@1.0.0",
+          "metric": "accuracy",
+          "normalized": 0.8975,
+          "status": "available",
+          "value": 0.8975,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 1.0,
+      "domains": {
+        "general_reasoning": 89.75
+      },
+      "index": "vllm-sr/general@1.0.0",
+      "model": "intern/intern-s2-preview-397b",
+      "provenance": [
+        "intern/intern-s2-preview-397b-report-mmlu-pro@1.0.0"
+      ],
+      "reasoning_effort": "enabled",
+      "score": 89.75,
+      "status": "available"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+          "benchmark_profile": "published-standard",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "evaluation": "intern/intern-s2-preview-397b-anchor-gpqa-diamond@1.0.0",
+          "metric": "accuracy",
+          "normalized": 0.8475,
+          "status": "available",
+          "value": 0.8475,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "cais/humanitys-last-exam@1.0.0",
+          "benchmark_profile": "text-only",
+          "benchmark_profiles": [
+            "independent-text-only",
+            "text-only"
+          ],
+          "evaluation": "intern/intern-s2-preview-397b-anchor-humanitys-last-exam@1.0.0",
+          "metric": "accuracy",
+          "normalized": 0.268,
+          "status": "available",
+          "value": 0.268,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 1.0,
+      "domains": {
+        "frontier_reasoning": 26.8,
+        "scientific_reasoning": 84.75
+      },
+      "index": "vllm-sr/reasoning@1.0.0",
+      "model": "intern/intern-s2-preview-397b",
+      "provenance": [
+        "intern/intern-s2-preview-397b-anchor-gpqa-diamond@1.0.0",
+        "intern/intern-s2-preview-397b-anchor-humanitys-last-exam@1.0.0"
+      ],
+      "reasoning_effort": "enabled",
+      "score": 55.775,
+      "status": "available"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "livecodebench/livecodebench@6.0.0",
+          "benchmark_profile": "published-code-generation",
+          "benchmark_profiles": [
+            "independent-code-generation",
+            "published-code-generation"
+          ],
+          "evaluation": "intern/intern-s2-preview-397b-anchor-livecodebench-v6@1.0.0",
+          "metric": "pass_at_1",
+          "normalized": 0.734,
+          "status": "available",
+          "value": 0.734,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "scicode-bench/scicode@1.0.0",
+          "benchmark_profile": "published-standard",
+          "benchmark_profiles": [
+            "independent-test-288",
+            "published-standard"
+          ],
+          "evaluation": "intern/intern-s2-preview-397b-report-scicode@1.0.0",
+          "metric": "score",
+          "normalized": 0.4911,
+          "status": "available",
+          "value": 0.4911,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 1.0,
+      "domains": {
+        "competitive_programming": 73.4,
+        "scientific_coding": 49.11
+      },
+      "index": "vllm-sr/coding@1.0.0",
+      "model": "intern/intern-s2-preview-397b",
+      "provenance": [
+        "intern/intern-s2-preview-397b-anchor-livecodebench-v6@1.0.0",
+        "intern/intern-s2-preview-397b-report-scicode@1.0.0"
+      ],
+      "reasoning_effort": "enabled",
+      "score": 61.254999999999995,
+      "status": "available"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "harbor/terminal-bench@2.1.0",
+          "benchmark_profile": "published-agent",
+          "benchmark_profiles": [
+            "independent-agent",
+            "published-agent"
+          ],
+          "evaluation": "intern/intern-s2-preview-397b-report-terminal-bench@1.0.0",
+          "metric": "resolved",
+          "normalized": 0.6742,
+          "status": "available",
+          "value": 0.6742,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 1.0,
+      "domains": {
+        "agentic_systems": 67.42
+      },
+      "index": "vllm-sr/agentic@1.0.0",
+      "model": "intern/intern-s2-preview-397b",
+      "provenance": [
+        "intern/intern-s2-preview-397b-report-terminal-bench@1.0.0"
+      ],
+      "reasoning_effort": "enabled",
+      "score": 67.42,
+      "status": "available"
+    },
+    {
+      "components": [
+        {
+          "index": "vllm-sr/general@1.0.0",
+          "normalized": 0.8975,
+          "status": "available",
+          "value": 0.8975,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/reasoning@1.0.0",
+          "normalized": 0.55775,
+          "status": "available",
+          "value": 0.55775,
+          "weight": 0.4
+        },
+        {
+          "index": "vllm-sr/coding@1.0.0",
+          "normalized": 0.6125499999999999,
+          "status": "available",
+          "value": 0.6125499999999999,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/agentic@1.0.0",
+          "normalized": 0.6742,
+          "status": "available",
+          "value": 0.6742,
+          "weight": 0.2
+        }
+      ],
+      "coverage": 1.0,
+      "index": "vllm-sr/intelligence@1.0.0",
+      "model": "intern/intern-s2-preview-397b",
+      "provenance": [
+        "intern/intern-s2-preview-397b-anchor-gpqa-diamond@1.0.0",
+        "intern/intern-s2-preview-397b-anchor-humanitys-last-exam@1.0.0",
+        "intern/intern-s2-preview-397b-anchor-livecodebench-v6@1.0.0",
+        "intern/intern-s2-preview-397b-report-mmlu-pro@1.0.0",
+        "intern/intern-s2-preview-397b-report-scicode@1.0.0",
+        "intern/intern-s2-preview-397b-report-terminal-bench@1.0.0"
+      ],
+      "reasoning_effort": "enabled",
+      "score": 65.995,
+      "status": "available"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "tiger-ai-lab/mmlu-pro@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/general@1.0.0",
+      "model": "intern/intern-s2-preview-35b",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "cais/humanitys-last-exam@1.0.0",
+          "benchmark_profiles": [
+            "independent-text-only",
+            "text-only"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/reasoning@1.0.0",
+      "model": "intern/intern-s2-preview-35b",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "livecodebench/livecodebench@6.0.0",
+          "benchmark_profiles": [
+            "independent-code-generation",
+            "published-code-generation"
+          ],
+          "metric": "pass_at_1",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "scicode-bench/scicode@1.0.0",
+          "benchmark_profiles": [
+            "independent-test-288",
+            "published-standard"
+          ],
+          "metric": "score",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/coding@1.0.0",
+      "model": "intern/intern-s2-preview-35b",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "harbor/terminal-bench@2.1.0",
+          "benchmark_profiles": [
+            "independent-agent",
+            "published-agent"
+          ],
+          "metric": "resolved",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/agentic@1.0.0",
+      "model": "intern/intern-s2-preview-35b",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "index": "vllm-sr/general@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/reasoning@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.4
+        },
+        {
+          "index": "vllm-sr/coding@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/agentic@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/intelligence@1.0.0",
+      "model": "intern/intern-s2-preview-35b",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "tiger-ai-lab/mmlu-pro@1.0.0",
+          "benchmark_profile": "published-standard",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "evaluation": "intern/intern-s2-preview-35b-eval-mmlu-pro@1.0.0",
+          "metric": "accuracy",
+          "normalized": 0.88,
+          "status": "available",
+          "value": 0.88,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 1.0,
+      "domains": {
+        "general_reasoning": 88.0
+      },
+      "index": "vllm-sr/general@1.0.0",
+      "model": "intern/intern-s2-preview-35b",
+      "provenance": [
+        "intern/intern-s2-preview-35b-eval-mmlu-pro@1.0.0"
+      ],
+      "reasoning_effort": "enabled",
+      "score": 88.0,
+      "status": "available"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "cais/humanitys-last-exam@1.0.0",
+          "benchmark_profiles": [
+            "independent-text-only",
+            "text-only"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/reasoning@1.0.0",
+      "model": "intern/intern-s2-preview-35b",
+      "provenance": [],
+      "reasoning_effort": "enabled",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "livecodebench/livecodebench@6.0.0",
+          "benchmark_profiles": [
+            "independent-code-generation",
+            "published-code-generation"
+          ],
+          "metric": "pass_at_1",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "scicode-bench/scicode@1.0.0",
+          "benchmark_profiles": [
+            "independent-test-288",
+            "published-standard"
+          ],
+          "metric": "score",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/coding@1.0.0",
+      "model": "intern/intern-s2-preview-35b",
+      "provenance": [],
+      "reasoning_effort": "enabled",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "harbor/terminal-bench@2.1.0",
+          "benchmark_profiles": [
+            "independent-agent",
+            "published-agent"
+          ],
+          "metric": "resolved",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/agentic@1.0.0",
+      "model": "intern/intern-s2-preview-35b",
+      "provenance": [],
+      "reasoning_effort": "enabled",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "index": "vllm-sr/general@1.0.0",
+          "normalized": 0.88,
+          "status": "available",
+          "value": 0.88,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/reasoning@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.4
+        },
+        {
+          "index": "vllm-sr/coding@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/agentic@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        }
+      ],
+      "coverage": 0.2,
+      "index": "vllm-sr/intelligence@1.0.0",
+      "model": "intern/intern-s2-preview-35b",
+      "provenance": [
+        "intern/intern-s2-preview-35b-eval-mmlu-pro@1.0.0"
+      ],
+      "reasoning_effort": "enabled",
+      "score": null,
+      "status": "partial"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "tiger-ai-lab/mmlu-pro@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/general@1.0.0",
+      "model": "intern/intern-s1",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "cais/humanitys-last-exam@1.0.0",
+          "benchmark_profiles": [
+            "independent-text-only",
+            "text-only"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/reasoning@1.0.0",
+      "model": "intern/intern-s1",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "livecodebench/livecodebench@6.0.0",
+          "benchmark_profiles": [
+            "independent-code-generation",
+            "published-code-generation"
+          ],
+          "metric": "pass_at_1",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "scicode-bench/scicode@1.0.0",
+          "benchmark_profiles": [
+            "independent-test-288",
+            "published-standard"
+          ],
+          "metric": "score",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/coding@1.0.0",
+      "model": "intern/intern-s1",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "harbor/terminal-bench@2.1.0",
+          "benchmark_profiles": [
+            "independent-agent",
+            "published-agent"
+          ],
+          "metric": "resolved",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/agentic@1.0.0",
+      "model": "intern/intern-s1",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "index": "vllm-sr/general@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/reasoning@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.4
+        },
+        {
+          "index": "vllm-sr/coding@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/agentic@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/intelligence@1.0.0",
+      "model": "intern/intern-s1",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "tiger-ai-lab/mmlu-pro@1.0.0",
+          "benchmark_profile": "published-standard",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "evaluation": "intern/intern-s1-model-card-mmlu-pro@1.0.0",
+          "metric": "accuracy",
+          "normalized": 0.835,
+          "status": "available",
+          "value": 0.835,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 1.0,
+      "domains": {
+        "general_reasoning": 83.5
+      },
+      "index": "vllm-sr/general@1.0.0",
+      "model": "intern/intern-s1",
+      "provenance": [
+        "intern/intern-s1-model-card-mmlu-pro@1.0.0"
+      ],
+      "reasoning_effort": "enabled",
+      "score": 83.5,
+      "status": "available"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "cais/humanitys-last-exam@1.0.0",
+          "benchmark_profiles": [
+            "independent-text-only",
+            "text-only"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/reasoning@1.0.0",
+      "model": "intern/intern-s1",
+      "provenance": [],
+      "reasoning_effort": "enabled",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "livecodebench/livecodebench@6.0.0",
+          "benchmark_profiles": [
+            "independent-code-generation",
+            "published-code-generation"
+          ],
+          "metric": "pass_at_1",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "scicode-bench/scicode@1.0.0",
+          "benchmark_profiles": [
+            "independent-test-288",
+            "published-standard"
+          ],
+          "metric": "score",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/coding@1.0.0",
+      "model": "intern/intern-s1",
+      "provenance": [],
+      "reasoning_effort": "enabled",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "harbor/terminal-bench@2.1.0",
+          "benchmark_profiles": [
+            "independent-agent",
+            "published-agent"
+          ],
+          "metric": "resolved",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/agentic@1.0.0",
+      "model": "intern/intern-s1",
+      "provenance": [],
+      "reasoning_effort": "enabled",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "index": "vllm-sr/general@1.0.0",
+          "normalized": 0.835,
+          "status": "available",
+          "value": 0.835,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/reasoning@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.4
+        },
+        {
+          "index": "vllm-sr/coding@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/agentic@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        }
+      ],
+      "coverage": 0.2,
+      "index": "vllm-sr/intelligence@1.0.0",
+      "model": "intern/intern-s1",
+      "provenance": [
+        "intern/intern-s1-model-card-mmlu-pro@1.0.0"
+      ],
+      "reasoning_effort": "enabled",
+      "score": null,
+      "status": "partial"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "tiger-ai-lab/mmlu-pro@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/general@1.0.0",
       "model": "meta/muse-spark-1.3",
       "provenance": [],
       "reasoning_effort": "minimal",
@@ -87970,6 +89566,172 @@ const builtInCatalogJSON = `{
         "chat",
         "reasoning",
         "tools",
+        "vision",
+        "long_context"
+      ],
+      "description": "Shanghai AI Laboratory's multimodal scientific foundation model for long-horizon reasoning and agentic workflows.",
+      "display_name": "Intern-S2-Preview 397B",
+      "distribution": {
+        "license": "Apache-2.0",
+        "source": "https://huggingface.co/internlm/Intern-S2-Preview-397B",
+        "type": "open_weights"
+      },
+      "family": "intern-s2-preview",
+      "id": "intern/intern-s2-preview-397b",
+      "kind": "physical",
+      "lifecycle": "active",
+      "limits": {
+        "context_window_size": 262144
+      },
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "parameter_size": "397B (17B active)",
+      "presentation": {
+        "logo": "monogram",
+        "monochrome": false,
+        "monogram": "I"
+      },
+      "publisher": "Shanghai AI Laboratory / Intern",
+      "released_at": "2026-07-16",
+      "revision": "f4ed28782e23ad9fb4e4895b9069dcd889f5e2a1",
+      "tags": [
+        "open_weights",
+        "multimodal",
+        "reasoning",
+        "agentic",
+        "long_context"
+      ],
+      "verification": {
+        "authority": "Shanghai AI Laboratory / Intern",
+        "source": "https://huggingface.co/internlm/Intern-S2-Preview-397B",
+        "status": "claimed",
+        "verified_at": "2026-09-11"
+      }
+    },
+    {
+      "capabilities": [
+        "chat",
+        "reasoning",
+        "tools",
+        "vision",
+        "long_context"
+      ],
+      "description": "Shanghai AI Laboratory's efficient multimodal scientific foundation model for reasoning and scientific agent workflows.",
+      "display_name": "Intern-S2-Preview 35B",
+      "distribution": {
+        "license": "Apache-2.0",
+        "source": "https://huggingface.co/internlm/Intern-S2-Preview",
+        "type": "open_weights"
+      },
+      "family": "intern-s2-preview",
+      "id": "intern/intern-s2-preview-35b",
+      "kind": "physical",
+      "lifecycle": "active",
+      "limits": {
+        "context_window_size": 131072
+      },
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "parameter_size": "35B (3B active)",
+      "presentation": {
+        "logo": "monogram",
+        "monochrome": false,
+        "monogram": "I"
+      },
+      "publisher": "Shanghai AI Laboratory / Intern",
+      "released_at": "2026-05-15",
+      "revision": "4f57cab513689b089019fce4ad24e26520df183c",
+      "tags": [
+        "open_weights",
+        "multimodal",
+        "reasoning",
+        "agentic",
+        "long_context"
+      ],
+      "verification": {
+        "authority": "Shanghai AI Laboratory / Intern",
+        "source": "https://huggingface.co/internlm/Intern-S2-Preview",
+        "status": "claimed",
+        "verified_at": "2026-09-11"
+      }
+    },
+    {
+      "capabilities": [
+        "chat",
+        "reasoning",
+        "tools",
+        "vision",
+        "video",
+        "long_context"
+      ],
+      "description": "Shanghai AI Laboratory's open multimodal reasoning model for scientific understanding and research assistance.",
+      "display_name": "Intern-S1",
+      "distribution": {
+        "license": "Apache-2.0",
+        "source": "https://huggingface.co/internlm/Intern-S1",
+        "type": "open_weights"
+      },
+      "family": "intern-s1",
+      "id": "intern/intern-s1",
+      "kind": "physical",
+      "lifecycle": "active",
+      "limits": {
+        "context_window_size": 65536,
+        "max_output_tokens": 32768
+      },
+      "modalities": {
+        "input": [
+          "text",
+          "image",
+          "video"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "parameter_size": "235B (22B active)",
+      "presentation": {
+        "logo": "monogram",
+        "monochrome": false,
+        "monogram": "I"
+      },
+      "publisher": "Shanghai AI Laboratory / Intern",
+      "released_at": "2025-07-24",
+      "revision": "4ecad381e28293c4825793f113327cc016cdcbda",
+      "tags": [
+        "open_weights",
+        "multimodal",
+        "reasoning",
+        "scientific",
+        "agentic",
+        "long_context"
+      ],
+      "verification": {
+        "authority": "Shanghai AI Laboratory / Intern",
+        "source": "https://huggingface.co/internlm/Intern-S1",
+        "status": "claimed",
+        "verified_at": "2026-09-11"
+      }
+    },
+    {
+      "capabilities": [
+        "chat",
+        "reasoning",
+        "tools",
         "structured_output",
         "vision",
         "audio",
@@ -95561,6 +97323,51 @@ const builtInCatalogJSON = `{
             "source": "https://huggingface.co/ai21labs/AI21-Jamba-Reasoning-3B",
             "status": "claimed",
             "verified_at": "2026-09-05"
+          }
+        },
+        {
+          "catalog": "intern/intern-s2-preview-397b",
+          "id": "internlm/Intern-S2-Preview-397B",
+          "lifecycle": "active",
+          "protocols": [
+            "openai/chat-completions@1",
+            "openai/responses@1"
+          ],
+          "relationship": "self_hosted",
+          "verification": {
+            "source": "https://huggingface.co/internlm/Intern-S2-Preview-397B",
+            "status": "claimed",
+            "verified_at": "2026-09-11"
+          }
+        },
+        {
+          "catalog": "intern/intern-s2-preview-35b",
+          "id": "internlm/Intern-S2-Preview",
+          "lifecycle": "active",
+          "protocols": [
+            "openai/chat-completions@1",
+            "openai/responses@1"
+          ],
+          "relationship": "self_hosted",
+          "verification": {
+            "source": "https://huggingface.co/internlm/Intern-S2-Preview",
+            "status": "claimed",
+            "verified_at": "2026-09-11"
+          }
+        },
+        {
+          "catalog": "intern/intern-s1",
+          "id": "internlm/Intern-S1",
+          "lifecycle": "active",
+          "protocols": [
+            "openai/chat-completions@1",
+            "openai/responses@1"
+          ],
+          "relationship": "self_hosted",
+          "verification": {
+            "source": "https://huggingface.co/internlm/Intern-S1",
+            "status": "claimed",
+            "verified_at": "2026-09-11"
           }
         },
         {

--- a/tools/catalog/tests/test_generate_model_catalog.py
+++ b/tools/catalog/tests/test_generate_model_catalog.py
@@ -525,6 +525,129 @@ class ModelCatalogCompilerTests(unittest.TestCase):
             {"score": 0},
         )
 
+    def test_intern_creator_has_exact_evidence_buckets_and_real_bindings(
+        self,
+    ) -> None:
+        manifest, resources, _ = catalog.load_and_validate()
+        intern_models = [
+            "intern/intern-s2-preview-397b",
+            "intern/intern-s2-preview-35b",
+            "intern/intern-s1",
+        ]
+        intern_model_set = set(intern_models)
+        creators = {
+            creator["publisher"]: creator["representative_models"]
+            for creator in manifest["inventory"]["physical"]["creators"]
+        }
+        self.assertEqual(
+            creators["Shanghai AI Laboratory / Intern"],
+            intern_models,
+        )
+
+        models = {model["id"]: model for model in resources["models"]}
+        self.assertEqual(
+            {models[model_id]["publisher"] for model_id in intern_models},
+            {"Shanghai AI Laboratory / Intern"},
+        )
+        self.assertEqual(
+            {model_id: models[model_id]["revision"] for model_id in intern_models},
+            {
+                "intern/intern-s2-preview-397b": (
+                    "f4ed28782e23ad9fb4e4895b9069dcd889f5e2a1"
+                ),
+                "intern/intern-s2-preview-35b": (
+                    "4f57cab513689b089019fce4ad24e26520df183c"
+                ),
+                "intern/intern-s1": (
+                    "4ecad381e28293c4825793f113327cc016cdcbda"
+                ),
+            },
+        )
+
+        buckets = _evaluation_benchmarks_by_bucket(resources, intern_model_set)
+        for model_id in intern_models:
+            self.assertGreaterEqual(
+                len(buckets[(model_id, "enabled", "vendor_claimed")]),
+                5,
+            )
+
+        anchor_benchmarks = {
+            "tiger-ai-lab/mmlu-pro@1.0.0",
+            "idavidrein/gpqa-diamond@1.0.0",
+            "cais/humanitys-last-exam@1.0.0",
+            "livecodebench/livecodebench@6.0.0",
+            "scicode-bench/scicode@1.0.0",
+            "harbor/terminal-bench@2.1.0",
+        }
+        anchor_evaluations = [
+            evaluation
+            for evaluation in resources["evaluations"]
+            if evaluation["model"] == "intern/intern-s2-preview-397b"
+            and evaluation["benchmark"] in anchor_benchmarks
+        ]
+        self.assertEqual(
+            {evaluation["benchmark"] for evaluation in anchor_evaluations},
+            anchor_benchmarks,
+        )
+        self.assertEqual(len(anchor_evaluations), 6)
+        self.assertTrue(
+            all(
+                evaluation["subject"]["model_revision"]
+                == "f4ed28782e23ad9fb4e4895b9069dcd889f5e2a1"
+                and evaluation["subject"]["task_artifact"].startswith("https://")
+                and evaluation["subject"]["cost_usd"] is None
+                and evaluation["subject"]["latency_ms"] is None
+                for evaluation in anchor_evaluations
+            )
+        )
+        self.assertTrue(
+            {
+                "matharena/hmmt-feb@2026.0.0",
+                "mmmu-benchmark/mmmu-pro@1.0.0",
+                "swe-bench/pro@1.0.0",
+            }.issubset(
+                buckets[("intern/intern-s2-preview-397b", "enabled", "vendor_claimed")]
+            )
+        )
+
+        snapshot = json.loads(catalog.render_outputs()[catalog.WEBSITE_OUTPUT])
+        anchor_results = {
+            result["index"]: result
+            for result in snapshot["index_results"]
+            if result["model"] == "intern/intern-s2-preview-397b"
+            and result["reasoning_effort"] == "enabled"
+        }
+        for index_id in (
+            "vllm-sr/general@1.0.0",
+            "vllm-sr/reasoning@1.0.0",
+            "vllm-sr/coding@1.0.0",
+            "vllm-sr/agentic@1.0.0",
+            "vllm-sr/intelligence@1.0.0",
+        ):
+            self.assertEqual(anchor_results[index_id]["status"], "available")
+            self.assertIsNotNone(anchor_results[index_id]["score"])
+
+        providers = {provider["id"]: provider for provider in resources["providers"]}
+        vllm_bindings = {
+            binding["catalog"]: binding
+            for binding in providers["vllm"]["models"]
+            if binding["catalog"] in intern_model_set
+        }
+        self.assertEqual(
+            {model_id: vllm_bindings[model_id]["id"] for model_id in intern_models},
+            {
+                "intern/intern-s2-preview-397b": "internlm/Intern-S2-Preview-397B",
+                "intern/intern-s2-preview-35b": "internlm/Intern-S2-Preview",
+                "intern/intern-s1": "internlm/Intern-S1",
+            },
+        )
+        self.assertTrue(
+            all(
+                binding["relationship"] == "self_hosted"
+                for binding in vllm_bindings.values()
+            )
+        )
+
     def test_stepfun_creator_has_exact_efforts_and_real_bindings(self) -> None:
         manifest, resources, _ = catalog.load_and_validate()
         stepfun_models = {

--- a/website/static/model-catalog/catalog.json
+++ b/website/static/model-catalog/catalog.json
@@ -12954,6 +12954,611 @@
       }
     },
     {
+      "benchmark": "tiger-ai-lab/mmlu-pro@1.0.0",
+      "benchmark_profile": "published-standard",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://arxiv.org/html/2608.13505v1",
+        "verification": "claimed"
+      },
+      "id": "intern/intern-s2-preview-397b-report-mmlu-pro@1.0.0",
+      "metrics": {
+        "accuracy": 0.8975
+      },
+      "model": "intern/intern-s2-preview-397b",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "cost_usd": null,
+        "dataset_variant": "MMLU-Pro",
+        "evaluation_harness": "OpenCompass",
+        "latency_ms": null,
+        "maximum_inference_tokens": 262144,
+        "model_revision": "f4ed28782e23ad9fb4e4895b9069dcd889f5e2a1",
+        "sampling_min_p": 0.0,
+        "sampling_temperature": 0.8,
+        "sampling_top_k": 50,
+        "sampling_top_p": 0.95,
+        "source_kind": "official_technical_report",
+        "source_model": "Intern-S2-Preview-397B",
+        "source_model_slug": "intern-s2-preview-397b",
+        "task_artifact": "https://github.com/TIGER-AI-Lab/MMLU-Pro",
+        "task_count": 12000
+      }
+    },
+    {
+      "benchmark": "matharena/hmmt-feb@2026.0.0",
+      "benchmark_profile": "pass-at-1",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://arxiv.org/html/2608.13505v1",
+        "verification": "claimed"
+      },
+      "id": "intern/intern-s2-preview-397b-report-hmmt@1.0.0",
+      "metrics": {
+        "pass_at_1": 0.9157
+      },
+      "model": "intern/intern-s2-preview-397b",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "cost_usd": null,
+        "dataset_variant": "February 2026 Harvard-MIT Mathematics Tournament",
+        "evaluation_harness": "OpenCompass",
+        "latency_ms": null,
+        "maximum_inference_tokens": 262144,
+        "model_revision": "f4ed28782e23ad9fb4e4895b9069dcd889f5e2a1",
+        "sampling_min_p": 0.0,
+        "sampling_temperature": 0.8,
+        "sampling_top_k": 50,
+        "sampling_top_p": 0.95,
+        "source_kind": "official_technical_report",
+        "source_model": "Intern-S2-Preview-397B",
+        "source_model_slug": "intern-s2-preview-397b",
+        "task_artifact": "https://github.com/eth-sri/matharena",
+        "task_count": 33
+      }
+    },
+    {
+      "benchmark": "mmmu-benchmark/mmmu-pro@1.0.0",
+      "benchmark_profile": "standard-10",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://arxiv.org/html/2608.13505v1",
+        "verification": "claimed"
+      },
+      "id": "intern/intern-s2-preview-397b-report-mmmu-pro@1.0.0",
+      "metrics": {
+        "accuracy": 0.8046
+      },
+      "model": "intern/intern-s2-preview-397b",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "cost_usd": null,
+        "dataset_variant": "MMMU-Pro",
+        "evaluation_harness": "VLMEvalKit",
+        "latency_ms": null,
+        "maximum_inference_tokens": 65536,
+        "model_revision": "f4ed28782e23ad9fb4e4895b9069dcd889f5e2a1",
+        "sampling_min_p": 0.0,
+        "sampling_temperature": 0.8,
+        "sampling_top_k": 50,
+        "sampling_top_p": 0.95,
+        "source_kind": "official_technical_report",
+        "source_model": "Intern-S2-Preview-397B",
+        "source_model_slug": "intern-s2-preview-397b",
+        "task_artifact": "https://github.com/MMMU-Benchmark/MMMU"
+      }
+    },
+    {
+      "benchmark": "harbor/terminal-bench@2.1.0",
+      "benchmark_profile": "published-agent",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://arxiv.org/html/2608.13505v1",
+        "verification": "claimed"
+      },
+      "id": "intern/intern-s2-preview-397b-report-terminal-bench@1.0.0",
+      "metrics": {
+        "resolved": 0.6742
+      },
+      "model": "intern/intern-s2-preview-397b",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "agent_harness": "Terminus 2",
+        "cost_usd": null,
+        "latency_ms": null,
+        "maximum_inference_tokens": 262144,
+        "model_revision": "f4ed28782e23ad9fb4e4895b9069dcd889f5e2a1",
+        "sampling_min_p": 0.0,
+        "sampling_temperature": 0.8,
+        "sampling_top_k": 50,
+        "sampling_top_p": 0.95,
+        "source_kind": "official_technical_report",
+        "source_model": "Intern-S2-Preview-397B",
+        "source_model_slug": "intern-s2-preview-397b",
+        "task_artifact": "https://github.com/harbor-framework/terminal-bench-2-1",
+        "task_count": 89
+      }
+    },
+    {
+      "benchmark": "swe-bench/pro@1.0.0",
+      "benchmark_profile": "published-agent",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://arxiv.org/html/2608.13505v1",
+        "verification": "claimed"
+      },
+      "id": "intern/intern-s2-preview-397b-report-swe-bench-pro@1.0.0",
+      "metrics": {
+        "resolved": 0.6156
+      },
+      "model": "intern/intern-s2-preview-397b",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "agent_harness": "Mini-SWE-Agent",
+        "cost_usd": null,
+        "evaluation_image": "modified official evaluation image",
+        "latency_ms": null,
+        "maximum_inference_tokens": 262144,
+        "model_revision": "f4ed28782e23ad9fb4e4895b9069dcd889f5e2a1",
+        "sampling_min_p": 0.0,
+        "sampling_temperature": 0.8,
+        "sampling_top_k": 50,
+        "sampling_top_p": 0.95,
+        "source_kind": "official_technical_report",
+        "source_model": "Intern-S2-Preview-397B",
+        "source_model_slug": "intern-s2-preview-397b",
+        "task_artifact": "https://scale.com/leaderboard/swe_bench_pro_public",
+        "task_count": 1865
+      }
+    },
+    {
+      "benchmark": "scicode-bench/scicode@1.0.0",
+      "benchmark_profile": "published-standard",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://arxiv.org/html/2608.13505v1",
+        "verification": "claimed"
+      },
+      "id": "intern/intern-s2-preview-397b-report-scicode@1.0.0",
+      "metrics": {
+        "score": 0.4911
+      },
+      "model": "intern/intern-s2-preview-397b",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "cost_usd": null,
+        "dataset_variant": "80 problems / 338 subproblems",
+        "evaluation_harness": "OpenCompass",
+        "latency_ms": null,
+        "maximum_inference_tokens": 262144,
+        "model_revision": "f4ed28782e23ad9fb4e4895b9069dcd889f5e2a1",
+        "sampling_min_p": 0.0,
+        "sampling_temperature": 0.8,
+        "sampling_top_k": 50,
+        "sampling_top_p": 0.95,
+        "source_kind": "official_technical_report",
+        "source_model": "Intern-S2-Preview-397B",
+        "source_model_slug": "intern-s2-preview-397b",
+        "task_artifact": "https://github.com/scicode-bench/SciCode",
+        "task_count": 338
+      }
+    },
+    {
+      "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+      "benchmark_profile": "published-standard",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://arxiv.org/html/2608.13505v1",
+        "verification": "claimed"
+      },
+      "id": "intern/intern-s2-preview-397b-anchor-gpqa-diamond@1.0.0",
+      "metrics": {
+        "accuracy": 0.8475
+      },
+      "model": "intern/intern-s2-preview-397b",
+      "observed_at": "2026-09-12",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "cost_usd": null,
+        "dataset_variant": "GPQA Diamond",
+        "evaluation_harness": "OpenCompass",
+        "latency_ms": null,
+        "maximum_inference_tokens": 262144,
+        "model_revision": "f4ed28782e23ad9fb4e4895b9069dcd889f5e2a1",
+        "sampling_min_p": 0.0,
+        "sampling_temperature": 0.8,
+        "sampling_top_k": 50,
+        "sampling_top_p": 0.95,
+        "source_kind": "official_anchor_reproduction",
+        "source_model": "Intern-S2-Preview-397B",
+        "source_model_slug": "intern-s2-preview-397b",
+        "task_artifact": "https://github.com/idavidrein/gpqa",
+        "task_count": 198
+      }
+    },
+    {
+      "benchmark": "cais/humanitys-last-exam@1.0.0",
+      "benchmark_profile": "text-only",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://arxiv.org/html/2608.13505v1",
+        "verification": "claimed"
+      },
+      "id": "intern/intern-s2-preview-397b-anchor-humanitys-last-exam@1.0.0",
+      "metrics": {
+        "accuracy": 0.268
+      },
+      "model": "intern/intern-s2-preview-397b",
+      "observed_at": "2026-09-12",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "cost_usd": null,
+        "dataset_variant": "May 2025 text-only subset",
+        "evaluation_harness": "OpenCompass",
+        "latency_ms": null,
+        "maximum_inference_tokens": 262144,
+        "model_revision": "f4ed28782e23ad9fb4e4895b9069dcd889f5e2a1",
+        "sampling_min_p": 0.0,
+        "sampling_temperature": 0.8,
+        "sampling_top_k": 50,
+        "sampling_top_p": 0.95,
+        "source_kind": "official_anchor_reproduction",
+        "source_model": "Intern-S2-Preview-397B",
+        "source_model_slug": "intern-s2-preview-397b",
+        "task_artifact": "https://github.com/centerforaisafety/hle",
+        "task_count": 2158,
+        "tool_policy": "no_tools"
+      }
+    },
+    {
+      "benchmark": "livecodebench/livecodebench@6.0.0",
+      "benchmark_profile": "published-code-generation",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://arxiv.org/html/2608.13505v1",
+        "verification": "claimed"
+      },
+      "id": "intern/intern-s2-preview-397b-anchor-livecodebench-v6@1.0.0",
+      "metrics": {
+        "pass_at_1": 0.734
+      },
+      "model": "intern/intern-s2-preview-397b",
+      "observed_at": "2026-09-12",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "cost_usd": null,
+        "dataset_release": "v6",
+        "evaluation_harness": "OpenCompass",
+        "latency_ms": null,
+        "maximum_inference_tokens": 262144,
+        "model_revision": "f4ed28782e23ad9fb4e4895b9069dcd889f5e2a1",
+        "problem_window": "2023-05_to_2025-04",
+        "sampling_min_p": 0.0,
+        "sampling_temperature": 0.8,
+        "sampling_top_k": 50,
+        "sampling_top_p": 0.95,
+        "source_kind": "official_anchor_reproduction",
+        "source_model": "Intern-S2-Preview-397B",
+        "source_model_slug": "intern-s2-preview-397b",
+        "task_artifact": "https://github.com/LiveCodeBench/LiveCodeBench",
+        "task_count": 1055
+      }
+    },
+    {
+      "benchmark": "tiger-ai-lab/mmlu-pro@1.0.0",
+      "benchmark_profile": "published-standard",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/internlm/Intern-S2-Preview",
+        "verification": "claimed"
+      },
+      "id": "intern/intern-s2-preview-35b-eval-mmlu-pro@1.0.0",
+      "metrics": {
+        "accuracy": 0.88
+      },
+      "model": "intern/intern-s2-preview-35b",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "dataset_variant": "MMLU-Pro",
+        "evaluation_harness": "OpenCompass",
+        "maximum_inference_tokens": 131072,
+        "model_revision": "4f57cab513689b089019fce4ad24e26520df183c",
+        "sampling_min_p": 0.0,
+        "sampling_temperature": 0.8,
+        "sampling_top_k": 50,
+        "sampling_top_p": 0.95,
+        "source_kind": "official_huggingface_eval_result",
+        "variant": "Intern-S2-Preview 35B"
+      }
+    },
+    {
+      "benchmark": "cais/humanitys-last-exam@1.0.0",
+      "benchmark_profile": "published-unspecified",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/internlm/Intern-S2-Preview",
+        "verification": "claimed"
+      },
+      "id": "intern/intern-s2-preview-35b-eval-hle@1.0.0",
+      "metrics": {
+        "accuracy": 0.2194
+      },
+      "model": "intern/intern-s2-preview-35b",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "dataset_variant": "HLE",
+        "evaluation_harness": "unspecified",
+        "maximum_inference_tokens": 131072,
+        "model_revision": "4f57cab513689b089019fce4ad24e26520df183c",
+        "sampling_min_p": 0.0,
+        "sampling_temperature": 0.8,
+        "sampling_top_k": 50,
+        "sampling_top_p": 0.95,
+        "source_kind": "official_huggingface_eval_result",
+        "tool_policy": "unspecified",
+        "variant": "Intern-S2-Preview 35B"
+      }
+    },
+    {
+      "benchmark": "matharena/hmmt-feb@2026.0.0",
+      "benchmark_profile": "pass-at-1",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/internlm/Intern-S2-Preview",
+        "verification": "claimed"
+      },
+      "id": "intern/intern-s2-preview-35b-eval-hmmt@1.0.0",
+      "metrics": {
+        "pass_at_1": 0.8731
+      },
+      "model": "intern/intern-s2-preview-35b",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "dataset_variant": "February 2026 Harvard-MIT Mathematics Tournament",
+        "evaluation_harness": "OpenCompass",
+        "maximum_inference_tokens": 131072,
+        "model_revision": "4f57cab513689b089019fce4ad24e26520df183c",
+        "sampling_min_p": 0.0,
+        "sampling_temperature": 0.8,
+        "sampling_top_k": 50,
+        "sampling_top_p": 0.95,
+        "source_kind": "official_huggingface_eval_result",
+        "variant": "Intern-S2-Preview 35B"
+      }
+    },
+    {
+      "benchmark": "mmmu-benchmark/mmmu-pro@1.0.0",
+      "benchmark_profile": "standard-10",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/internlm/Intern-S2-Preview",
+        "verification": "claimed"
+      },
+      "id": "intern/intern-s2-preview-35b-eval-mmmu-pro@1.0.0",
+      "metrics": {
+        "accuracy": 0.7688
+      },
+      "model": "intern/intern-s2-preview-35b",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "dataset_variant": "MMMU-Pro",
+        "evaluation_harness": "VLMEvalKit",
+        "evaluation_label": "MMMU Pro Vision",
+        "maximum_inference_tokens": 65536,
+        "model_revision": "4f57cab513689b089019fce4ad24e26520df183c",
+        "sampling_min_p": 0.0,
+        "sampling_temperature": 0.8,
+        "sampling_top_k": 50,
+        "sampling_top_p": 0.95,
+        "source_kind": "official_huggingface_eval_result",
+        "variant": "Intern-S2-Preview 35B"
+      }
+    },
+    {
+      "benchmark": "swe-bench/verified@1.0.0",
+      "benchmark_profile": "published-agent",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/internlm/Intern-S2-Preview",
+        "verification": "claimed"
+      },
+      "id": "intern/intern-s2-preview-35b-eval-swe-bench-verified@1.0.0",
+      "metrics": {
+        "resolved": 0.64
+      },
+      "model": "intern/intern-s2-preview-35b",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "evaluation_label": "SWE-bench Verified",
+        "model_revision": "4f57cab513689b089019fce4ad24e26520df183c",
+        "source_kind": "official_huggingface_eval_result",
+        "variant": "Intern-S2-Preview 35B"
+      }
+    },
+    {
+      "benchmark": "tiger-ai-lab/mmlu-pro@1.0.0",
+      "benchmark_profile": "published-standard",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/internlm/Intern-S1/blob/4ecad381e28293c4825793f113327cc016cdcbda/README.md",
+        "verification": "claimed"
+      },
+      "id": "intern/intern-s1-model-card-mmlu-pro@1.0.0",
+      "metrics": {
+        "accuracy": 0.835
+      },
+      "model": "intern/intern-s1",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "dataset_variant": "MMLU-Pro",
+        "evaluation_harness": "OpenCompass",
+        "model_revision": "4ecad381e28293c4825793f113327cc016cdcbda",
+        "sampling_min_p": 0.0,
+        "sampling_temperature": 0.7,
+        "sampling_top_k": 50,
+        "sampling_top_p": 1.0,
+        "source_kind": "official_model_card",
+        "variant": "Intern-S1"
+      }
+    },
+    {
+      "benchmark": "mmmu-benchmark/mmmu@1.0.0",
+      "benchmark_profile": "dev-val",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/internlm/Intern-S1/blob/4ecad381e28293c4825793f113327cc016cdcbda/README.md",
+        "verification": "claimed"
+      },
+      "id": "intern/intern-s1-model-card-mmmu@1.0.0",
+      "metrics": {
+        "accuracy": 0.777
+      },
+      "model": "intern/intern-s1",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "dataset_variant": "MMMU (model card table; split unspecified)",
+        "evaluation_harness": "VLMEvalKit",
+        "model_revision": "4ecad381e28293c4825793f113327cc016cdcbda",
+        "sampling_min_p": 0.0,
+        "sampling_temperature": 0.7,
+        "sampling_top_k": 50,
+        "sampling_top_p": 1.0,
+        "source_kind": "official_model_card",
+        "variant": "Intern-S1"
+      }
+    },
+    {
+      "benchmark": "mathvista/mathvista@1.0.0",
+      "benchmark_profile": "mini",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/internlm/Intern-S1/blob/4ecad381e28293c4825793f113327cc016cdcbda/README.md",
+        "verification": "claimed"
+      },
+      "id": "intern/intern-s1-model-card-mathvista@1.0.0",
+      "metrics": {
+        "accuracy": 0.815
+      },
+      "model": "intern/intern-s1",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "dataset_variant": "MathVista mini",
+        "evaluation_harness": "VLMEvalKit",
+        "model_revision": "4ecad381e28293c4825793f113327cc016cdcbda",
+        "sampling_min_p": 0.0,
+        "sampling_temperature": 0.7,
+        "sampling_top_k": 50,
+        "sampling_top_p": 1.0,
+        "source_kind": "official_model_card",
+        "variant": "Intern-S1"
+      }
+    },
+    {
+      "benchmark": "matharena/aime@2025.0.0",
+      "benchmark_profile": "pass-at-1",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/internlm/Intern-S1/blob/4ecad381e28293c4825793f113327cc016cdcbda/README.md",
+        "verification": "claimed"
+      },
+      "id": "intern/intern-s1-model-card-aime-2025@1.0.0",
+      "metrics": {
+        "pass_at_1": 0.86
+      },
+      "model": "intern/intern-s1",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "dataset_variant": "AIME2025",
+        "evaluation_harness": "OpenCompass",
+        "model_revision": "4ecad381e28293c4825793f113327cc016cdcbda",
+        "sampling_min_p": 0.0,
+        "sampling_temperature": 0.7,
+        "sampling_top_k": 50,
+        "sampling_top_p": 1.0,
+        "source_kind": "official_model_card",
+        "variant": "Intern-S1"
+      }
+    },
+    {
+      "benchmark": "google/ifeval@1.0.0",
+      "benchmark_profile": "published-standard",
+      "evidence": {
+        "provenance": "vendor_claimed",
+        "redistributable": true,
+        "source": "https://huggingface.co/internlm/Intern-S1/blob/4ecad381e28293c4825793f113327cc016cdcbda/README.md",
+        "verification": "claimed"
+      },
+      "id": "intern/intern-s1-model-card-ifeval@1.0.0",
+      "metrics": {
+        "accuracy": 0.867
+      },
+      "model": "intern/intern-s1",
+      "observed_at": "2026-09-11",
+      "reasoning_effort": "enabled",
+      "status": "available",
+      "subject": {
+        "evaluation_harness": "OpenCompass",
+        "model_revision": "4ecad381e28293c4825793f113327cc016cdcbda",
+        "sampling_min_p": 0.0,
+        "sampling_temperature": 0.7,
+        "sampling_top_k": 50,
+        "sampling_top_p": 1.0,
+        "source_kind": "official_model_card",
+        "variant": "Intern-S1"
+      }
+    },
+    {
       "benchmark": "artificial-analysis/briefcase@1.0.0",
       "benchmark_profile": "independent-agent",
       "evidence": {
@@ -52572,6 +53177,997 @@
       ],
       "coverage": 0.0,
       "index": "vllm-sr/general@1.0.0",
+      "model": "intern/intern-s2-preview-397b",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "cais/humanitys-last-exam@1.0.0",
+          "benchmark_profiles": [
+            "independent-text-only",
+            "text-only"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/reasoning@1.0.0",
+      "model": "intern/intern-s2-preview-397b",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "livecodebench/livecodebench@6.0.0",
+          "benchmark_profiles": [
+            "independent-code-generation",
+            "published-code-generation"
+          ],
+          "metric": "pass_at_1",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "scicode-bench/scicode@1.0.0",
+          "benchmark_profiles": [
+            "independent-test-288",
+            "published-standard"
+          ],
+          "metric": "score",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/coding@1.0.0",
+      "model": "intern/intern-s2-preview-397b",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "harbor/terminal-bench@2.1.0",
+          "benchmark_profiles": [
+            "independent-agent",
+            "published-agent"
+          ],
+          "metric": "resolved",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/agentic@1.0.0",
+      "model": "intern/intern-s2-preview-397b",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "index": "vllm-sr/general@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/reasoning@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.4
+        },
+        {
+          "index": "vllm-sr/coding@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/agentic@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/intelligence@1.0.0",
+      "model": "intern/intern-s2-preview-397b",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "tiger-ai-lab/mmlu-pro@1.0.0",
+          "benchmark_profile": "published-standard",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "evaluation": "intern/intern-s2-preview-397b-report-mmlu-pro@1.0.0",
+          "metric": "accuracy",
+          "normalized": 0.8975,
+          "status": "available",
+          "value": 0.8975,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 1.0,
+      "domains": {
+        "general_reasoning": 89.75
+      },
+      "index": "vllm-sr/general@1.0.0",
+      "model": "intern/intern-s2-preview-397b",
+      "provenance": [
+        "intern/intern-s2-preview-397b-report-mmlu-pro@1.0.0"
+      ],
+      "reasoning_effort": "enabled",
+      "score": 89.75,
+      "status": "available"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+          "benchmark_profile": "published-standard",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "evaluation": "intern/intern-s2-preview-397b-anchor-gpqa-diamond@1.0.0",
+          "metric": "accuracy",
+          "normalized": 0.8475,
+          "status": "available",
+          "value": 0.8475,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "cais/humanitys-last-exam@1.0.0",
+          "benchmark_profile": "text-only",
+          "benchmark_profiles": [
+            "independent-text-only",
+            "text-only"
+          ],
+          "evaluation": "intern/intern-s2-preview-397b-anchor-humanitys-last-exam@1.0.0",
+          "metric": "accuracy",
+          "normalized": 0.268,
+          "status": "available",
+          "value": 0.268,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 1.0,
+      "domains": {
+        "frontier_reasoning": 26.8,
+        "scientific_reasoning": 84.75
+      },
+      "index": "vllm-sr/reasoning@1.0.0",
+      "model": "intern/intern-s2-preview-397b",
+      "provenance": [
+        "intern/intern-s2-preview-397b-anchor-gpqa-diamond@1.0.0",
+        "intern/intern-s2-preview-397b-anchor-humanitys-last-exam@1.0.0"
+      ],
+      "reasoning_effort": "enabled",
+      "score": 55.775,
+      "status": "available"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "livecodebench/livecodebench@6.0.0",
+          "benchmark_profile": "published-code-generation",
+          "benchmark_profiles": [
+            "independent-code-generation",
+            "published-code-generation"
+          ],
+          "evaluation": "intern/intern-s2-preview-397b-anchor-livecodebench-v6@1.0.0",
+          "metric": "pass_at_1",
+          "normalized": 0.734,
+          "status": "available",
+          "value": 0.734,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "scicode-bench/scicode@1.0.0",
+          "benchmark_profile": "published-standard",
+          "benchmark_profiles": [
+            "independent-test-288",
+            "published-standard"
+          ],
+          "evaluation": "intern/intern-s2-preview-397b-report-scicode@1.0.0",
+          "metric": "score",
+          "normalized": 0.4911,
+          "status": "available",
+          "value": 0.4911,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 1.0,
+      "domains": {
+        "competitive_programming": 73.4,
+        "scientific_coding": 49.11
+      },
+      "index": "vllm-sr/coding@1.0.0",
+      "model": "intern/intern-s2-preview-397b",
+      "provenance": [
+        "intern/intern-s2-preview-397b-anchor-livecodebench-v6@1.0.0",
+        "intern/intern-s2-preview-397b-report-scicode@1.0.0"
+      ],
+      "reasoning_effort": "enabled",
+      "score": 61.254999999999995,
+      "status": "available"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "harbor/terminal-bench@2.1.0",
+          "benchmark_profile": "published-agent",
+          "benchmark_profiles": [
+            "independent-agent",
+            "published-agent"
+          ],
+          "evaluation": "intern/intern-s2-preview-397b-report-terminal-bench@1.0.0",
+          "metric": "resolved",
+          "normalized": 0.6742,
+          "status": "available",
+          "value": 0.6742,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 1.0,
+      "domains": {
+        "agentic_systems": 67.42
+      },
+      "index": "vllm-sr/agentic@1.0.0",
+      "model": "intern/intern-s2-preview-397b",
+      "provenance": [
+        "intern/intern-s2-preview-397b-report-terminal-bench@1.0.0"
+      ],
+      "reasoning_effort": "enabled",
+      "score": 67.42,
+      "status": "available"
+    },
+    {
+      "components": [
+        {
+          "index": "vllm-sr/general@1.0.0",
+          "normalized": 0.8975,
+          "status": "available",
+          "value": 0.8975,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/reasoning@1.0.0",
+          "normalized": 0.55775,
+          "status": "available",
+          "value": 0.55775,
+          "weight": 0.4
+        },
+        {
+          "index": "vllm-sr/coding@1.0.0",
+          "normalized": 0.6125499999999999,
+          "status": "available",
+          "value": 0.6125499999999999,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/agentic@1.0.0",
+          "normalized": 0.6742,
+          "status": "available",
+          "value": 0.6742,
+          "weight": 0.2
+        }
+      ],
+      "coverage": 1.0,
+      "index": "vllm-sr/intelligence@1.0.0",
+      "model": "intern/intern-s2-preview-397b",
+      "provenance": [
+        "intern/intern-s2-preview-397b-anchor-gpqa-diamond@1.0.0",
+        "intern/intern-s2-preview-397b-anchor-humanitys-last-exam@1.0.0",
+        "intern/intern-s2-preview-397b-anchor-livecodebench-v6@1.0.0",
+        "intern/intern-s2-preview-397b-report-mmlu-pro@1.0.0",
+        "intern/intern-s2-preview-397b-report-scicode@1.0.0",
+        "intern/intern-s2-preview-397b-report-terminal-bench@1.0.0"
+      ],
+      "reasoning_effort": "enabled",
+      "score": 65.995,
+      "status": "available"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "tiger-ai-lab/mmlu-pro@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/general@1.0.0",
+      "model": "intern/intern-s2-preview-35b",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "cais/humanitys-last-exam@1.0.0",
+          "benchmark_profiles": [
+            "independent-text-only",
+            "text-only"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/reasoning@1.0.0",
+      "model": "intern/intern-s2-preview-35b",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "livecodebench/livecodebench@6.0.0",
+          "benchmark_profiles": [
+            "independent-code-generation",
+            "published-code-generation"
+          ],
+          "metric": "pass_at_1",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "scicode-bench/scicode@1.0.0",
+          "benchmark_profiles": [
+            "independent-test-288",
+            "published-standard"
+          ],
+          "metric": "score",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/coding@1.0.0",
+      "model": "intern/intern-s2-preview-35b",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "harbor/terminal-bench@2.1.0",
+          "benchmark_profiles": [
+            "independent-agent",
+            "published-agent"
+          ],
+          "metric": "resolved",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/agentic@1.0.0",
+      "model": "intern/intern-s2-preview-35b",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "index": "vllm-sr/general@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/reasoning@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.4
+        },
+        {
+          "index": "vllm-sr/coding@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/agentic@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/intelligence@1.0.0",
+      "model": "intern/intern-s2-preview-35b",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "tiger-ai-lab/mmlu-pro@1.0.0",
+          "benchmark_profile": "published-standard",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "evaluation": "intern/intern-s2-preview-35b-eval-mmlu-pro@1.0.0",
+          "metric": "accuracy",
+          "normalized": 0.88,
+          "status": "available",
+          "value": 0.88,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 1.0,
+      "domains": {
+        "general_reasoning": 88.0
+      },
+      "index": "vllm-sr/general@1.0.0",
+      "model": "intern/intern-s2-preview-35b",
+      "provenance": [
+        "intern/intern-s2-preview-35b-eval-mmlu-pro@1.0.0"
+      ],
+      "reasoning_effort": "enabled",
+      "score": 88.0,
+      "status": "available"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "cais/humanitys-last-exam@1.0.0",
+          "benchmark_profiles": [
+            "independent-text-only",
+            "text-only"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/reasoning@1.0.0",
+      "model": "intern/intern-s2-preview-35b",
+      "provenance": [],
+      "reasoning_effort": "enabled",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "livecodebench/livecodebench@6.0.0",
+          "benchmark_profiles": [
+            "independent-code-generation",
+            "published-code-generation"
+          ],
+          "metric": "pass_at_1",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "scicode-bench/scicode@1.0.0",
+          "benchmark_profiles": [
+            "independent-test-288",
+            "published-standard"
+          ],
+          "metric": "score",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/coding@1.0.0",
+      "model": "intern/intern-s2-preview-35b",
+      "provenance": [],
+      "reasoning_effort": "enabled",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "harbor/terminal-bench@2.1.0",
+          "benchmark_profiles": [
+            "independent-agent",
+            "published-agent"
+          ],
+          "metric": "resolved",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/agentic@1.0.0",
+      "model": "intern/intern-s2-preview-35b",
+      "provenance": [],
+      "reasoning_effort": "enabled",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "index": "vllm-sr/general@1.0.0",
+          "normalized": 0.88,
+          "status": "available",
+          "value": 0.88,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/reasoning@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.4
+        },
+        {
+          "index": "vllm-sr/coding@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/agentic@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        }
+      ],
+      "coverage": 0.2,
+      "index": "vllm-sr/intelligence@1.0.0",
+      "model": "intern/intern-s2-preview-35b",
+      "provenance": [
+        "intern/intern-s2-preview-35b-eval-mmlu-pro@1.0.0"
+      ],
+      "reasoning_effort": "enabled",
+      "score": null,
+      "status": "partial"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "tiger-ai-lab/mmlu-pro@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/general@1.0.0",
+      "model": "intern/intern-s1",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "cais/humanitys-last-exam@1.0.0",
+          "benchmark_profiles": [
+            "independent-text-only",
+            "text-only"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/reasoning@1.0.0",
+      "model": "intern/intern-s1",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "livecodebench/livecodebench@6.0.0",
+          "benchmark_profiles": [
+            "independent-code-generation",
+            "published-code-generation"
+          ],
+          "metric": "pass_at_1",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "scicode-bench/scicode@1.0.0",
+          "benchmark_profiles": [
+            "independent-test-288",
+            "published-standard"
+          ],
+          "metric": "score",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/coding@1.0.0",
+      "model": "intern/intern-s1",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "harbor/terminal-bench@2.1.0",
+          "benchmark_profiles": [
+            "independent-agent",
+            "published-agent"
+          ],
+          "metric": "resolved",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/agentic@1.0.0",
+      "model": "intern/intern-s1",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "index": "vllm-sr/general@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/reasoning@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.4
+        },
+        {
+          "index": "vllm-sr/coding@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/agentic@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/intelligence@1.0.0",
+      "model": "intern/intern-s1",
+      "provenance": [],
+      "reasoning_effort": "default",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "tiger-ai-lab/mmlu-pro@1.0.0",
+          "benchmark_profile": "published-standard",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "evaluation": "intern/intern-s1-model-card-mmlu-pro@1.0.0",
+          "metric": "accuracy",
+          "normalized": 0.835,
+          "status": "available",
+          "value": 0.835,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 1.0,
+      "domains": {
+        "general_reasoning": 83.5
+      },
+      "index": "vllm-sr/general@1.0.0",
+      "model": "intern/intern-s1",
+      "provenance": [
+        "intern/intern-s1-model-card-mmlu-pro@1.0.0"
+      ],
+      "reasoning_effort": "enabled",
+      "score": 83.5,
+      "status": "available"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "idavidrein/gpqa-diamond@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "cais/humanitys-last-exam@1.0.0",
+          "benchmark_profiles": [
+            "independent-text-only",
+            "text-only"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/reasoning@1.0.0",
+      "model": "intern/intern-s1",
+      "provenance": [],
+      "reasoning_effort": "enabled",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "livecodebench/livecodebench@6.0.0",
+          "benchmark_profiles": [
+            "independent-code-generation",
+            "published-code-generation"
+          ],
+          "metric": "pass_at_1",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        },
+        {
+          "benchmark": "scicode-bench/scicode@1.0.0",
+          "benchmark_profiles": [
+            "independent-test-288",
+            "published-standard"
+          ],
+          "metric": "score",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.5
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/coding@1.0.0",
+      "model": "intern/intern-s1",
+      "provenance": [],
+      "reasoning_effort": "enabled",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "harbor/terminal-bench@2.1.0",
+          "benchmark_profiles": [
+            "independent-agent",
+            "published-agent"
+          ],
+          "metric": "resolved",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/agentic@1.0.0",
+      "model": "intern/intern-s1",
+      "provenance": [],
+      "reasoning_effort": "enabled",
+      "score": null,
+      "status": "missing"
+    },
+    {
+      "components": [
+        {
+          "index": "vllm-sr/general@1.0.0",
+          "normalized": 0.835,
+          "status": "available",
+          "value": 0.835,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/reasoning@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.4
+        },
+        {
+          "index": "vllm-sr/coding@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        },
+        {
+          "index": "vllm-sr/agentic@1.0.0",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 0.2
+        }
+      ],
+      "coverage": 0.2,
+      "index": "vllm-sr/intelligence@1.0.0",
+      "model": "intern/intern-s1",
+      "provenance": [
+        "intern/intern-s1-model-card-mmlu-pro@1.0.0"
+      ],
+      "reasoning_effort": "enabled",
+      "score": null,
+      "status": "partial"
+    },
+    {
+      "components": [
+        {
+          "benchmark": "tiger-ai-lab/mmlu-pro@1.0.0",
+          "benchmark_profiles": [
+            "independent-standard",
+            "published-standard"
+          ],
+          "metric": "accuracy",
+          "normalized": null,
+          "status": "missing",
+          "value": null,
+          "weight": 1.0
+        }
+      ],
+      "coverage": 0.0,
+      "index": "vllm-sr/general@1.0.0",
       "model": "meta/muse-spark-1.3",
       "provenance": [],
       "reasoning_effort": "minimal",
@@ -87964,6 +89560,172 @@
         "chat",
         "reasoning",
         "tools",
+        "vision",
+        "long_context"
+      ],
+      "description": "Shanghai AI Laboratory's multimodal scientific foundation model for long-horizon reasoning and agentic workflows.",
+      "display_name": "Intern-S2-Preview 397B",
+      "distribution": {
+        "license": "Apache-2.0",
+        "source": "https://huggingface.co/internlm/Intern-S2-Preview-397B",
+        "type": "open_weights"
+      },
+      "family": "intern-s2-preview",
+      "id": "intern/intern-s2-preview-397b",
+      "kind": "physical",
+      "lifecycle": "active",
+      "limits": {
+        "context_window_size": 262144
+      },
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "parameter_size": "397B (17B active)",
+      "presentation": {
+        "logo": "monogram",
+        "monochrome": false,
+        "monogram": "I"
+      },
+      "publisher": "Shanghai AI Laboratory / Intern",
+      "released_at": "2026-07-16",
+      "revision": "f4ed28782e23ad9fb4e4895b9069dcd889f5e2a1",
+      "tags": [
+        "open_weights",
+        "multimodal",
+        "reasoning",
+        "agentic",
+        "long_context"
+      ],
+      "verification": {
+        "authority": "Shanghai AI Laboratory / Intern",
+        "source": "https://huggingface.co/internlm/Intern-S2-Preview-397B",
+        "status": "claimed",
+        "verified_at": "2026-09-11"
+      }
+    },
+    {
+      "capabilities": [
+        "chat",
+        "reasoning",
+        "tools",
+        "vision",
+        "long_context"
+      ],
+      "description": "Shanghai AI Laboratory's efficient multimodal scientific foundation model for reasoning and scientific agent workflows.",
+      "display_name": "Intern-S2-Preview 35B",
+      "distribution": {
+        "license": "Apache-2.0",
+        "source": "https://huggingface.co/internlm/Intern-S2-Preview",
+        "type": "open_weights"
+      },
+      "family": "intern-s2-preview",
+      "id": "intern/intern-s2-preview-35b",
+      "kind": "physical",
+      "lifecycle": "active",
+      "limits": {
+        "context_window_size": 131072
+      },
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "parameter_size": "35B (3B active)",
+      "presentation": {
+        "logo": "monogram",
+        "monochrome": false,
+        "monogram": "I"
+      },
+      "publisher": "Shanghai AI Laboratory / Intern",
+      "released_at": "2026-05-15",
+      "revision": "4f57cab513689b089019fce4ad24e26520df183c",
+      "tags": [
+        "open_weights",
+        "multimodal",
+        "reasoning",
+        "agentic",
+        "long_context"
+      ],
+      "verification": {
+        "authority": "Shanghai AI Laboratory / Intern",
+        "source": "https://huggingface.co/internlm/Intern-S2-Preview",
+        "status": "claimed",
+        "verified_at": "2026-09-11"
+      }
+    },
+    {
+      "capabilities": [
+        "chat",
+        "reasoning",
+        "tools",
+        "vision",
+        "video",
+        "long_context"
+      ],
+      "description": "Shanghai AI Laboratory's open multimodal reasoning model for scientific understanding and research assistance.",
+      "display_name": "Intern-S1",
+      "distribution": {
+        "license": "Apache-2.0",
+        "source": "https://huggingface.co/internlm/Intern-S1",
+        "type": "open_weights"
+      },
+      "family": "intern-s1",
+      "id": "intern/intern-s1",
+      "kind": "physical",
+      "lifecycle": "active",
+      "limits": {
+        "context_window_size": 65536,
+        "max_output_tokens": 32768
+      },
+      "modalities": {
+        "input": [
+          "text",
+          "image",
+          "video"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "parameter_size": "235B (22B active)",
+      "presentation": {
+        "logo": "monogram",
+        "monochrome": false,
+        "monogram": "I"
+      },
+      "publisher": "Shanghai AI Laboratory / Intern",
+      "released_at": "2025-07-24",
+      "revision": "4ecad381e28293c4825793f113327cc016cdcbda",
+      "tags": [
+        "open_weights",
+        "multimodal",
+        "reasoning",
+        "scientific",
+        "agentic",
+        "long_context"
+      ],
+      "verification": {
+        "authority": "Shanghai AI Laboratory / Intern",
+        "source": "https://huggingface.co/internlm/Intern-S1",
+        "status": "claimed",
+        "verified_at": "2026-09-11"
+      }
+    },
+    {
+      "capabilities": [
+        "chat",
+        "reasoning",
+        "tools",
         "structured_output",
         "vision",
         "audio",
@@ -95555,6 +97317,51 @@
             "source": "https://huggingface.co/ai21labs/AI21-Jamba-Reasoning-3B",
             "status": "claimed",
             "verified_at": "2026-09-05"
+          }
+        },
+        {
+          "catalog": "intern/intern-s2-preview-397b",
+          "id": "internlm/Intern-S2-Preview-397B",
+          "lifecycle": "active",
+          "protocols": [
+            "openai/chat-completions@1",
+            "openai/responses@1"
+          ],
+          "relationship": "self_hosted",
+          "verification": {
+            "source": "https://huggingface.co/internlm/Intern-S2-Preview-397B",
+            "status": "claimed",
+            "verified_at": "2026-09-11"
+          }
+        },
+        {
+          "catalog": "intern/intern-s2-preview-35b",
+          "id": "internlm/Intern-S2-Preview",
+          "lifecycle": "active",
+          "protocols": [
+            "openai/chat-completions@1",
+            "openai/responses@1"
+          ],
+          "relationship": "self_hosted",
+          "verification": {
+            "source": "https://huggingface.co/internlm/Intern-S2-Preview",
+            "status": "claimed",
+            "verified_at": "2026-09-11"
+          }
+        },
+        {
+          "catalog": "intern/intern-s1",
+          "id": "internlm/Intern-S1",
+          "lifecycle": "active",
+          "protocols": [
+            "openai/chat-completions@1",
+            "openai/responses@1"
+          ],
+          "relationship": "self_hosted",
+          "verification": {
+            "source": "https://huggingface.co/internlm/Intern-S1",
+            "status": "claimed",
+            "verified_at": "2026-09-11"
           }
         },
         {


### PR DESCRIPTION
<!-- markdownlint-disable -->

Closes #3603

## Purpose

Admit Shanghai AI Laboratory / Intern as a creator-owned built-in catalog slice under `wg/evaluation-quality`.

- Adds exactly three canonical Intern Model Cards and exact self-hosted vLLM mappings.
- Keeps the existing 397B, 35B, and S1 model revisions and non-anchor evidence records.
- Completes the 397B anchor evidence set required by Intelligence 1.0: MMLU-Pro, GPQA Diamond, Humanity's Last Exam text-only, LiveCodeBench v6, SciCode, and Terminal-Bench 2.1.
- Verifies that the same 397B revision and `enabled` reasoning effort materialize `available` General, Reasoning, Coding, Agentic, and Overall Intelligence profiles.
- Regenerates the Router recipe, Go catalog, website snapshot, and dashboard inventory projection.

## Test Plan

- `python tools/catalog/generate_model_catalog.py --check`
- `python -m unittest -v tools.catalog.tests.test_generate_model_catalog`
- `python tools/ci/sync_evaluation_catalogs.py --check`
- `python tools/catalog/audit_model_catalog.py --require-min-evaluations-per-model 5`
- `go test ./pkg/catalog/...` from `src/semantic-router`
- `go test ./handlers/ -run TestGeneratedPublicModelCatalogSatisfiesDashboardContract -count=1` from `dashboard/backend`

## Test Result

- Passed catalog generation check.
- Passed all 23 `test_generate_model_catalog` tests.
- Passed evaluation catalog synchronization check.
- Passed catalog audit: 99 physical models, 5 virtual models, 61 providers, 1529 evaluations, and 1529 available evaluations; no physical model is below five benchmarks in an exact evidence bucket.
- Passed `go test ./pkg/catalog/...`.
- Dashboard handler test is blocked on Windows during package compilation by pre-existing undefined symbols `maxRuntimeLogLineBytes` and `runtimeLogTruncatedMarker` in `dashboard/backend/handlers/logs_test.go`; the target test did not execute.

---
<details>
<summary>Semantic Router PR Checklist</summary>

- [x] PR title begins with exactly one bracketed category, such as `[Feature]`, `[Bug]`, `[Docs]`, `[Test]`, `[Research]`, `[Community]`, or `[CI/Build]`
- [x] The title does not stack prefixes such as `[Router][Docs]`; affected modules belong in labels and the PR body
- [x] The PR links an `accepted` issue with exactly one owner: one `wg/*` label for project work or `owner/maintainers` for repository governance
- [x] Commits in this PR are signed off with `git commit -s`
- [x] The Purpose, Test Plan, and Test Result sections reflect the actual scope, commands, and blockers for this change

</details>

See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow and commit guidance.
