### PR TITLE
[Bug] correct branding and docs links

### DIFF
--- a/dashboard/frontend/src/components/Layout.tsx
+++ b/dashboard/frontend/src/components/Layout.tsx
@@ -333,7 +333,7 @@ const Layout: React.FC<LayoutProps> = ({
           <div className={styles.headerRight}>
             <PlatformBranding variant="inline" className={styles.headerBranding} />
             <a
-              href="https://vllm-sr.ai"
+              href="https://vllm-sr.ai/docs/intro/"
               target="_blank"
               rel="noopener noreferrer"
               className={styles.iconButton}

--- a/dashboard/frontend/src/components/PlatformBranding.tsx
+++ b/dashboard/frontend/src/components/PlatformBranding.tsx
@@ -33,7 +33,9 @@ const PlatformBranding = ({ variant = 'default', className = '' }: PlatformBrand
 
   return (
     <div className={`${styles.container} ${styles[variant]} ${className}`}>
-      <img src={imageSrc} alt="AMD" className={styles.logo} />
+      <a href="https://www.amd.com/" target="_blank" rel="noopener noreferrer">
+        <img src={imageSrc} alt="AMD" className={styles.logo} />
+      </a>
       {variant === 'inline' ? null : <span className={styles.text}>Powered by AMD GPU</span>}
     </div>
   )


### PR DESCRIPTION
## Summary

Re-submit the fix from #3686 because the original PR is blocked on DCO and the original contributor is no longer active.

- Make the AMD dashboard branding link to AMD's official site.
- Point the authenticated Documentation icon at the documentation intro page.

This preserves the original contribution from @nightcityblade; the replacement commit includes `Co-authored-by: nightcityblade <nightcityblade@gmail.com>`.

Fixes #3682
Supersedes #3686

## Testing

- Diff verified to match #3686 exactly.
- Based on the latest `main` head.